### PR TITLE
Return `dropped` when report window has expired

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1244,7 +1244,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value is false, return <strong>dropped</strong>.
 1. Assert: |sourceToAttribute|'s [=attribution source/randomized response=] is
     null or an [=set/is empty|empty=] [=set=].
-1. If |sourceToAttribute|'s [=attribution source/event report window time=] is less than the current time, return. 
+1. If |sourceToAttribute|'s [=attribution source/event report window time=] is less than the current time, return <strong>dropped</strong>.
 1. Let |matchedConfig| be null.
 1. [=map/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
     [=attribution trigger/event-level trigger configurations=]:
@@ -1304,7 +1304,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger| and an
 [=attribution source=] |sourceToAttribute|, run the following steps:
 
-1. If |sourceToAttribute|'s [=attribution source/aggregatable report window time=] is less than the current time, return. 
+1. If |sourceToAttribute|'s [=attribution source/aggregatable report window time=] is less than the current time, return <strong>dropped</strong>.
 1. Let |report| be the result of running [=obtain an aggregatable report=] with |sourceToAttribute| and |trigger|.
 1. If |report|'s [=aggregatable report/contributions=] [=list/is empty=], return <strong>dropped</strong>.
 1. If |trigger|'s [=attribution trigger/aggregatable dedup key=] is not null and


### PR DESCRIPTION
This was an oversight in #577.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/609.html" title="Last updated on Nov 9, 2022, 7:00 PM UTC (8808fbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/609/d33f461...apasel422:8808fbe.html" title="Last updated on Nov 9, 2022, 7:00 PM UTC (8808fbe)">Diff</a>