### PR TITLE
Fix broken reference to current wall time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,7 @@ spec:html; type:element; text:script
 </pre>
 <pre class="anchors">
 spec: hr-time; type: dfn; urlPrefix: https://w3c.github.io/hr-time/
-    text: current wall time; url: #dfn-moment
+    text: current wall time; url: #dfn-current-wall-time
     text: duration; url: #dfn-duration
     text: moment; url: #dfn-moment
 spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/704.html" title="Last updated on Feb 15, 2023, 2:25 PM UTC (0fb46d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/704/9990e3d...apasel422:0fb46d0.html" title="Last updated on Feb 15, 2023, 2:25 PM UTC (0fb46d0)">Diff</a>