### PR TITLE
Fix broken default allowlist links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -108,9 +108,9 @@ Issue: Specify monkeypatches for source/trigger registration.
 
 # Permissions Policy integration # {#permission-policy-integration}
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=default allowlist=] is `'self'`.
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn noexport>attribution-reporting</dfn></code>". Its [=policy-controlled feature/default allowlist=] is `'self'`.
 
-Note: In the Chromium implementation the [=default allowlist=] is temporarily set to `*` to ease testing.
+Note: In the Chromium implementation the [=policy-controlled feature/default allowlist=] is temporarily set to `*` to ease testing.
 
 # Structures # {#structures}
 


### PR DESCRIPTION
Broken by https://github.com/w3c/webappsec-permissions-policy/pull/498.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/668.html" title="Last updated on Jan 12, 2023, 5:28 PM UTC (2d769ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/668/d727ea7...apasel422:2d769ce.html" title="Last updated on Jan 12, 2023, 5:28 PM UTC (2d769ce)">Diff</a>