### PR TITLE
Use source time for attribution rate limit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1747,7 +1747,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     : [=attribution rate-limit record/reporting endpoint=]
     :: |sourceToAttribute|'s [=attribution source/reporting endpoint=]
     : [=attribution rate-limit record/time=]
-    :: |trigger|'s [=attribution trigger/trigger time=]
+    :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
 1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/681.html" title="Last updated on Jan 20, 2023, 7:50 PM UTC (14a659b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/681/04f842a...linnan-github:14a659b.html" title="Last updated on Jan 20, 2023, 7:50 PM UTC (14a659b)">Diff</a>