### PR TITLE
Fix broken references to URL fields

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -816,10 +816,10 @@ To <dfn>generate a report URL</dfn> for a given [=attribution report=] |report|,
 1. Let |reportUrl| be a new [=URL record=].
 1. Let |reportingOrigin| be |report|'s [=attribution report/reporting endpoint=].
 1. Assert: |reportingOrigin| is not an [=opaque origin=].
-1. Set |reportUrl|'s [=URL/scheme=] to |reportingOrigin|'s [=origin/scheme=].
-1. Set |reportUrl|'s [=URL/host=] to |reportingOrigin|'s [=origin/host=].
-1. Set |reportUrl|'s [=URL/port=] to |reportingOrigin|'s [=origin/port=].
-1. Set |reportUrl|'s [=URL/path=] to «"`.well-known`", "`attribution-reporting`", "`report-attribution`"».
+1. Set |reportUrl|'s [=url/scheme=] to |reportingOrigin|'s [=origin/scheme=].
+1. Set |reportUrl|'s [=url/host=] to |reportingOrigin|'s [=origin/host=].
+1. Set |reportUrl|'s [=url/port=] to |reportingOrigin|'s [=origin/port=].
+1. Set |reportUrl|'s [=url/path=] to «"`.well-known`", "`attribution-reporting`", "`report-attribution`"».
 1. Return |reportUrl|.
 
 <h3 id="issue-report-request">Issuing a report request</h3>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/259.html" title="Last updated on Oct 21, 2021, 3:55 PM UTC (dca7219)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/259/35b92a3...apasel422:dca7219.html" title="Last updated on Oct 21, 2021, 3:55 PM UTC (dca7219)">Diff</a>