### PR TITLE
Make event-trigger registration optional

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -172,6 +172,10 @@ L1 = 1 << 16
 true_agg_campaign_counts = raw_agg_campaign_counts / (L1 / 2)
 true_agg_geo_value = 1024 * raw_agg_geo_value / (L1 / 2)
 ```
+
+Note that aggregatable trigger registration is independent of event-level
+trigger registration.
+
 ### Aggregatable reports
 
 Aggregatable reports will look very similar to event-level reports. They will be

--- a/EVENT.md
+++ b/EVENT.md
@@ -499,9 +499,9 @@ to do selective filtering to set `trigger_data` based on `filter_data`:
 ]
 ```
 
-If the filters do not match for any of the event triggers, the trigger data and
-priority both default to 0 and the dedup key defaults to not being set, and
-attribution proceeds normally.
+If the filters do not match for any of the event triggers, no event-level report
+will be created. Note that this still allows an aggregatable report to be
+created [if requested](AGGREGATE.md#attribution-trigger-registration).
 
 If the filters match for multiple event triggers, the first matching event
 trigger is used.

--- a/EVENT.md
+++ b/EVENT.md
@@ -500,8 +500,7 @@ to do selective filtering to set `trigger_data` based on `filter_data`:
 ```
 
 If the filters do not match for any of the event triggers, no event-level report
-will be created. Note that this still allows an aggregatable report to be
-created [if requested](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#attribution-trigger-registration).
+will be created.
 
 If the filters match for multiple event triggers, the first matching event
 trigger is used.

--- a/EVENT.md
+++ b/EVENT.md
@@ -501,7 +501,7 @@ to do selective filtering to set `trigger_data` based on `filter_data`:
 
 If the filters do not match for any of the event triggers, no event-level report
 will be created. Note that this still allows an aggregatable report to be
-created [if requested](AGGREGATE.md#attribution-trigger-registration).
+created [if requested](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATE.md#attribution-trigger-registration).
 
 If the filters match for multiple event triggers, the first matching event
 trigger is used.


### PR DESCRIPTION
This improves the utility of the API for reporting origins that are only interested in aggregatable reports, reducing unnecessary local storage and bandwidth.