### PR TITLE
Link to map setters in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1162,10 +1162,10 @@ To <dfn>serialize an [=event-level report=]</dfn> |report|, run the following st
     : "`report_id`"
     :: |report|'s [=event-level report/report ID=]
 
-1. If |report|'s [=event-level report/source debug key=] is not null, set
+1. If |report|'s [=event-level report/source debug key=] is not null, [=map/set=]
     |data|["`source_debug_key`"] to |report|'s [=event-level report/source debug key=],
     [=serialize an integer|serialized=].
-1. If |report|'s [=event-level report/trigger debug key=] is not null, set
+1. If |report|'s [=event-level report/trigger debug key=] is not null, [=map/set=]
     |data|["`trigger_debug_key`"] to |report|'s [=event-level report/trigger debug key=],
     [=serialize an integer|serialized=].
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/469.html" title="Last updated on Jun 1, 2022, 3:37 PM UTC (188f1c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/469/40bfa3a...188f1c6.html" title="Last updated on Jun 1, 2022, 3:37 PM UTC (188f1c6)">Diff</a>