### PR TITLE
Remove destinations from OS-Source header

### DIFF
--- a/app_to_web.md
+++ b/app_to_web.md
@@ -36,11 +36,9 @@ Attribution-Reporting-Support: os, web
 If this header indicates OS support, the reporting origin can optionally respond to the request with a [string structured header](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-3.3.3) that indicates a desire to use the OS’s attribution API instead of the browser’s. Note that the API also allows browsers to only support OS-level attribution if they choose.
 ```
 // Registers a source against a native OS attribution API
-Attribution-Reporting-Register-OS-Source: "https://adtech.example/register-android-source?..."; os-destination=<os destination>; web-destination=<web destination>
+Attribution-Reporting-Register-OS-Source: "https://adtech.example/register-android-source?..."
 
 ```
-
-Note that we still require the response to declare a destination for clicks and views to the browser even when registering with the OS level attribution API. This allows the browser to help enforce destination matching for web destinations. The OS destination will be a platform-specific application name (e.g. an Android package name), the web destination will be a scheme + eTLD+1.
 
 Trigger registrations will accept a new response header as well:
 ```


### PR DESCRIPTION
With destination matching removed from the core web APIs(https://github.com/WICG/attribution-reporting-api/pull/592), we do not need to mirror it for cross app and web sources.