### PR TITLE
Group attribution-success and verbose debugging reports under transitional debugging reports

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -12,7 +12,7 @@
   - [Attribution trigger registration](#attribution-trigger-registration)
   - [Aggregatable reports](#aggregatable-reports)
   - [Optional: transitional debugging reports](#optional-transitional-debugging-reports)
-    - [Attribution-succeeded debugging reports](#attribution-succeeded-debugging-reports)
+    - [Attribution-succeed debugging reports](#attribution-succeed-debugging-reports)
     - [Verbose debugging reports](#verbose-debugging-reports)
   - [Contribution bounding and budgeting](#contribution-bounding-and-budgeting)
   - [Storage limits](#storage-limits)
@@ -266,7 +266,7 @@ The browser is free to utilize techniques like retries to minimize data loss.
 * The `payload` will contain the actual histogram contributions. It should be be
   encrypted and then base64 encoded, see [below](#encrypted-payload).
 
-Optional debugging fields are discussed [below](#attribution-succeeded-debugging-reports).
+Optional debugging fields are discussed [below](#attribution-succeed-debugging-reports).
 
 #### Encrypted payload
 The `payload` should be a [CBOR](https://cbor.io) map encrypted via
@@ -331,9 +331,9 @@ keys are delivered to different users.
 
 ### Optional: transitional debugging reports
 
-#### Attribution-succeeded debugging reports
+#### Attribution-succeed debugging reports
 
-If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeeded-debugging-reports)
+If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeed-debugging-reports)
 is enabled, additional debug fields will be present in aggregatable reports.
 The `source_debug_key` and `trigger_debug_key` fields match those in the
 event-level reports. If both the source and trigger debug keys are set, there

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -12,7 +12,7 @@
   - [Attribution trigger registration](#attribution-trigger-registration)
   - [Aggregatable reports](#aggregatable-reports)
   - [Optional: transitional debugging reports](#optional-transitional-debugging-reports)
-    - [Attribution-succeed debugging reports](#attribution-succeed-debugging-reports)
+    - [Attribution-success debugging reports](#attribution-success-debugging-reports)
     - [Verbose debugging reports](#verbose-debugging-reports)
   - [Contribution bounding and budgeting](#contribution-bounding-and-budgeting)
   - [Storage limits](#storage-limits)
@@ -266,7 +266,7 @@ The browser is free to utilize techniques like retries to minimize data loss.
 * The `payload` will contain the actual histogram contributions. It should be be
   encrypted and then base64 encoded, see [below](#encrypted-payload).
 
-Optional debugging fields are discussed [below](#attribution-succeed-debugging-reports).
+Optional debugging fields are discussed [below](#attribution-success-debugging-reports).
 
 #### Encrypted payload
 The `payload` should be a [CBOR](https://cbor.io) map encrypted via
@@ -331,9 +331,9 @@ keys are delivered to different users.
 
 ### Optional: transitional debugging reports
 
-#### Attribution-succeed debugging reports
+#### Attribution-success debugging reports
 
-If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeed-debugging-reports)
+If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-success-debugging-reports)
 is enabled, additional debug fields will be present in aggregatable reports.
 The `source_debug_key` and `trigger_debug_key` fields match those in the
 event-level reports. If both the source and trigger debug keys are set, there

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -333,7 +333,7 @@ keys are delivered to different users.
 
 #### Attribution-succeeded debugging reports
 
-If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeeded-debug-reports)
+If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeeded-debugging-reports)
 is enabled, additional debug fields will be present in aggregatable reports.
 The `source_debug_key` and `trigger_debug_key` fields match those in the
 event-level reports. If both the source and trigger debug keys are set, there

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -263,7 +263,7 @@ The browser is free to utilize techniques like retries to minimize data loss.
 * The `payload` will contain the actual histogram contributions. It should be be
   encrypted and then base64 encoded, see [below](#encrypted-payload).
 
-Optional debugging fields are discussed [below](#optional-extended-debugging-reports).
+Optional debugging fields are discussed [below](#optional-primary-debugging-reports).
 
 #### Encrypted payload
 The `payload` should be a [CBOR](https://cbor.io) map encrypted via
@@ -326,9 +326,9 @@ future versions of the API), the endpoint URL should also change.
 **Note:** The browser may need some mechanism to ensure that the same set of
 keys are delivered to different users.
 
-#### Optional: extended debugging reports
+#### Optional: primary debugging reports
 
-If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#optional-extended-debugging-reports)
+If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#optional-primary-debugging-reports)
 is enabled, additional debug fields will be present in aggregatable reports.
 The `source_debug_key` and `trigger_debug_key` fields match those in the
 event-level reports. If both the source and trigger debug keys are set, there

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -11,6 +11,9 @@
   - [Attribution source registration](#attribution-source-registration)
   - [Attribution trigger registration](#attribution-trigger-registration)
   - [Aggregatable reports](#aggregatable-reports)
+  - [Optional: transitional debugging reports](#optional-transitional-debugging-reports)
+    - [Attribution-succeeded debugging reports](#attribution-succeeded-debugging-reports)
+    - [Verbose debugging reports](#verbose-debugging-reports)
   - [Contribution bounding and budgeting](#contribution-bounding-and-budgeting)
   - [Storage limits](#storage-limits)
 - [Data processing through a Secure Aggregation Service](#data-processing-through-a-secure-aggregation-service)
@@ -263,7 +266,7 @@ The browser is free to utilize techniques like retries to minimize data loss.
 * The `payload` will contain the actual histogram contributions. It should be be
   encrypted and then base64 encoded, see [below](#encrypted-payload).
 
-Optional debugging fields are discussed [below](#optional-primary-debugging-reports).
+Optional debugging fields are discussed [below](#attribution-succeeded-debugging-reports).
 
 #### Encrypted payload
 The `payload` should be a [CBOR](https://cbor.io) map encrypted via
@@ -326,9 +329,11 @@ future versions of the API), the endpoint URL should also change.
 **Note:** The browser may need some mechanism to ensure that the same set of
 keys are delivered to different users.
 
-#### Optional: primary debugging reports
+### Optional: transitional debugging reports
 
-If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#optional-primary-debugging-reports)
+#### Attribution-succeeded debugging reports
+
+If [debugging](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-succeeded-debug-reports)
 is enabled, additional debug fields will be present in aggregatable reports.
 The `source_debug_key` and `trigger_debug_key` fields match those in the
 event-level reports. If both the source and trigger debug keys are set, there
@@ -345,6 +350,12 @@ The debug reports should be almost identical to the normal reports, including th
 additional debug fields. However, the `payload` ciphertext will differ due to
 repeating the encryption operation and the `key_id` may differ if the previous
 key had since expired or the browser randomly chose a different valid public key.
+
+#### Verbose debugging reports
+
+As outlined in the
+  [event-level explainer](https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#verbose-debugging-reports),
+certain aggregate attribution failures can be monitored as well.
 
 ### Contribution bounding and budgeting
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -36,7 +36,7 @@ extension on top of this.
   - [Data Encoding](#data-encoding)
   - [Optional attribution filters](#optional-attribution-filters)
   - [Optional: transitional debugging reports](#optional-transitional-debugging-reports)
-    - [Attribution-succeed debugging reports](#attribution-succeed-debugging-reports)
+    - [Attribution-success debugging reports](#attribution-success-debugging-reports)
     - [Verbose debugging reports](#verbose-debugging-reports)
   - [Noisy fake conversion example](#noisy-fake-conversion-example)
   - [Storage limits](#storage-limits)
@@ -577,7 +577,7 @@ Note that in the context of proposals such as
 [CHIPS](https://github.com/privacycg/CHIPS), the cookie must be unpartitioned in
 order to allow debug keys to be registered.
 
-#### Attribution-succeed debugging reports
+#### Attribution-success debugging reports
 
 Source and trigger registrations will both accept a new field `debug_key`:
 ```jsonc

--- a/EVENT.md
+++ b/EVENT.md
@@ -566,7 +566,7 @@ alternatives.
 To ensure that this data (which could enable cross-site tracking) is only
 available in a transitional phase while third-party cookies are available and
 are already capable of user tracking, the browser will check (at both source
-and trigger registration) for the presence of a special `SameSite=None` cookie
+and trigger registration) for the presence of a special cookie
 set by the reporting origin:
 ```http
 Set-Cookie: ar_debug=1; SameSite=None; Secure; HttpOnly

--- a/EVENT.md
+++ b/EVENT.md
@@ -36,7 +36,7 @@ extension on top of this.
   - [Data Encoding](#data-encoding)
   - [Optional attribution filters](#optional-attribution-filters)
   - [Optional: transitional debugging reports](#optional-transitional-debugging-reports)
-    - [Attribution-succeeded debugging reports](#attribution-succeeded-debugging-reports)
+    - [Attribution-succeed debugging reports](#attribution-succeed-debugging-reports)
     - [Verbose debugging reports](#verbose-debugging-reports)
   - [Noisy fake conversion example](#noisy-fake-conversion-example)
   - [Storage limits](#storage-limits)
@@ -577,7 +577,7 @@ Note that in the context of proposals such as
 [CHIPS](https://github.com/privacycg/CHIPS), the cookie must be unpartitioned in
 order to allow debug keys to be registered.
 
-#### Attribution-succeeded debugging reports
+#### Attribution-succeed debugging reports
 
 Source and trigger registrations will both accept a new field `debug_key`:
 ```jsonc

--- a/EVENT.md
+++ b/EVENT.md
@@ -35,7 +35,7 @@ extension on top of this.
   - [Attribution Reports](#attribution-reports)
   - [Data Encoding](#data-encoding)
   - [Optional attribution filters](#optional-attribution-filters)
-  - [Optional: extended debugging reports](#optional-extended-debugging-reports)
+  - [Optional: Primary debugging reports](#optional-primary-debugging-reports)
   - [Optional: verbose debugging reports](#optional-verbose-debugging-reports)
   - [Noisy fake conversion example](#noisy-fake-conversion-example)
   - [Storage limits](#storage-limits)
@@ -552,7 +552,7 @@ will be created.
 If the filters match for multiple event triggers, the first matching event
 trigger is used.
 
-### Optional: extended debugging reports
+### Optional: primary debugging reports
 
 The Attribution Reporting API is a new and fairly complex way to do attribution
 measurement without third-party cookies. As such, we are open to introducing a
@@ -610,7 +610,7 @@ order to allow debug keys to be registered.
 We also introduce a debugging framework to allow developers to monitor certain
 failures in the attribution registrations.
 
-Similar to [extended debugging reports](#optional-extended-debugging-reports),
+Similar to [primary debugging reports](#optional-primary-debugging-reports),
 failure modes that may enable cross-site tracking are only reported in a
 transitional phase while third-party cookies are available and the browser will
 check for the presence of the `ar_debug` cookie set by the reporting origin.

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -2,9 +2,8 @@ Verbose Debugging Reports
 =========================
 
 This document is a collection of [verbose debugging
-reports](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-verbose-debugging-reports)
-that are supported. Note that the types marked `cookie-based` are only reported
-in a transitional phase while third-party cookies are available.
+reports](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#verbose-debugging-reports)
+that are supported.
 
 ### Source debugging reports
 
@@ -14,16 +13,16 @@ registrations](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT
 #### `source-destination-limit`
 A source is rejected due to the [destination limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources).
 
-#### `source-noised` (cookie-based)
+#### `source-noised`
 [Noise](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#data-limits-and-noise) is applied to a source event.
 
-#### `source-storage-limit` (cookie-based)
+#### `source-storage-limit`
 A source is rejected due to the [storage limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#storage-limits).
 
-#### `source-unknown-error` (cookie-based)
+#### `source-unknown-error`
 System error.
 
-### Trigger debugging reports (cookie-based)
+### Trigger debugging reports
 
 Here are the debugging reports supported for [attribution trigger
 registrations](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#triggering-attribution).
@@ -112,9 +111,9 @@ This table defines the fields in the `body` dictionary.
 | `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | ` trigger_debug_key` |
 | --- | --- | --- | --- | --- | --- | --- |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-noised`](#source-noised-cookie-based) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
-| [`source-storage-limit`](#source-storage-limit-cookie-based) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-unknown-error`](#source-unknown-error-cookie-based) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
+| [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
+| [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
This is to avoid confusion with the two types of debugging reports.