### PR TITLE
Default event_trigger_data to 0 if omitted or it has the wrong type

### DIFF
--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -235,7 +235,7 @@ const eventTriggerData = list(
       filters: optional(filters()),
       not_filters: optional(filters()),
       priority: optional(int64),
-      trigger_data: required(uint64),
+      trigger_data: optional(uint64),
     }),
   limits.maxEventTriggerData
 )

--- a/index.bs
+++ b/index.bs
@@ -894,12 +894,12 @@ To <dfn>parse event triggers</dfn> given an [=ordered map=] |map|:
 1. If |values| is not a [=list=], return null.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not an [=ordered map=], return null.
-    1. If |value|["`trigger_data`"] does not [=map/exists|exist=] or is not a
-        [=string=], return null.
-    1. Let |triggerData| be the result of applying the
-        <a spec="html">rules for parsing non-negative integers</a> to
-        |value|["`trigger_data`"].
-    1. If |triggerData| is an error, set |triggerData| to 0.
+    1. Let |triggerData| be 0.
+    1. If |value|["`trigger_data`"] [=map/exists=] and is a [=string=]:
+        1. Set |triggerData| to the result of applying the
+            <a spec="html">rules for parsing non-negative integers</a> to
+            |value|["`trigger_data`"].
+        1. If |triggerData| is an error, set |triggerData| to 0.
     1. Let |dedupKey| be null.
     1. If |value|["`deduplication_key`"] [=map/exists=] and is a [=string=]:
         1. Set |dedupKey| to the result of applying the


### PR DESCRIPTION
The [explainer](https://github.com/WICG/attribution-reporting-api/blob/608e6da694849b1c07d297b54009b02ca9385a29/EVENT.md?plain=1#L296) already indicates that this field is optional, and this spec change aligns this field with the behavior of `source_event_id` in #518.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/542.html" title="Last updated on Aug 16, 2022, 3:09 PM UTC (f0e70fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/542/608e6da...apasel422:f0e70fd.html" title="Last updated on Aug 16, 2022, 3:09 PM UTC (f0e70fd)">Diff</a>