### PR TITLE
Fix unexpired destinations limit return to handle new algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -831,7 +831,7 @@ To <dfn>check if an [=attribution source=] exceeds the unexpired destination lim
 1. For each [=attribution rate-limit record=] |unexpiredRecord| of |unexpiredSources|:
     1. [=set/append=] |unexpiredRecord|'s [=attribution rate-limit record/attribution destination=] to |unexpiredDestinations|.
 1. Let |newDestinations| be the result of taking the [=set/union=] of |unexpiredDestinations| and |source|'s [=attribution source/attribution destinations=].
-1. Return whether |newDestinations|'s [=set/size=] is greater than or equal to the user agent's [=max destinations covered by unexpired sources=].
+1. Return whether |newDestinations|'s [=set/size=] is greater than the user agent's [=max destinations covered by unexpired sources=].
 
 
 <h3 id="processing-an-attribution-source">Processing an attribution source</h3>


### PR DESCRIPTION
The algorithm changes for checking unexpired destination limit from #601 includes appending the new source's destinations with the set holding the currently stored destinations when checking if the size has surpassed the max destinations per source site. Previously, the new source's destination was never appended to this set, so it made sense to have the set's size check be greater than or equal to the max limit, but now it makes more sense to make the condition just greater than.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/650.html" title="Last updated on Dec 15, 2022, 1:35 PM UTC (0259ad7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/650/14b657c...0259ad7.html" title="Last updated on Dec 15, 2022, 1:35 PM UTC (0259ad7)">Diff</a>