### PR TITLE
Remove obsolete scheme issue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -916,8 +916,6 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
     :: |debugReportingEnabled|
 1. Return |source|.
 
-Issue: Ensure that all sites in |attributionDestinations| have HTTP/HTTPS [=origin/schemes=].
-
 <h3 id="check-unexpired-destination-limit">Checking unexpired destination limit</h3>
 
 To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an


### PR DESCRIPTION
The scheme checks are already performed by the "parse an attribution destination" algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/674.html" title="Last updated on Jan 18, 2023, 3:55 PM UTC (6e07b1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/674/57375df...apasel422:6e07b1d.html" title="Last updated on Jan 18, 2023, 3:55 PM UTC (6e07b1d)">Diff</a>