### PR TITLE
Default report windows to expiry after expiry is rounded

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -891,9 +891,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. Let |expiry| be the result of running [=obtain a source expiry=] on |value|["`expiry`"].
 1. If |expiry| is null, set |expiry| to 30 days.
 1. Let |eventReportWindow| be the result of running [=obtain a source expiry=] on |value|["`event_report_window`"].
-1. If |eventReportWindow| is null or greater than |expiry|, set |eventReportWindow| to |expiry|.
 1. Let |aggregatableReportWindow| be the result of running [=obtain a source expiry=] on |value|["`aggregatable_report_window`"].
-1. If |aggregatableReportWindow| is null or greater than |expiry|, set |aggregatableReportWindow| to |expiry|.
 1. Let |priority| be 0.
 1. If |value|["`priority`"] [=map/exists=] and is a [=string=]:
     1. Set |priority| to the result of applying the
@@ -931,6 +929,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
         [=randomized event-source trigger rate=].
     1. Set |maxAttributionsPerSource| to the user agent's
         [=max attributions per event source=].
+1. If |eventReportWindow| is null or greater than |expiry|, set |eventReportWindow| to |expiry|.
+1. If |aggregatableReportWindow| is null or greater than |expiry|, set |aggregatableReportWindow| to |expiry|.
 1. Let |numReportWindows| be the result of running
     [=obtain the number of report windows=] with |sourceType|.
 1. Let |debugReportingEnabled| be false.


### PR DESCRIPTION
Currently the report windows are default to expiry before it is rounded, which may result in report windows greater than expiry.