### PR TITLE
Update ara-tester-list.md

### DIFF
--- a/ara-tester-list.md
+++ b/ara-tester-list.md
@@ -45,3 +45,4 @@ The usefulness of this page depends on testers sharing information and updates; 
 | NextRoll | Demand-side platform (DSP) | | | privacysandbox@nextroll.com |
 | RTB House | Demand-side platform (DSP) | | | privacysandbox@rtbhouse.com |
 | CyberAgent | Demand-side platform (DSP) | | | privacysandbox@cyberagent.co.jp |
+| Google (Ads Products & Platforms) | Ad tech services | Testing ongoing | | Clients can reach out to their account manager directly |


### PR DESCRIPTION
Updated ara-tester-list.md for Google Ads. 

| Google (Ads Products & Platforms) | Ad tech services | Testing ongoing |  | Clients can reach out to their account manager directly |
