### PR TITLE
Bound report windows by expiry time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -728,9 +728,9 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. Let |expiry| be the result of running [=obtain a source expiry=] on |value|["`expiry`"].
 1. If |expiry| is null, set |expiry| to 30 days.
 1. Let |eventReportWindow| be the result of running [=obtain a source expiry=] on |value|["`event_report_window`"].
-1. If |eventReportWindow| is null, set |eventReportWindow| to |expiry|.
+1. If |eventReportWindow| is null or greater than expiry, set |eventReportWindow| to |expiry|.
 1. Let |aggregatableReportWindow| be the result of running [=obtain a source expiry=] on |value|["`aggregatable_report_window`"].
-1. If |aggregatableReportWindow| is null, set |aggregatableReportWindow| to |expiry|.
+1. If |aggregatableReportWindow| is null or greater than expiry, set |aggregatableReportWindow| to |expiry|.
 1. Let |priority| be 0.
 1. If |value|["`priority`"] [=map/exists=] and is a [=string=]:
     1. Set |priority| to the result of applying the

--- a/index.bs
+++ b/index.bs
@@ -728,7 +728,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. Let |expiry| be the result of running [=obtain a source expiry=] on |value|["`expiry`"].
 1. If |expiry| is null, set |expiry| to 30 days.
 1. Let |eventReportWindow| be the result of running [=obtain a source expiry=] on |value|["`event_report_window`"].
-1. If |eventReportWindow| is null or greater than expiry, set |eventReportWindow| to |expiry|.
+1. If |eventReportWindow| is null or greater than |expiry|, set |eventReportWindow| to |expiry|.
 1. Let |aggregatableReportWindow| be the result of running [=obtain a source expiry=] on |value|["`aggregatable_report_window`"].
 1. If |aggregatableReportWindow| is null or greater than expiry, set |aggregatableReportWindow| to |expiry|.
 1. Let |priority| be 0.

--- a/index.bs
+++ b/index.bs
@@ -730,7 +730,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. Let |eventReportWindow| be the result of running [=obtain a source expiry=] on |value|["`event_report_window`"].
 1. If |eventReportWindow| is null or greater than |expiry|, set |eventReportWindow| to |expiry|.
 1. Let |aggregatableReportWindow| be the result of running [=obtain a source expiry=] on |value|["`aggregatable_report_window`"].
-1. If |aggregatableReportWindow| is null or greater than expiry, set |aggregatableReportWindow| to |expiry|.
+1. If |aggregatableReportWindow| is null or greater than |expiry|, set |aggregatableReportWindow| to |expiry|.
 1. Let |priority| be 0.
 1. If |value|["`priority`"] [=map/exists=] and is a [=string=]:
     1. Set |priority| to the result of applying the


### PR DESCRIPTION
After discussion with @johnivdel, report windows should be guaranteed to be less than or equal to expiry. If the report window time(s) provided are greater than the expiry time, the report window will be clamped to expiry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/610.html" title="Last updated on Nov 9, 2022, 8:48 PM UTC (6c17e70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/610/14b657c...6c17e70.html" title="Last updated on Nov 9, 2022, 8:48 PM UTC (6c17e70)">Diff</a>