### PR TITLE
Use fake trigger time or source time for fake report rate limit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1065,11 +1065,15 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=list/Remove=] all [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if the result of running
     [=can attribution rate-limit record be removed=] with |entry| and |source|'s [=attribution source/source time=] is true.
 1. If |source|'s [=attribution source/randomized response=] is not null and is a [=set=]:
+    1. Let |triggerTime| be null.
     1. [=set/iterate|For each=] [=trigger state=] |triggerState| of |source|'s
         [=attribution source/randomized response=]:
         1. Let |fakeReport| be the result of running [=obtain a fake report=]
             with |source| and |triggerState|.
         1. [=set/Append=] |fakeReport| to the [=event-level report cache=].
+        1. If |triggerTime| is null or |fakeReport|'s [=event-level report/trigger time=] is less than |triggerTime|,
+            set |triggerTime| to |fakeReport|'s [=event-level report/trigger time=].
+    1. If |triggerTime| is null, set |triggerTime| to |source|'s [=attribution source/source time=].
     1. If |source|'s [=attribution source/randomized response=] is not [=set/is empty|empty=],
         then set |source|'s [=attribution source/event-level attributable=] value to false.
     1. [=map/iterate|For each=] |destination| in [=source=]'s [=attribution source/attribution destinations=]:
@@ -1083,7 +1087,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/reporting endpoint=]
             :: |source|'s [=attribution source/reporting endpoint=]
             : [=attribution rate-limit record/time=]
-            :: |source|'s [=attribution source/source time=]
+            :: |triggerTime|
             : [=attribution rate-limit record/expiry time=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/676.html" title="Last updated on Jan 19, 2023, 3:33 PM UTC (0f37631)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/676/bdfa8a8...linnan-github:0f37631.html" title="Last updated on Jan 19, 2023, 3:33 PM UTC (0f37631)">Diff</a>