### PR TITLE
Set report request's origin to reporting endpoint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2399,6 +2399,8 @@ and a [=header list=] |newHeaders| (defaults to an empty [=list=]):
     :: "`no-referrer`"
     :   [=request/client=]
     ::  `null`
+    :   [=request/origin=]
+    ::  |report|'s  [=event-level report/reporting endpoint=]
     :   [=request/window=]
     ::  "`no-window`"
     :   [=request/service-workers mode=]

--- a/index.bs
+++ b/index.bs
@@ -2400,7 +2400,7 @@ and a [=header list=] |newHeaders| (defaults to an empty [=list=]):
     :   [=request/client=]
     ::  `null`
     :   [=request/origin=]
-    ::  |report|'s  [=event-level report/reporting endpoint=]
+    ::  |url|'s [=url/origin=]
     :   [=request/window=]
     ::  "`no-window`"
     :   [=request/service-workers mode=]


### PR DESCRIPTION
Otherwise, the default of `"client"` interacts incompatibly with the
setting of the request's `client` to `null`.

Fixes #546


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/547.html" title="Last updated on Apr 3, 2023, 1:32 PM UTC (8e0137d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/547/ec2982b...apasel422:8e0137d.html" title="Last updated on Apr 3, 2023, 1:32 PM UTC (8e0137d)">Diff</a>