### PR TITLE
Replace erroneous map-iteration links with set iteration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1063,7 +1063,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=list/Remove=] all [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if the result of running
     [=can attribution rate-limit record be removed=] with |entry| and |source|'s [=attribution source/source time=] is true.
 1. If |source|'s [=attribution source/randomized response=] is not null and is a [=set=]:
-    1. [=map/iterate|For each=] [=trigger state=] |triggerState| of |source|'s
+    1. [=set/iterate|For each=] [=trigger state=] |triggerState| of |source|'s
         [=attribution source/randomized response=]:
         1. Let |fakeReport| be the result of running [=obtain a fake report=]
             with |source| and |triggerState|.
@@ -1359,7 +1359,7 @@ Given an [=attribution rate-limit record=] |newRecord|:
      * |record|'s [=attribution rate-limit record/attribution destination=] and |newRecord|'s [=attribution rate-limit record/attribution destination=] are equal
      * |record|'s [=attribution rate-limit record/time=] is at least [=attribution rate-limit window=] before |newRecord|'s [=attribution rate-limit record/time=]
 1. Let |distinctReportingEndpoints| be a new empty [=ordered set=].
-1. [=map/iterate|For each=] |record| of |matchingRateLimitRecords|, [=set/append=] |record|'s
+1. [=set/iterate|For each=] |record| of |matchingRateLimitRecords|, [=set/append=] |record|'s
      [=attribution rate-limit record/reporting endpoint=] to |distinctReportingEndpoints|.
 1. If |distinctReportingEndpoints| [=list/contains=] |newRecord|'s
     [=attribution rate-limit record/reporting endpoint=], return <strong>allowed</strong>.
@@ -1491,7 +1491,7 @@ and a [=boolean=] |topLevelFiltersMatch|, run the following steps:
         |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. Let |matchedConfig| be null.
-1. [=map/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
+1. [=set/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
     [=attribution trigger/event-level trigger configurations=]:
     1. If the result of running
         [=match an attribution source's filter data against filters and negated filters=] with |sourceToAttribute|,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/673.html" title="Last updated on Jan 18, 2023, 3:19 PM UTC (85102c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/673/5e102d4...apasel422:85102c1.html" title="Last updated on Jan 18, 2023, 3:19 PM UTC (85102c1)">Diff</a>