### PR TITLE
Introduce optional error reports

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -630,7 +630,7 @@ included in the request body as a JSON object:
 }
 ```
 
-These error reports will be sent immediately upon the error occuring during
+These error reports will be sent immediately upon the error occurring during
 source registration.
 
 Note that if other failures are reported using this framework, the browser may


### PR DESCRIPTION
Fixes #160. 

Currently we only support one failure mode, as other failure modes may have privacy/security implications and need more thoughts/mitigations.

This proposal has a hard dependency on #482. 