### PR TITLE
Fix report-count calculation in report-prioritization spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -672,6 +672,7 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     1. Let |lowestPriorityReport| be the first item in |matchingReports|.
     1. If |report|'s [=attribution report/trigger priority=] is less than or equal to |lowestPriorityReport|'s [=attribution report/trigger priority=], return.
     1. Remove |lowestPriorityReport| from the [=attribution report cache=].
+    1. Decrement |sourceToAttribute|'s [=attribution source/number of reports=] value by 1.
 1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
 1. For each |item| of |matchingSources|:
     1. [=list/Remove=] |item| from the [=attribution source cache=].


### PR DESCRIPTION
Without this, when the new report is replacing an existing one, the number of reports ends up being one greater than it should be.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/250.html" title="Last updated on Oct 12, 2021, 3:46 PM UTC (4876c77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/250/0b51ed0...apasel422:4876c77.html" title="Last updated on Oct 12, 2021, 3:46 PM UTC (4876c77)">Diff</a>