### PR TITLE
Rename "aggregatable source" to "aggregation keys"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -290,7 +290,7 @@ An attribution source is a [=struct=] with the following items:
 :: An [=attribution filter map=].
 : <dfn>debug key</dfn>
 :: Null or a non-negative 64-bit integer.
-: <dfn>aggregatable source</dfn>
+: <dfn>aggregation keys</dfn>
 :: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are
     non-negative 128-bit integers.
 
@@ -923,7 +923,7 @@ Given an [=attribution rate-limit record=] |newRecord|:
 To <dfn>create [=attribution aggregatable histograms=]</dfn> given an [=attribution source=] |source| and an
  [=attribution trigger=] |trigger|, run the following steps:
 
-1. Let |aggregationKeys| be |source|'s [=attribution source/aggregatable source=].
+1. Let |aggregationKeys| be |source|'s [=attribution source/aggregation keys=].
 1. Let |aggregatableTrigger| be |trigger|'s [=attribution trigger/aggregatable trigger=].
 1. [=list/iterate|For each=] |triggerData| of |aggregatableTrigger|'s [=attribution aggregatable trigger/trigger data=]:
     1. If the result of running [=match an attribution source's filter data against filters=] with


### PR DESCRIPTION
This name is more clear, and aligns with #434.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/456.html" title="Last updated on May 26, 2022, 5:55 PM UTC (5df731d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/456/d2e33b2...apasel422:5df731d.html" title="Last updated on May 26, 2022, 5:55 PM UTC (5df731d)">Diff</a>