### PR TITLE
Make source_event_id field optional

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -184,9 +184,9 @@ header `Attribution-Reporting-Register-Source` of the form:
 - `destination`: an origin whose eTLD+1 is where attribution will be triggered
 for this source.
 
-- `source_event_id`: A string encoding a 64-bit unsigned integer which
+- `source_event_id`: (optional) A string encoding a 64-bit unsigned integer which
 represents the event-level data associated with this source. This will be
-limited to 64 bits of information but the value can vary.
+limited to 64 bits of information but the value can vary. Defaults to 0.
 
 - `expiry`: (optional) expiry in seconds for when the source should be
 deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry

--- a/header-validator/data.source.js
+++ b/header-validator/data.source.js
@@ -88,10 +88,6 @@ export const invalidSourceHeadersAsObjects = [
     source_event_id: '12340873456',
     destination: 'http://example.com',
   },
-  // Missing required field Source event ID
-  {
-    destination: 'https://example.com',
-  },
   // Missing required field Destination
   {
     source_event_id: '12340873456',
@@ -157,7 +153,7 @@ export const invalidSourceHeadersAsObjects = [
   // Multiple errors
   {
     destination: 'foo',
-    priority: '-12340873456',
+    priority: 'bar',
   },
   // ⚠️ ⚠️ ⚠️ WARNINGS ⚠️ ⚠️ ⚠️
   // Unknown field `foo`

--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -186,7 +186,7 @@ export function validateSource(source) {
     expiry: optional(int64),
     filter_data: optional(filters(/*allowSourceType=*/ false)),
     priority: optional(int64),
-    source_event_id: required(uint64),
+    source_event_id: optional(uint64),
   })
   return state.result()
 }

--- a/index.bs
+++ b/index.bs
@@ -677,13 +677,13 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. Let |value| be the result of running
     [=parse a JSON string to an Infra value=] with |json|.
 1. If |value| is not an [=ordered map=], return null.
-1. If |value|["`source_event_id`"] does not [=map/exists|exist=] or is not a
-    [=string=], return null.
-1. Let |sourceEventId| be the result of applying the
-    <a spec="html">rules for parsing non-negative integers</a> to
-    |value|["`source_event_id`"] modulo the user agent's
-    [=source event ID cardinality=].
-1. If |sourceEventId| is an error, return null.
+1. Let |sourceEventId| be 0.
+1. If |value|["`source_event_id`"] [=map/exists=] and is a [=string=]:
+    1. Set |sourceEventId| to the result of applying the
+        <a spec="html">rules for parsing non-negative integers</a> to
+        |value|["`source_event_id`"] modulo the user agent's
+        [=source event ID cardinality=].
+    1. If |sourceEventId| is an error, set |sourceEventId| to 0.
 1. If |value|["`destination`"] does not [=map/exists|exist=] or is not a
     [=string=], return null.
 1. Let |attributionDestination| be the result of running


### PR DESCRIPTION
This simplifies source registration for users of the API who only care about aggregatable reports, for which the source_event_id value is irrelevant.

Fixes #517


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/518.html" title="Last updated on Jul 26, 2022, 1:48 PM UTC (983ad9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/518/9bbe9bd...apasel422:983ad9a.html" title="Last updated on Jul 26, 2022, 1:48 PM UTC (983ad9a)">Diff</a>