### PR TITLE
Remove opaque qualifier from attribution source identifier

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,7 +265,7 @@ An attribution source is a [=struct=] with the following items:
 
 <dl dfn-for="attribution source">
 : <dfn>source identifier</dfn>
-:: A unique opaque string.
+:: A string.
 : <dfn>source origin</dfn>
 :: An [=url/origin=].
 : <dfn>event id</dfn>
@@ -333,7 +333,7 @@ An attribution report is a [=struct=] with the following items:
 : <dfn>trigger time</dfn>
 :: A point in time.
 : <dfn>source identifier</dfn>
-:: An opaque string.
+:: A string.
 
 </dl>
 
@@ -383,7 +383,7 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 <h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
 
 To <dfn>obtain an attribution source</dfn> from an <{a}> element |anchor|:
-1. Let |sourceIdentifier| be a new unique opaque string.
+1. Let |sourceIdentifier| be a new unique string.
 1. Let |currentTime| be the current time.
 1. If |anchor| does not have both an <{a/attributiondestination}> attribute and
     an <{a/attributionsourceeventid}> attribute, return null.


### PR DESCRIPTION
Fixes #242


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/243.html" title="Last updated on Oct 7, 2021, 2:24 PM UTC (bd9ae5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/243/a9f33a8...apasel422:bd9ae5e.html" title="Last updated on Oct 7, 2021, 2:24 PM UTC (bd9ae5e)">Diff</a>