### PR TITLE
Fix typo in attribution_destination shared info field

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1938,7 +1938,7 @@ of running the following steps:
 
     : "`api`"
     :: "`attribution-reporting`"
-    : "`attribution destination`"
+    : "`attribution_destination`"
     :: |report|'s [=aggregatable report/effective attribution destination=], <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>
     : "`report_id`"
     :: |report|'s [=aggregatable report/report ID=]


### PR DESCRIPTION
[The Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/aggregatable_attribution_utils.cc;l=152;drc=0f570d2cac14c50891a3369be2b88f5678ec96c2) uses an underscore, not a space.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/697.html" title="Last updated on Feb 8, 2023, 6:03 PM UTC (2b700c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/697/95753e4...apasel422:2b700c0.html" title="Last updated on Feb 8, 2023, 6:03 PM UTC (2b700c0)">Diff</a>