### PR TITLE
Specify aggregatable report triggering algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1534,6 +1534,7 @@ required aggregatable budget</dfn> is the total [=aggregatable contribution/valu
 To <dfn>obtain an aggregatable report</dfn> given an [=attribution source=] |source| and
 an [=attribution trigger=] |trigger|:
 
+1. Let |reportTime| be the result of running [=obtain an aggregatable report delivery time=] with |trigger|'s [=attribution trigger/trigger time=].
 1. Let |report| be a new [=aggregatable report=] struct whose items are:
 
     : [=aggregatable report/reporting endpoint=]
@@ -1543,9 +1544,9 @@ an [=attribution trigger=] |trigger|:
     : [=aggregatable report/source time=]
     :: |source|'s [=attribution source/source time=].
     : [=aggregatable report/original report time=]
-    :: The result of running [=obtain an aggregatable report delivery time=] with |trigger|'s [=attribution trigger/trigger time=].
+    :: |reportTime|.
     : [=aggregatable report/report time=]
-    :: |report|'s [=aggregatable report/original report time=].
+    :: |reportTime|.
     : [=aggregatable report/report id=]
     :: The result of [=generating a random UUID=].
     : [=aggregatable report/source debug key=]

--- a/index.bs
+++ b/index.bs
@@ -936,6 +936,8 @@ a [=trigger state=] |triggerState|:
     :: «»
     : [=attribution trigger/aggregatable values=]
     :: «[]»
+    : [=attribution trigger/aggregatable dedup key=]
+    :: null
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. Set |fakeReport|'s [=event-level report/report time=] to the result of

--- a/index.bs
+++ b/index.bs
@@ -1267,9 +1267,11 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
     1. [=list/Append=] |contribution| to |contributions|.
 1. Return |contributions|.
 
-<h3 dfn id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
+<h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
 
-Given an [=aggregatable report=] |report| and an [=attribution source=] |sourceToAttribute|:
+To <dfn>check if an [=attribution source=] can create [=aggregatable contributions=]</dfn> given an
+[=aggregatable report=] |report| and an [=attribution source=] |sourceToAttribute|, run the following steps:
+
 
 1. Let |remainingAggregatableBudget| be [=allowed aggregatable budget per source=] minus |sourceToAttribute|'s
     [=attribution source/aggregatable budget consumed=].
@@ -1351,7 +1353,8 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     [=aggregatable report/attribution destination=] equals |trigger|'s [=attribution trigger/attribution destination=].
 1. If |numMatchingReports| is greater than or equal to the user agent's
     [=max aggregatable reports per attribution destination=], return <strong>dropped</strong>.
-1. If the result of running [=can source create aggregatable contributions=] is false, return <strong>dropped</strong>.
+1. If the result of running [=check if an attribution source can create aggregatable contributions=]
+    is false, return <strong>dropped</strong>.
 1. If the [=list/size=] of the [=aggregatable report cache=] is greater than or equal to the user
     agent's [=max aggregatable report cache size=], return <strong>cache full</strong>.
 1. Add |report| to the [=aggregatable report cache=].

--- a/index.bs
+++ b/index.bs
@@ -1365,6 +1365,8 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     [=attempt to deliver a debug report=] with |report|.
 1. Return <strong>attributed</strong>.
 
+TODO: Specify aggregatable deduplication key feature.
+
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
 To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -38,7 +38,7 @@ for cross-site identifiers like third-party cookies.
 
 Pages/embedded sites are given the ability to register [=attribution sources=] and
 [=attribution triggers=], which can be linked by the User Agent to generate and
-send [=event-level reports=] containing information from both of those events.
+send [=attribution reports=] containing information from both of those events.
 
 A reporter `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example`
@@ -54,7 +54,7 @@ the User Agent attempts to match the trigger to previously registered source eve
 where the sources/triggers were registered and configurations provided by the reporter.
 
 If the User Agent is able to attribute the trigger to a source, it will generate and
-send an [=event-level report=] to the reporter via an HTTP POST request at a later point
+send an [=attribution report=] to the reporter via an HTTP POST request at a later point
 in time.
 
 # HTML monkeypatches # {#html-monkeypatches}
@@ -292,6 +292,8 @@ An attribution source is a [=struct=] with the following items:
 :: A point in time.
 : <dfn>number of event-level reports</dfn>
 :: Number of [=event-level reports=] created for this [=attribution source=].
+: <dfn>event-level attributable</dfn> (default true)
+:: A [=boolean=].
 : <dfn>dedup keys</dfn>
 :: [=ordered set=] of [=event-level trigger configuration/dedup keys=] associated with this [=attribution source=].
 : <dfn>randomized response</dfn>
@@ -307,6 +309,8 @@ An attribution source is a [=struct=] with the following items:
     non-negative 128-bit integers.
 : <dfn>aggregatable expiry</dfn>
 :: A length of time.
+: <dfn>aggregatable budget consumed</dfn>
+:: Total [=aggregatable contribution/value=] of all [=aggregatable contributions=] created with this [=attribution source=].
 
 </dl>
 
@@ -373,9 +377,31 @@ An attribution trigger is a [=struct=] with the following items:
 
 </dl>
 
+<h3 dfn-type=dfn>Attribution report</h3>
+
+An attribution report is a [=struct=] with the following items:
+
+<dl dfn-for="attribution report, aggregatable report, event-level report">
+: <dfn>reporting endpoint</dfn>
+:: An [=url/origin=].
+: <dfn>attribution destination</dfn>
+:: A [=site=].
+: <dfn>report time</dfn>
+:: A point in time.
+: <dfn>delivered</dfn> (default false)
+:: A [=boolean=].
+: <dfn>report ID</dfn>
+:: A [=string=].
+: <dfn>source debug key</dfn>
+:: Null or a non-negative 64-bit integer.
+: <dfn>trigger debug key</dfn>
+:: Null or a non-negative 64-bit integer.
+
+</dl>
+
 <h3 dfn-type=dfn>Event-level report</h3>
 
-An event-level report is a [=struct=] with the following items:
+An event-level report is an [=attribution report=] with the following additional items:
 
 <dl dfn-for="event-level report">
 : <dfn>event ID</dfn>
@@ -386,26 +412,12 @@ An event-level report is a [=struct=] with the following items:
 :: A non-negative 64-bit integer.
 : <dfn>randomized trigger rate</dfn>
 :: A number between 0 and 1 (both inclusive).
-: <dfn>reporting endpoint</dfn>
-:: An [=url/origin=].
-: <dfn>attribution destination</dfn>
-:: A [=site=].
-: <dfn>report time</dfn>
-:: A point in time.
 : <dfn>trigger priority</dfn>
 :: A 64-bit integer.
 : <dfn>trigger time</dfn>
 :: A point in time.
 : <dfn>source identifier</dfn>
 :: A string.
-: <dfn>delivered</dfn> (default false)
-:: A [=boolean=].
-: <dfn>report ID</dfn>
-:: A [=string=].
-: <dfn>source debug key</dfn>
-:: Null or a non-negative 64-bit integer.
-: <dfn>trigger debug key</dfn>
-:: Null or a non-negative 64-bit integer.
 
 </dl>
 
@@ -420,6 +432,22 @@ An aggregatable contribution is a [=struct=] with the following items:
 :: A non-negative 32-bit integer.
 
 </dl>
+
+<h3 dfn-type=dfn>Aggregatable report</h3>
+
+An aggregatable report is an [=attribution report=] with the following items:
+
+<dl dfn-for="aggregatable report">
+: <dfn>source time</dfn>
+:: A point in time.
+: <dfn>original report time</dfn>
+:: A point in time.
+: <dfn>contributions</dfn>
+:: An [=list=] of [=aggregatable contributions=].
+
+</dl>
+
+Issue: Use [=aggregatable report/delivered=] in [=queue a report for delivery=].
 
 <h3 dfn-type=dfn>Attribution rate-limit record</h3>
 
@@ -446,6 +474,8 @@ An attribution rate-limit record is a [=struct=] with the following items:
 A user agent holds an <dfn>attribution source cache</dfn>, which is an [=ordered set=] of [=attribution sources=].
 
 A user agent holds an <dfn>event-level report cache</dfn>, which is an [=ordered set=] of [=event-level reports=].
+
+A user agent holds an <dfn>aggregatable report cache</dfn>, which is an [=ordered set=] of [=aggregatable reports=].
 
 A user agent holds an <dfn>attribution rate-limit cache</dfn>, which is an [=ordered set=] of [=attribution rate-limit records=].
 
@@ -507,10 +537,14 @@ for triggers that are attributed to an [=attribution source=] whose
 (both inclusive) that controls the randomized response probability of an
 [=attribution source=] whose [=attribution source/source type=] is "`event`".
 
-<dfn>Max reports per attribution destination</dfn> is a positive integer that
+<dfn>Max event-level reports per attribution destination</dfn> is a positive integer that
 controls how many [=event-level reports=] can be in the
 [=event-level report cache=] per
 [=event-level report/attribution destination=].
+
+<dfn>Max aggregatable reports per attribution destination</dfn> is a vendor-specific integer which controls how
+many [=aggregatable reports=] can be in the [=aggregatable report cache=] for an
+[=aggregatable report/attribution destination=].
 
 <dfn>Max attributions per navigation source</dfn> is a positive integer that
 controls how many times a single [=attribution source=] whose
@@ -553,8 +587,21 @@ controls the maximum number of attributions for a
 <dfn>Max source cache size</dfn> is a positive integer that controls how many
 [=attribution sources=] can be in the [=attribution source cache=].
 
-<dfn>Max report cache size</dfn> is a positive integer that controls how many
+<dfn>Max event-level report cache size</dfn> is a positive integer that controls how many
 [=event-level reports=] can be in the [=event-level report cache=].
+
+<dfn>Max aggregatable report cache size</dfn> is a vendor-specific integer which controls how many
+[=aggregatable reports=] can be in the [=aggregatable report cache=].
+
+<dfn>Allowed aggregatable budget per source</dfn> is a vendor-specific integer that controls the total
+[=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
+an [=attribution source=].
+
+<dfn>Min aggregatable report delay</dfn> is a non-negative length of time that controls the minimum
+delay to deliver an aggregatable report.
+
+<dfn>Randomized aggregatable report delay</dfn> is a positive length of time that controls the
+random delay to deliver an aggregatable report.
 
 # General Algorithms # {#general-algorithms}
 
@@ -820,6 +867,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
     :: |aggregationKeys|
     : [=attribution source/aggregatable expiry=]
     :: |aggregatableExpiry|
+    : [=attribution source/aggregatable budget consumed=]
+    :: 0
 1. Return |source|.
 
 Issue: Ensure that |attributionDestination|'s [=origin/scheme=] is HTTP/HTTPS.
@@ -883,6 +932,10 @@ a [=trigger state=] |triggerState|:
     :: null
     : [=attribution trigger/event-level trigger configurations=]
     :: « |fakeConfig| »
+    : [=attribution trigger/aggregatable trigger data=]
+    :: «»
+    : [=attribution trigger/aggregatable values=]
+    :: «[]»
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. Set |fakeReport|'s [=event-level report/report time=] to the result of
@@ -928,10 +981,11 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         1. Let |fakeReport| be the result of running [=obtain a fake report=]
             with |source| and |triggerState|.
         1. [=set/Append=] |fakeReport| to the [=event-level report cache=].
-    1. If |source|'s [=attribution source/randomized response=] is not [=set/is empty|empty=], return.
+    1. If |source|'s [=attribution source/randomized response=] is not [=set/is empty|empty=],
+        then set |source|'s [=attribution source/event-level attributable=] value to false.
 1. [=set/Append=] |source| to |cache|.
 
-Issue: Should fake reports respect the user agent's [=max reports per attribution destination=]?
+Issue: Should fake reports respect the user agent's [=max event-level reports per attribution destination=]?
 
 # Triggering Algorithms # {#trigger-algorithms}
 
@@ -1213,7 +1267,98 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
     1. [=list/Append=] |contribution| to |contributions|.
 1. Return |contributions|.
 
-Issue: Use [=create aggregatable contributions=] in [=trigger attribution=].
+<h3 dfn id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
+
+Given an [=aggregatable report=] |report| and an [=attribution source=] |sourceToAttribute|:
+1. Let |remainingAggregatableBudget| be [=allowed aggregatable budget per source=] minus |sourceToAttribute|'s
+    [=attribution source/aggregatable budget consumed=].
+1. Assert: |remainingAggregatableBudget| is greater than or equal to 0.
+1. If |report|'s [=aggregatable report/required aggregatable budget=] is greater than
+    |remainingAggregatableBudget|, return false.
+1. Return true.
+
+<h3 algorithm id="triggering-event-level-attribution">Triggering event-level attribution</h3>
+
+To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger| and an
+[=attribution source=] |sourceToAttribute| run the following steps:
+
+1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value is false, return <strong>dropped</strong>.
+1. Assert: |sourceToAttribute|'s [=attribution source/randomized response=] is
+    null or an [=set/is empty|empty=] [=set=].
+1. Let |matchedConfig| be null.
+1. [=map/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
+    [=attribution trigger/event-level trigger configurations=]:
+    1. If the result of running
+        [=match an attribution source's filter data against filters=] with |sourceToAttribute|,
+        |config|'s [=event-level trigger configuration/filters=], and
+        [=match an attribution source's filter data against filters/isNegated=] set to false is false, [=iteration/continue=].
+    1. If the result of running
+        [=match an attribution source's filter data against filters=] with |sourceToAttribute|,
+        |config|'s [=event-level trigger configuration/negated filters=], and
+        [=match an attribution source's filter data against filters/isNegated=] set to true is false, [=iteration/continue=].
+    1. Set |matchedConfig| to |config|.
+    1. [=iteration/Break=].
+1. If |matchedConfig| is null, return.
+1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null and
+    |sourceToAttribute|'s [=attribution source/dedup keys=] [=list/contains=] it, return <strong>dropped</strong>.
+1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
+    [=event-level report/attribution destination=] equals |trigger|'s [=attribution trigger/attribution destination=].
+1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=],
+    return <strong>dropped</strong>.
+1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|, |trigger|,
+    and |matchedConfig|.
+1. Let |maxAttributionsPerSource| be the user agent's [=max attributions per navigation source=].
+1. If |sourceToAttribute|'s [=attribution source/source type=] is "`event`", set
+    |maxAttributionsPerSource| to the user agent's [=max attributions per event source=].
+1. If |sourceToAttribute|'s [=attribution source/number of event-level reports=] value is equal to
+    |maxAttributionsPerSource|, then:
+    1. Let |matchingReports| be all entries in the [=event-level report cache=] where all of the following are true:
+         * entry's [=event-level report/report time=] and |report|'s [=event-level report/report time=] are equal.
+         * entry's [=event-level report/source identifier=] [=string/is=] |report|'s [=event-level report/source identifier=]
+    1. If |matchingReports| is empty, then set |sourceToAttribute|'s [=attribution source/event-level attributable=] value to false
+        and return <strong>dropped</strong>.
+    1. Set |matchingReports| to the result of [=list/sort in ascending order|sorting=] |matchingReports|
+        in ascending order, with |a| being less than |b| if any of the following are true:
+             * |a|'s [=event-level report/trigger priority=] is less than |b|'s [=event-level report/trigger priority=].
+             * |a|'s [=event-level report/trigger priority=] is equal to |b|'s [=event-level report/trigger priority=]
+                and |a|'s [=event-level report/trigger time=] is greater than |b|'s [=event-level report/trigger time=].
+    1. Let |lowestPriorityReport| be the first item in |matchingReports|.
+    1. If |report|'s [=event-level report/trigger priority=] is less than or equal to
+        |lowestPriorityReport|'s [=event-level report/trigger priority=], return <strong>dropped</strong>.
+    1. [=list/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
+    1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
+1. If the [=list/size=] of the [=event-level report cache=] is greater than or equal to the user
+    agent's [=max event-level report cache size=], return <strong>cache full</strong>.
+1. If |sourceToAttribute|'s [=attribution source/randomized response=] is
+    null, [=set/append=] |report| to the [=event-level report cache=].
+1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
+1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
+    [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
+1. If |report|'s [=event-level report/source debug key=] is not null and |report|'s
+    [=event-level report/trigger debug key=] is not null, [=queue a task=] to
+    [=attempt to deliver a debug report=] with |report|.
+1. Return <strong>attributed</strong>.
+
+<h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>
+
+To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger| and an
+[=attribution source=] |sourceToAttribute| run the following steps:
+1. Let |report| be the result of running [=obtain an aggregatable report=] with |sourceToAttribute| and |trigger|.
+1. If |report|'s [=aggregatable report/contributions=] [=list/is empty=], return <strong>dropped</strong>.
+1. Let |numMatchingReports| be the number of entries in the [=aggregatable report cache=] whose
+    [=aggregatable report/attribution destination=] equals |trigger|'s [=attribution trigger/attribution destination=].
+1. If |numMatchingReports| is greater than or equal to the user agent's
+    [=max aggregatable reports per attribution destination=], return <strong>dropped</strong>.
+1. If the result of running [=can source create aggregatable contributions=] is false, return <strong>dropped</strong>.
+1. If the [=list/size=] of the [=aggregatable report cache=] is greater than or equal to the user
+    agent's [=max aggregatable report cache size=], return <strong>cache full</strong>.
+1. Add |report| to the [=aggregatable report cache=].
+1. Increment |sourceToAttribute|'s [=attribution source/aggregatable budget consumed=] value by
+    |report|'s [=aggregatable report/required aggregatable budget=].
+1. If |report|'s [=aggregatable report/source debug key=] is not null and |report|'s
+    [=aggregatable report/trigger debug key=] is not null, [=queue a task=] to
+    [=attempt to deliver a debug report=] with |report|.
+1. Return <strong>attributed</strong>.
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
@@ -1231,8 +1376,6 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
       * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
          [=attribution source/source time=] is less than |b|'s [=attribution source/source time=].
 1. Let |sourceToAttribute| be the first item in |matchingSources|.
-1. [=Assert=]: |sourceToAttribute|'s [=attribution source/randomized response=] is
-    null or an [=set/is empty|empty=] [=set=].
 1. If the result of running
     [=match an attribution source's filter data against filters=] with
     |sourceToAttribute|, |trigger|'s [=attribution trigger/filters=], and
@@ -1241,26 +1384,6 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     [=match an attribution source's filter data against filters=] with
     |sourceToAttribute|, |trigger|'s [=attribution trigger/negated filters=], and
     [=match an attribution source's filter data against filters/isNegated=] set to true is false, return.
-1. Let |matchedConfig| be null.
-1. [=map/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
-    [=attribution trigger/event-level trigger configurations=]:
-    1. If the result of running
-        [=match an attribution source's filter data against filters=] with |sourceToAttribute|,
-        |config|'s [=event-level trigger configuration/filters=], and
-        [=match an attribution source's filter data against filters/isNegated=] set to false is false, [=iteration/continue=].
-    1. If the result of running
-        [=match an attribution source's filter data against filters=] with |sourceToAttribute|,
-        |config|'s [=event-level trigger configuration/negated filters=], and
-        [=match an attribution source's filter data against filters/isNegated=] set to true is false, [=iteration/continue=].
-    1. Set |matchedConfig| to |config|.
-    1. [=iteration/Break=].
-1. If |matchedConfig| is null, return.
-1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null and
-    |sourceToAttribute|'s [=attribution source/dedup keys=] [=list/contains=] it, return.
-1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
-    [=event-level report/attribution destination=] equals |attributionDestination|.
-1. If |numMatchingReports| is greater than or equal to the user agent's
-    [=max reports per attribution destination=], return.
 1. If the result of running [=should attribution be blocked by rate limit=] with |trigger| and
     |sourceToAttribute| is <strong>blocked</strong>, return.
 1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
@@ -1278,42 +1401,16 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     :: null
 1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
     |rateLimitRecord| is <strong>blocked</strong>, return.
-1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|, |trigger|,
-    and |matchedConfig|.
-1. Let |maxAttributionsPerSource| be the user agent's [=max attributions per navigation source=].
-1. If |sourceToAttribute|'s [=attribution source/source type=] is "`event`", set
-    |maxAttributionsPerSource| to the user agent's [=max attributions per event source=].
-1. If |sourceToAttribute|'s [=attribution source/number of event-level reports=] value is equal to
-    |maxAttributionsPerSource|, then:
-    1. Let |matchingReports| be all entries in the [=event-level report cache=] where all of the following are true:
-         * entry's [=event-level report/report time=] and |report|'s [=event-level report/report time=] are equal.
-         * entry's [=event-level report/source identifier=] [=string/is=] |report|'s [=event-level report/source identifier=]
-    1. If |matchingReports| is empty, then [=list/remove=] |sourceToAttribute| from the [=attribution source cache=] and return.
-    1. Set |matchingReports| to the result of [=list/sort in ascending order|sorting=] |matchingReports|
-        in ascending order, with |a| being less than |b| if any of the following are true:
-             * |a|'s [=event-level report/trigger priority=] is less than |b|'s [=event-level report/trigger priority=].
-             * |a|'s [=event-level report/trigger priority=] is equal to |b|'s [=event-level report/trigger priority=]
-                and |a|'s [=event-level report/trigger time=] is greater than |b|'s [=event-level report/trigger time=].
-    1. Let |lowestPriorityReport| be the first item in |matchingReports|.
-    1. If |report|'s [=event-level report/trigger priority=] is less than or equal to |lowestPriorityReport|'s [=event-level report/trigger priority=], return.
-    1. [=list/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
-    1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
+1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=].
+1. Let |aggregatableResult| be the result of running [=trigger aggregatable attribution=].
+1. If both |eventLevelResult| and |aggregatableResult| are <strong>dropped</strong>, return.
 1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
 1. For each |item| of |matchingSources|:
     1. [=list/Remove=] |item| from the [=attribution source cache=].
-1. If the [=list/size=] of the [=event-level report cache=] is greater than or equal to the user
-    agent's [=max report cache size=], return.
-1. If |sourceToAttribute|'s [=attribution source/randomized response=] is
-    null, [=set/append=] |report| to the [=event-level report cache=].
-1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
-1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
-    [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
+1. If neither |eventLevelResult| nor |aggregatableResult| is <strong>attributed</strong>, return.
 1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. [=list/Remove=] all entries from the [=attribution rate-limit cache=] if the result of running
     [=can attribution rate-limit record be removed=] with the entry is true.
-1. If |report|'s [=event-level report/source debug key=] is not null and |report|'s
-    [=event-level report/trigger debug key=] is not null, [=queue a task=] to
-    [=attempt to deliver a debug report=] with |report|.
 
 <h3 algorithm id="delivery-time">Establishing report delivery time</h3>
 
@@ -1369,6 +1466,11 @@ To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution 
 1. Return the result of running [=obtain a report time from deadline=] with
     |source|'s [=attribution source/source time=] and |deadlineToUse|.
 
+To <dfn>obtain an aggregatable report delivery time</dfn> given a [=attribution trigger/trigger time=]
+|triggerTime|, perform the following steps. They return a point in time.
+1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
+1. Return |triggerTime| + [=min aggregatable report delay=] + |r| * [=randomized aggregatable report delay=].
+
 <h3 algorithm id="obtaining-an-event-level-report">Obtaining an event-level report</h3>
 
 To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |source|, an [=attribution trigger=]
@@ -1404,6 +1506,39 @@ To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |sour
     :: |source|'s [=attribution source/debug key=].
     : [=event-level report/trigger debug key=]
     :: |trigger|'s [=attribution trigger/debug key=].
+1. Return |report|.
+
+<h3 id="obtaining-required-aggregatable-budget">Obtaining an aggregatable report's required budget</h3>
+
+An [=aggregatable report=] |report|'s <dfn for="aggregatable report">
+required aggregatable budget</dfn> is the total [=aggregatable contribution/value=] of |report|'s
+[=aggregatable report/contributions=].
+
+<h3 algorithm id="obtaining-an-aggregatable-report">Obtaining an aggregatable report</h3>
+
+To <dfn>obtain an aggregatable report</dfn> given an [=attribution source=] |source| and
+an [=attribution trigger=] |trigger|:
+
+1. Let |report| be a new [=aggregatable report=] struct whose items are:
+
+    : [=aggregatable report/reporting endpoint=]
+    :: |source|'s [=attribution source/reporting endpoint=].
+    : [=aggregatable report/attribution destination=]
+    :: |source|'s [=attribution source/attribution destination=].
+    : [=aggregatable report/source time=]
+    :: |source|'s [=attribution source/source time=]
+    : [=aggregatable report/original report time=]
+    :: The result of running [=obtain an aggregatable report delivery time=] with |trigger|'s [=attribution trigger/trigger time=].
+    : [=aggregatable report/report time=]
+    :: |report|'s [=aggregatable report/original report time=]
+    : [=aggregatable report/report id=]
+    :: The result of [=generating a random UUID=].
+    : [=aggregatable report/source debug key=]
+    :: |source|'s [=attribution source/debug key=].
+    : [=aggregatable report/trigger debug key=]
+    :: |trigger|'s [=attribution trigger/debug key=].
+    : [=aggregatable report/contributions=]
+    :: The result of running [=create aggregatable contributions=] with |source| and |trigger|.
 1. Return |report|.
 
 # Report delivery # {#report-delivery}
@@ -1541,6 +1676,8 @@ To <dfn>attempt to deliver a debug report</dfn> given an [=event-level report=] 
     [=generate a report URL/isDebugReport=] set to true.
 1. Let |request| be the result of executing [=create a report request=] on |report|.
 1. [=Fetch=] |request|.
+
+Issue: Update for [=aggregatable report=].
 
 Issue(220): This fetch should use a network partition key for an opaque origin.
 

--- a/index.bs
+++ b/index.bs
@@ -1367,7 +1367,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
-To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:
+To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:
 
 1. Let |attributionDestination| be |trigger|'s [=attribution trigger/attribution destination=].
 1. Let |matchingSources| be all entries in the [=attribution source cache=] where all of the following are true:

--- a/index.bs
+++ b/index.bs
@@ -311,6 +311,8 @@ An attribution source is a [=struct=] with the following items:
 :: A length of time.
 : <dfn>aggregatable budget consumed</dfn>
 :: A non-negative integer, total [=aggregatable contribution/value=] of all [=aggregatable contributions=] created with this [=attribution source=].
+: <dfn>aggregatable dedup keys</dfn>
+:: [=ordered set=] of [=attribution trigger/aggregatable dedup keys=] associated with this [=attribution source=].
 
 </dl>
 
@@ -1351,6 +1353,9 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 
 1. Let |report| be the result of running [=obtain an aggregatable report=] with |sourceToAttribute| and |trigger|.
 1. If |report|'s [=aggregatable report/contributions=] [=list/is empty=], return <strong>dropped</strong>.
+1. If |trigger|'s [=attribution trigger/aggregatable dedup key=] is not null and
+    |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=]
+    [=list/contains=] it, return <strong>dropped</strong>.
 1. Let |numMatchingReports| be the number of entries in the [=aggregatable report cache=] whose
     [=aggregatable report/attribution destination=] equals |trigger|'s [=attribution trigger/attribution destination=].
 1. If |numMatchingReports| is greater than or equal to the user agent's
@@ -1362,12 +1367,12 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. Add |report| to the [=aggregatable report cache=].
 1. Increment |sourceToAttribute|'s [=attribution source/aggregatable budget consumed=] value by
     |report|'s [=aggregatable report/required aggregatable budget=].
+1. If |trigger|'s [=attribution trigger/aggregatable dedup key=] is not null,
+    [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].
 1. If |report|'s [=aggregatable report/source debug key=] is not null and |report|'s
     [=aggregatable report/trigger debug key=] is not null, [=queue a task=] to
     [=attempt to deliver a debug report=] with |report|.
 1. Return <strong>attributed</strong>.
-
-TODO: Specify aggregatable deduplication key feature.
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1354,7 +1354,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. If |numMatchingReports| is greater than or equal to the user agent's
     [=max aggregatable reports per attribution destination=], return <strong>dropped</strong>.
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]
-    is false, return <strong>dropped</strong>.
+    with |report| and |sourceToAttribute| is false, return <strong>dropped</strong>.
 1. If the [=list/size=] of the [=aggregatable report cache=] is greater than or equal to the user
     agent's [=max aggregatable report cache size=], return <strong>cache full</strong>.
 1. Add |report| to the [=aggregatable report cache=].

--- a/index.bs
+++ b/index.bs
@@ -1305,7 +1305,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
         [=match an attribution source's filter data against filters/isNegated=] set to true is false, [=iteration/continue=].
     1. Set |matchedConfig| to |config|.
     1. [=iteration/Break=].
-1. If |matchedConfig| is null, return.
+1. If |matchedConfig| is null, return <strong>dropped</strong>.
 1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null and
     |sourceToAttribute|'s [=attribution source/dedup keys=] [=list/contains=] it, return <strong>dropped</strong>.
 1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose

--- a/index.bs
+++ b/index.bs
@@ -435,7 +435,7 @@ An aggregatable contribution is a [=struct=] with the following items:
 
 <h3 dfn-type=dfn>Aggregatable report</h3>
 
-An aggregatable report is an [=attribution report=] with the following items:
+An aggregatable report is an [=attribution report=] with the following additional items:
 
 <dl dfn-for="aggregatable report">
 : <dfn>source time</dfn>
@@ -443,7 +443,7 @@ An aggregatable report is an [=attribution report=] with the following items:
 : <dfn>original report time</dfn>
 :: A point in time.
 : <dfn>contributions</dfn>
-:: An [=list=] of [=aggregatable contributions=].
+:: A [=list=] of [=aggregatable contributions=].
 
 </dl>
 
@@ -542,8 +542,8 @@ controls how many [=event-level reports=] can be in the
 [=event-level report cache=] per
 [=event-level report/attribution destination=].
 
-<dfn>Max aggregatable reports per attribution destination</dfn> is a vendor-specific integer which controls how
-many [=aggregatable reports=] can be in the [=aggregatable report cache=] for an
+<dfn>Max aggregatable reports per attribution destination</dfn> is a positive integer that controls how
+many [=aggregatable reports=] can be in the [=aggregatable report cache=] per
 [=aggregatable report/attribution destination=].
 
 <dfn>Max attributions per navigation source</dfn> is a positive integer that
@@ -590,18 +590,18 @@ controls the maximum number of attributions for a
 <dfn>Max event-level report cache size</dfn> is a positive integer that controls how many
 [=event-level reports=] can be in the [=event-level report cache=].
 
-<dfn>Max aggregatable report cache size</dfn> is a vendor-specific integer which controls how many
+<dfn>Max aggregatable report cache size</dfn> is a positive integer that controls how many
 [=aggregatable reports=] can be in the [=aggregatable report cache=].
 
-<dfn>Allowed aggregatable budget per source</dfn> is a vendor-specific integer that controls the total
+<dfn>Allowed aggregatable budget per source</dfn> is a positive integer that controls the total
 [=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
 an [=attribution source=].
 
 <dfn>Min aggregatable report delay</dfn> is a non-negative length of time that controls the minimum
-delay to deliver an aggregatable report.
+delay to deliver an [=aggregatable report=].
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive length of time that controls the
-random delay to deliver an aggregatable report.
+random delay to deliver an [=aggregatable report=].
 
 # General Algorithms # {#general-algorithms}
 
@@ -1270,6 +1270,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
 <h3 dfn id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
 
 Given an [=aggregatable report=] |report| and an [=attribution source=] |sourceToAttribute|:
+
 1. Let |remainingAggregatableBudget| be [=allowed aggregatable budget per source=] minus |sourceToAttribute|'s
     [=attribution source/aggregatable budget consumed=].
 1. Assert: |remainingAggregatableBudget| is greater than or equal to 0.
@@ -1280,7 +1281,7 @@ Given an [=aggregatable report=] |report| and an [=attribution source=] |sourceT
 <h3 algorithm id="triggering-event-level-attribution">Triggering event-level attribution</h3>
 
 To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger| and an
-[=attribution source=] |sourceToAttribute| run the following steps:
+[=attribution source=] |sourceToAttribute|, run the following steps:
 
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value is false, return <strong>dropped</strong>.
 1. Assert: |sourceToAttribute|'s [=attribution source/randomized response=] is
@@ -1342,7 +1343,8 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 <h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>
 
 To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger| and an
-[=attribution source=] |sourceToAttribute| run the following steps:
+[=attribution source=] |sourceToAttribute|, run the following steps:
+
 1. Let |report| be the result of running [=obtain an aggregatable report=] with |sourceToAttribute| and |trigger|.
 1. If |report|'s [=aggregatable report/contributions=] [=list/is empty=], return <strong>dropped</strong>.
 1. Let |numMatchingReports| be the number of entries in the [=aggregatable report cache=] whose
@@ -1362,14 +1364,14 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
-To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run the following steps:
+To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:
 
 1. Let |attributionDestination| be |trigger|'s [=attribution trigger/attribution destination=].
 1. Let |matchingSources| be all entries in the [=attribution source cache=] where all of the following are true:
      * entry's [=attribution source/attribution destination=] and |attributionDestination| are equal.
      * entry's [=attribution source/reporting endpoint=] and |trigger|'s [=attribution trigger/reporting endpoint=] are [=same origin=].
      * entry's [=attribution source/expiry time=] is greater than the current time.
-1. If |matchingSources| is empty, return.
+1. If |matchingSources| [=set/is empty=], return.
 1. Set |matchingSources| to the result of [=list/sort in descending order|sorting=] |matchingSources|
     in descending order, with |a| being less than |b| if any of the following are true:
       * |a|'s [=attribution source/priority=] is less than |b|'s [=attribution source/priority=].
@@ -1406,7 +1408,7 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 1. If both |eventLevelResult| and |aggregatableResult| are <strong>dropped</strong>, return.
 1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
 1. For each |item| of |matchingSources|:
-    1. [=list/Remove=] |item| from the [=attribution source cache=].
+    1. [=set/Remove=] |item| from the [=attribution source cache=].
 1. If neither |eventLevelResult| nor |aggregatableResult| is <strong>attributed</strong>, return.
 1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. [=list/Remove=] all entries from the [=attribution rate-limit cache=] if the result of running
@@ -1466,8 +1468,9 @@ To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution 
 1. Return the result of running [=obtain a report time from deadline=] with
     |source|'s [=attribution source/source time=] and |deadlineToUse|.
 
-To <dfn>obtain an aggregatable report delivery time</dfn> given a [=attribution trigger/trigger time=]
+To <dfn>obtain an aggregatable report delivery time</dfn> given a point in time
 |triggerTime|, perform the following steps. They return a point in time.
+
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
 1. Return |triggerTime| + [=min aggregatable report delay=] + |r| * [=randomized aggregatable report delay=].
 

--- a/index.bs
+++ b/index.bs
@@ -310,7 +310,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>aggregatable expiry</dfn>
 :: A length of time.
 : <dfn>aggregatable budget consumed</dfn>
-:: Total [=aggregatable contribution/value=] of all [=aggregatable contributions=] created with this [=attribution source=].
+:: A non-negative integer, total [=aggregatable contribution/value=] of all [=aggregatable contributions=] created with this [=attribution source=].
 
 </dl>
 
@@ -1529,11 +1529,11 @@ an [=attribution trigger=] |trigger|:
     : [=aggregatable report/attribution destination=]
     :: |source|'s [=attribution source/attribution destination=].
     : [=aggregatable report/source time=]
-    :: |source|'s [=attribution source/source time=]
+    :: |source|'s [=attribution source/source time=].
     : [=aggregatable report/original report time=]
     :: The result of running [=obtain an aggregatable report delivery time=] with |trigger|'s [=attribution trigger/trigger time=].
     : [=aggregatable report/report time=]
-    :: |report|'s [=aggregatable report/original report time=]
+    :: |report|'s [=aggregatable report/original report time=].
     : [=aggregatable report/report id=]
     :: The result of [=generating a random UUID=].
     : [=aggregatable report/source debug key=]


### PR DESCRIPTION
Introduce aggregatable attribution report struct and spec the algorithm to trigger aggregatable attribution.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/423.html" title="Last updated on Oct 17, 2022, 5:31 PM UTC (99b40f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/423/737c5cd...99b40f7.html" title="Last updated on Oct 17, 2022, 5:31 PM UTC (99b40f7)">Diff</a>