### PR TITLE
Add stub specification for debug-key cookie checks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -571,7 +571,8 @@ To <dfn>check if a debug key is allowed</dfn> given an [=origin=]
 1. Return <strong>blocked</strong>.
 
 Issue: Check for "`ar_debug`" cookie on |reportingOrigin| and return
-<strong>allowed</strong> if it's valid.
+<strong>allowed</strong> if it exists, is `Secure`, is `HttpOnly`, and is
+`SameSite=None`.
 
 <h3 id="obtaining-randomized-response">Obtaining a randomized response</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -562,6 +562,17 @@ To <dfn>parse filter data</dfn> given a |value| and a [=string=]
 Issue: Determine whether to limit [=string/length=] or
 [=string/code point length=] for |filter| and |d| above.
 
+<h3 id="debug-keys">Debug keys</h3>
+
+To <dfn>check if a debug key is allowed</dfn> given an [=origin=]
+|reportingOrigin|:
+
+1. [=Assert=]: |reportingOrigin| is a [=potentially trustworthy origin=].
+1. Return <strong>blocked</strong>.
+
+Issue: Check for "`ar_debug`" cookie on |reportingOrigin| and return
+<strong>allowed</strong> if it's valid.
+
 <h3 id="obtaining-randomized-response">Obtaining a randomized response</h3>
 
 To <dfn>obtain a randomized response</dfn> given |trueValue|, a [=set=] |possibleValues|, and a
@@ -692,6 +703,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
         <a spec="html">rules for parsing non-negative integers</a> to
         |value|["`debug_key`"].
     1. If |debugKey| is an error, set |debugKey| to null.
+    1. If the result of running [=check if a debug key is allowed=] with
+        |reportingOrigin| is <strong>blocked</strong>, set |debugKey| to null.
 1. Let |triggerDataCardinality| be the user agent's
     [=navigation-source trigger data cardinality=].
 1. Let |randomizedTriggerRate| be the user agent's
@@ -910,6 +923,8 @@ To <dfn noexport>parse trigger-registration JSON</dfn> given a [=string=]
         <a spec="html">rules for parsing non-negative integers</a> to
         |value|["`debug_key`"].
     1. If |debugKey| is an error, set |debugKey| to null.
+    1. If the result of running [=check if a debug key is allowed=] with
+        |reportingOrigin| is <strong>blocked</strong>, set |debugKey| to null.
 1. Let |filters| be a new [=attribution filter map=].
 1. If |value|["`filters`"] exists:
     1. Set |filters| to the result of running [=parse filter data=] with


### PR DESCRIPTION
It's unclear how best to reference the cookie standard, so for now we always block debug-key setting.

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/479.html" title="Last updated on Jun 7, 2022, 4:23 PM UTC (8c20e43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/479/8ee7e65...apasel422:8c20e43.html" title="Last updated on Jun 7, 2022, 4:23 PM UTC (8c20e43)">Diff</a>