### PR TITLE
Shorten aggregation key id example

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -129,7 +129,7 @@ header](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#tri
       // which will take up 7 bits of space in the resulting key.
       "key_piece": "0xA80",
       // Apply this key piece to:
-      "source_keys": ["geoValue", "nonMatchingKeyIdsAreIgnored"]
+      "source_keys": ["geoValue", "nonMatchingKeyIdsIgnored"]
     }
   ],
   "aggregatable_values": {


### PR DESCRIPTION
The existing key id is actually longer than the limit and will fail.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/484.html" title="Last updated on Nov 30, 2022, 8:59 PM UTC (d2d1a80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/484/8020de4...d2d1a80.html" title="Last updated on Nov 30, 2022, 8:59 PM UTC (d2d1a80)">Diff</a>