### PR TITLE
Extract algorithm for checking both rate limits during attribution

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1419,7 +1419,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
-    |rateLimitRecord| is <strong>blocked</strong>:
+    | newRecord | is <strong>blocked</strong>:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.

--- a/index.bs
+++ b/index.bs
@@ -1419,7 +1419,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
-    | newRecord | is <strong>blocked</strong>:
+    |newRecord| is <strong>blocked</strong>:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.

--- a/index.bs
+++ b/index.bs
@@ -1373,7 +1373,7 @@ To <dfn>match an attribution source's filter data against filters and negated fi
     |source|, |notFilters|, and [=match an attribution source's filter data against filters/isNegated=] set to true is false, return false.
 1. Return true.
 
-<h3 dfn id="should-rate-limit-attribution">Should attribution be blocked by rate limit</h3>
+<h3 dfn id="should-block-attribution-for-attribution-limit">Should attribution be blocked by attribution rate limit</h3>
 
 Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
 
@@ -1406,6 +1406,25 @@ Given an [=attribution rate-limit record=] |newRecord|:
 1. If |distinctReportingEndpoints|'s [=list/size=] is greater than or equal to |max|, return
     <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
+
+<h3 dfn id="should-block-attribution-for-rate-limits">Should attribution be blocked by rate limits</h3>
+
+Given an [=attribution trigger=] |trigger|, an [=attribution source=]
+|sourceToAttribute|, and an [=attribution rate-limit record=] |newRecord|:
+
+1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger| and
+    |sourceToAttribute| is <strong>blocked</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-attributions-per-source-destination-limit=]</code>", |trigger|, |sourceToAttribute| and
+        [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
+    |rateLimitRecord| is <strong>blocked</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>", |trigger|, |sourceToAttribute| and
+        [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. Return null.
 
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
@@ -1556,18 +1575,9 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
         with "<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If the result of running [=should attribution be blocked by rate limit=] with |trigger| and
-    |sourceToAttribute| is <strong>blocked</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-attributions-per-source-destination-limit=]</code>", |trigger|, |sourceToAttribute| and
-        [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
-    |rateLimitRecord| is <strong>blocked</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>", |trigger|, |sourceToAttribute| and
-        [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. If the result of running [=should attribution be blocked by rate limits=]
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
+    return it.
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|, |trigger|,
     and |matchedConfig|.
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
@@ -1660,18 +1670,9 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
          with "<code>[=trigger debug data type/trigger-aggregate-storage-limit=]</code>", |trigger|, |sourceToAttribute| and
          [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If the result of running [=should attribution be blocked by rate limit=] with |trigger| and
-    |sourceToAttribute| is <strong>blocked</strong>:
-     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-         with "<code>[=trigger debug data type/trigger-attributions-per-source-destination-limit=]</code>", |trigger|, |sourceToAttribute| and
-        [=obtain debug data on trigger registration/report=] set to null.
-     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
-    |rateLimitRecord| is <strong>blocked</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>", |trigger|, |sourceToAttribute| and
-        [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. If the result of running [=should attribution be blocked by rate limits=]
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
+    return it.
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]
     with |report| and |sourceToAttribute| is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]


### PR DESCRIPTION
Since the logic is the same for both event-level and aggregatable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/688.html" title="Last updated on Jan 24, 2023, 2:57 PM UTC (66cc92f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/688/cc8812c...apasel422:66cc92f.html" title="Last updated on Jan 24, 2023, 2:57 PM UTC (66cc92f)">Diff</a>