### PR TITLE
Clarify language on bad OS response headers

### DIFF
--- a/app_to_web.md
+++ b/app_to_web.md
@@ -56,7 +56,7 @@ Normal attribution logic in the browser will be halted.
 
 For a site to enable App<->Web attribution after integrating with the Web API, they will only need to make server side changes.
 
-A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will fail cause a registration failure (including web registration).
+A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will cause a registration failure (including web registration).
 
 ## Privacy considerations
 

--- a/app_to_web.md
+++ b/app_to_web.md
@@ -56,7 +56,7 @@ Normal attribution logic in the browser will be halted.
 
 For a site to enable App<->Web attribution after integrating with the Web API, they will only need to make server side changes.
 
-A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will cause a registration failure (including web registration).
+A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will cause the entire registration to fail (including web registration).
 
 ## Privacy considerations
 

--- a/app_to_web.md
+++ b/app_to_web.md
@@ -56,7 +56,7 @@ Normal attribution logic in the browser will be halted.
 
 For a site to enable App<->Web attribution after integrating with the Web API, they will only need to make server side changes.
 
-A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will not forward any information to the underlying OS. Normal Attribution-Reporting headers in this case will work normally.
+A reporting origin responding with the `Attribution-Reporting-Register-OS-Source` or `Attribution-Reporting-Register-OS-Trigger` headers while `Attribution-Reporting-Support` does not contain `os` will fail cause a registration failure (including web registration).
 
 ## Privacy considerations
 


### PR DESCRIPTION
The current language is vague and can be interpreted in two ways.