### PR TITLE
Update Permissions Policy default allowlist

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ Issue: Specify monkeypatches for source/trigger registration.
 
 # Permissions Policy integration # {#permission-policy-integration}
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is <code>''self''</code>.
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is `'self'`.
 
 # Structures # {#structures}
 

--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ Issue: Specify monkeypatches for source/trigger registration.
 
 # Permissions Policy integration # {#permission-policy-integration}
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is 'self'.
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is <code>'self'</code>.
 
 # Structures # {#structures}
 

--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ Issue: Specify monkeypatches for source/trigger registration.
 
 # Permissions Policy integration # {#permission-policy-integration}
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is *.
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is 'self'.
 
 # Structures # {#structures}
 

--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ Issue: Specify monkeypatches for source/trigger registration.
 
 # Permissions Policy integration # {#permission-policy-integration}
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is <code>'self'</code>.
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is <code>''self''</code>.
 
 # Structures # {#structures}
 


### PR DESCRIPTION
It should be 'self', not *, since we do not automatically allow the feature in cross origin contexts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/463.html" title="Last updated on May 31, 2022, 4:22 PM UTC (ce45257)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/463/3e365fb...ce45257.html" title="Last updated on May 31, 2022, 4:22 PM UTC (ce45257)">Diff</a>