### PR TITLE
Remove truncation wording for aggregation keys

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -92,7 +92,7 @@ fully defined at trigger time using a combination (binary OR) of this piece and
 trigger-side pieces.
 
 Final keys will be restricted to a maximum of 128 bits. This means that hex
-strings in the JSON should be limited to at most 32 digits.
+strings in the JSON must be limited to at most 32 digits.
 
 ### Attribution trigger registration
 


### PR DESCRIPTION
The current description is a bit confusing and the implementation just errors if the specified key piece is longer than the limit. It seems to be more clear as the truncation can be in either direction.