### PR TITLE
Return early and skip verbose debug reports if trigger has no data

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1720,6 +1720,10 @@ To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
 1. Return |matchingSources|.
 
 To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:
+
+1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
+    [=set/is empty=] and |trigger|'s
+    [=attribution trigger/aggregatable trigger data=] [=list/is empty=], return.
 1. Let |matchingSources| be the result of running [=find matching sources=] with |trigger|.
 1. If |matchingSources| [=list/is empty=]:
     1. Run [=obtain and deliver a debug report on trigger registration=]

--- a/index.bs
+++ b/index.bs
@@ -1723,7 +1723,9 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=set/is empty=] and |trigger|'s
-    [=attribution trigger/aggregatable trigger data=] [=list/is empty=], return.
+    [=attribution trigger/aggregatable trigger data=] [=list/is empty=] and
+    |trigger|'s [=attribution trigger/aggregatable values=] [=map/is empty=],
+    return.
 1. Let |matchingSources| be the result of running [=find matching sources=] with |trigger|.
 1. If |matchingSources| [=list/is empty=]:
     1. Run [=obtain and deliver a debug report on trigger registration=]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/686.html" title="Last updated on Jan 23, 2023, 6:32 PM UTC (9b37b19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/686/437301c...apasel422:9b37b19.html" title="Last updated on Jan 23, 2023, 6:32 PM UTC (9b37b19)">Diff</a>