### PR TITLE
Specify window.open monkeypatch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -219,12 +219,12 @@ add the following steps:
 1. Let |attributionSource| be the result of running [=obtain an attribution source from window features=] with |tokenizedFeatures| and |source browsing context|.
 
 Modify the step:
-> 3. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
+> 3. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to |source browsing context|.
 
 to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 
 Modify the step:
-> 5. Navigate target browsing context to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
+> 5. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to |source browsing context|.
 
 to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 

--- a/index.bs
+++ b/index.bs
@@ -213,18 +213,18 @@ the <a spec="html">navigate</a> algorithm.
 
 In <a spec="html">window open steps</a> after
 
-> 10. If target browsing context is null, then return null.
+> 10. If |target browsing context| is null, then return null.
 
 add the following steps:
-1. Let |attributionSource| be the result of running [=obtain an attribution source from window features=] with |tokenizedFeatures| and |source browsing context|.
+1. Let |attributionSource| be the result of running [=obtain an attribution source from window features=] with <var ignore="">tokenizedFeatures</var> and |source browsing context|.
 
 Modify the step:
-> 3. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to |source browsing context|.
+> 3. [=Navigate=] |target browsing context| to |request|, with <var>[=exceptionsEnabled=]</var> set to true and the [=source browsing context=] set to |source browsing context|.
 
 to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 
 Modify the step:
-> 5. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to |source browsing context|.
+> 5. [=Navigate=] |target browsing context| to |request|, with <var>[=exceptionsEnabled=]</var> set to true and the [=source browsing context=] set to |source browsing context|.
 
 to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 

--- a/index.bs
+++ b/index.bs
@@ -208,7 +208,7 @@ to call <a spec="html">navigate</a> with |attributionSource| set to |attribution
 
 <h3 id="monkeypatch-window-open">Window open steps</h4>
 
-Attribution source information declared via `window.open()` need to be passed to
+Attribution source information declared via `window.open()` needs to be passed to
 the <a spec="html">navigate</a> algorithm.
 
 In <a spec="html">window open steps</a> after
@@ -216,10 +216,10 @@ In <a spec="html">window open steps</a> after
 > 10. If target browsing context is null, then return null.
 
 add the following steps:
-1. Let <var>attributionSource</var> be the result of running [=obtain an attribution source from window features=] with tokenizedFeatures and source browsing context
+1. Let |attributionSource| be the result of running [=obtain an attribution source from window features=] with |tokenizedFeatures| and |source browsing context|.
 
 Modify the step:
-> 3. Navigate target browsing context to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
+> 3. Navigate |target browsing context| to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
 
 to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 
@@ -599,10 +599,10 @@ Issue: Specify the steps for making attributionsrc request.
 To <dfn>obtain an attribution source from window features</dfn> given an [=ordered map=] |tokenizedFeatures|
 and a [=browsing context=] |sourceBrowsingContext|:
 
-1. If |tokenizedFeatures|["attributionsrc"] does not exist, return null.
+1. If |tokenizedFeatures|["attributionsrc"] does not [=map/exists|exist=], return null.
 1. If |sourceBrowsingContext|'s [=browsing context/active window=] does not have [=transient activation=], return null.
-1. Let |decodedSrcBytes| be the result of [=string/percent-decode|percent-decoding=] |tokenizedFeatures|["attributionsrc"]
-1. Let |decodedSrc| be the [=UTF-8 decode without BOM=] of |decodedSrcBytes|
+1. Let |decodedSrcBytes| be the result of [=string/percent-decode|percent-decoding=] |tokenizedFeatures|["attributionsrc"].
+1. Let |decodedSrc| be the [=UTF-8 decode without BOM=] of |decodedSrcBytes|.
 1. Return null.
 
 Issue: Specify the steps for making an attributionsrc request with |decodedSrc|.

--- a/index.bs
+++ b/index.bs
@@ -206,6 +206,27 @@ Modify the step:
 
 to call <a spec="html">navigate</a> with |attributionSource| set to |attributionSource|.
 
+<h3 id="monkeypatch-window-open">Window open steps</h4>
+
+Attribution source information declared via `window.open()` need to be passed to
+the <a spec="html">navigate</a> algorithm.
+
+In <a spec="html">window open steps</a> after
+
+> 10. If target browsing context is null, then return null.
+
+add the following steps:
+1. Let <var>attributionSource</var> be the result of running [=obtain an attribution source from window features=] with tokenizedFeatures and source browsing context
+
+Modify the step:
+> 3. Navigate target browsing context to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
+
+to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
+
+Modify the step:
+> 5. Navigate target browsing context to request, with exceptionsEnabled set to true and the source browsing context set to source browsing context.
+
+to also pass |attributionSource| into the <a spec="html">navigate</a> algorithm.
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
@@ -572,6 +593,19 @@ To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element
 1. Return null.
 
 Issue: Specify the steps for making attributionsrc request.
+
+<h3 algorithm id="obtaining-attribution-source-window-features">Obtaining an attribution source from window features</h3>
+
+To <dfn>obtain an attribution source from window features</dfn> given an [=ordered map=] |tokenizedFeatures|
+and a [=browsing context=] |sourceBrowsingContext|:
+
+1. If |tokenizedFeatures|["attributionsrc"] does not exist, return null.
+1. If |sourceBrowsingContext|'s [=browsing context/active window=] does not have [=transient activation=], return null.
+1. Let |decodedSrcBytes| be the result of [=string/percent-decode|percent-decoding=] |tokenizedFeatures|["attributionsrc"]
+1. Let |decodedSrc| be the [=UTF-8 decode without BOM=] of |decodedSrcBytes|
+1. Return null.
+
+Issue: Specify the steps for making an attributionsrc request with |decodedSrc|.
 
 <h3 algorithm id="parsing-source-registration">Parsing source-registration JSON</h3>
 


### PR DESCRIPTION
Note: this leaves an open issue after parsing the `attributionsrc` string similar to the anchor registration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/476.html" title="Last updated on Jun 6, 2022, 3:37 PM UTC (757d4b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/476/6d3b06c...757d4b1.html" title="Last updated on Jun 6, 2022, 3:37 PM UTC (757d4b1)">Diff</a>