### PR TITLE
Skip verbose debug report if no event-level trigger data is provided

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1514,6 +1514,9 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 [=attribution source=] |sourceToAttribute|, an [=attribution rate-limit record=] |rateLimitRecord|
 and a [=boolean=] |topLevelFiltersMatch|, run the following steps:
 
+1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
+    [=list/is empty=], return the [=triggering result=]
+    ("<code>[=triggering status/dropped=]</code>", null).
 1. If |sourceToAttribute|'s [=attribution source/randomized response=] is not null and is not [=set/is empty|empty=]:
     1. Assert: |sourceToAttribute|'s [=attribution source/event-level attributable=] is false.
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]


### PR DESCRIPTION
Fixes #680


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/682.html" title="Last updated on Jan 20, 2023, 9:10 PM UTC (f684008)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/682/9214d1e...apasel422:f684008.html" title="Last updated on Jan 20, 2023, 9:10 PM UTC (f684008)">Diff</a>