### PR TITLE
Remove landing page restriction for navigation sources

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -208,12 +208,8 @@ since it is the origin that will end up receiving attribution reports.
 
 ### Handling an attribution source event
 
-A `navigation` attribution source event will be logged to storage if the
-resulting document being navigated to ends up sharing an eTLD+1 with the
-`destination` origin. Additionally, the navigation needs occur with [transient
-user activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation).
-
-`event` sources don’t require any of the above constraints to be logged.
+A `navigation` attribution source event will be logged to storage if  the navigation occurs with [transient
+user activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation). `event` sources don’t require activation.
 
 An attribution source will be eligible for reporting if any page on the
 `destination` eTLD+1 (advertiser site) triggers attribution for the associated

--- a/index.bs
+++ b/index.bs
@@ -173,9 +173,6 @@ to set the [=navigation params/attribution source=] of |navigationParams| to |at
 
 <h4 id="monkeypatch-document-creation">Document creation</h4>
 
-At the time <a spec="html">create and initialize a <code>Document</code> object</a> is invoked, the user agent knows the final URL used for the
-navigation and can validate the [=attribution source/attribution destination=].
-
 In <a spec="html">create and initialize a <code>Document</code> object</a>, before
 
 > 2. Let permissionsPolicy be the result of creating a permissions policy from a response given browsingContext
@@ -849,8 +846,6 @@ To <dfn>maybe process a navigation attribution source</dfn> given a <a spec="HTM
 1. If |browsingContext| is not a <a spec="html">top-level browsing context</a>, return.
 1. Let <var>attributionSource</var> be |navigationParams|'s [=navigation params/attribution source=].
 1. If |attributionSource| is null, return.
-1. If |attributionSource|'s [=attribution source/attribution destination=] is not [=same site=] to |navigationParams|'s
-    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-origin">origin</a>, return.
 1. [=Queue a task=] to [=process an attribution source=] with |attributionSource|.
 
 To <dfn>obtain a fake report</dfn> given an [=attribution source=] |source| and


### PR DESCRIPTION
Fixes #590


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/592.html" title="Last updated on Oct 26, 2022, 9:07 PM UTC (d844202)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/592/0b4ce8a...d844202.html" title="Last updated on Oct 26, 2022, 9:07 PM UTC (d844202)">Diff</a>