### PR TITLE
Fix erroneous set/empty links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -753,7 +753,7 @@ To <dfn>parse attribution destinations</dfn> from a value |val|:
     1. If |destination| is null, return null.
     1. [=set/append=] |destination| to |result|.
 1. If |result|'s [=set/size=] is greater than 3, return null.
-1. If |result| is [=set/empty=], return null.
+1. If |result| [=set/is empty=], return null.
 1. return |result|.
 
 Issue: confirm that the maximum destinations size is workable.
@@ -950,7 +950,7 @@ To <dfn>check if an [=attribution source=] exceeds the unexpired destination lim
      * |record|'s [=attribution rate-limit record/source site=] and |source|'s [=attribution source/source site=] are equal
      * |record|'s [=attribution rate-limit record/reporting endpoint=] and |source|'s [=attribution source/reporting endpoint=] are equal
      * |record|'s [=attribution rate-limit record/expiry time=] is greater than |source|'s [=attribution source/source time=]
-1. Let |unexpiredDestinations| be an [=set/empty=] [=set=].
+1. Let |unexpiredDestinations| be an [=set/is empty|empty=] [=set=].
 1. For each [=attribution rate-limit record=] |unexpiredRecord| of |unexpiredSources|:
     1. [=set/append=] |unexpiredRecord|'s [=attribution rate-limit record/attribution destination=] to |unexpiredDestinations|.
 1. Let |newDestinations| be the result of taking the [=set/union=] of |unexpiredDestinations| and |source|'s [=attribution source/attribution destinations=].
@@ -1939,7 +1939,7 @@ Issue: This would ideally be replaced by a more descriptive algorithm in Infra. 
 
 To <dfn>serialize [=event-level report/attribution destinations=]</dfn> |destinations|, run the following steps:
 
-1. [=Assert=]: |destinations| is not [=set/empty=].
+1. [=Assert=]: |destinations| is not [=set/is empty|empty=].
 1. Let |destinationStrings| be a [=list=]
 1. [=list/iterate|For each=] |destination| in |destinations|:
     1. [=Assert=]: |destination| is not the [=opaque origin=].


### PR DESCRIPTION
`set/empty` refers to the algorithm that clears a set.
`set/is empty` refers to the algorithm that checks if a set has no elements.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/683.html" title="Last updated on Jan 23, 2023, 2:15 PM UTC (6228d00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/683/eb1283d...apasel422:6228d00.html" title="Last updated on Jan 23, 2023, 2:15 PM UTC (6228d00)">Diff</a>