### PR TITLE
Make attribution report destination a site and fix referrer generator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -367,7 +367,7 @@ An attribution report is a [=struct=] with the following items:
 : <dfn>reporting endpoint</dfn>
 :: An [=url/origin=].
 : <dfn>attribution destination</dfn>
-:: An [=url/origin=].
+:: A [=site=].
 : <dfn>report time</dfn>
 :: A point in time.
 : <dfn>trigger priority</dfn>
@@ -834,9 +834,8 @@ To <dfn>attempt to deliver a report</dfn> given an [=attribution report=] |repor
 1. Let |referrer| be a new [=URL record=].
 1. Let |destination| be |report|'s [=attribution report/attribution destination=].
 1. Assert: |destination| is not an [=opaque origin=].
-1. Set |reportUrl|'s [=URL/scheme=] to |destination|'s [=origin/scheme=].
-1. Set |reportUrl|'s [=URL/host=] to |destination|'s [=origin/host=].
-1. Set |reportUrl|'s [=URL/port=] to |destination|'s [=origin/port=].
+1. Set |referrer|'s [=URL/scheme=] to |destination|'s scheme.
+1. Set |referrer|'s [=URL/host=] to |destination|'s host.
 1. Let |request| be a new [=request=] with the following properties:
     :   `method`
     ::  "`POST`"


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/258.html" title="Last updated on Oct 19, 2021, 6:21 PM UTC (4cf7972)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/258/ec9f6e8...apasel422:4cf7972.html" title="Last updated on Oct 19, 2021, 6:21 PM UTC (4cf7972)">Diff</a>