### PR TITLE
source-success verbose debug report

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -422,6 +422,7 @@ Possible values are:
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
+<li>"<dfn><code>source-success</code></dfn>"
 <li>"<dfn><code>source-unknown-error</code></dfn>"
 </ul>
 
@@ -1044,6 +1045,7 @@ and a [=suitable origin=] |reportingOrigin|:
     :: Return <strong>allowed</strong>.
     : "<code>[=source debug data type/source-noised=]</code>"
     : "<code>[=source debug data type/source-storage-limit=]</code>"
+    : "<code>[=source debug data type/source-success=]</code>"
     : "<code>[=source debug data type/source-unknown-error=]</code>"
     :: Return the result of running [=check if cookie-based debugging is allowed=] with |reportingOrigin|.
 
@@ -1113,10 +1115,13 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         : [=attribution rate-limit record/expiry time=]
         :: |source|'s [=attribution source/expiry time=]
     1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
-        |rateLimitRecord| is <strong>blocked</strong>, return.
+        |rateLimitRecord| is <strong>blocked</strong>:
+        1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-success=]</code>" and |source|.
+        1. Return.
     1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. [=list/Remove=] all [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if the result of running
     [=can attribution rate-limit record be removed=] with |entry| and |source|'s [=attribution source/source time=] is true.
+1. Let |debugDataType| be "<code>[=source debug data type/source-success=]</code>".
 1. If |source|'s [=attribution source/randomized response=] is not null and is a [=set=]:
     1. [=set/iterate|For each=] [=trigger state=] |triggerState| of |source|'s
         [=attribution source/randomized response=]:
@@ -1140,7 +1145,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/expiry time=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-noised=]</code>" and |source|.
+    1. Set |debugDataType| to "<code>[=source debug  data type/source-noised=]</code>".
+1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the

--- a/index.bs
+++ b/index.bs
@@ -1145,7 +1145,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/expiry time=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
-    1. Set |debugDataType| to "<code>[=source debug  data type/source-noised=]</code>".
+    1. Set |debugDataType| to "<code>[=source debug data type/source-noised=]</code>".
 1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
 1. [=set/Append=] |source| to |cache|.
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -21,7 +21,7 @@ A source is rejected due to the [storage limit](https://github.com/WICG/attribut
 
 #### `source-success`
 A source is successfully registered. Note that this is also sent when a source
-is rejected due to the [unattributed reporting origin limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits) to mitigate security concern.
+is rejected due to the [unattributed reporting origin limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits) to mitigate security concerns.
 
 #### `source-unknown-error`
 System error.

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -117,6 +117,7 @@ This table defines the fields in the `body` dictionary.
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -19,6 +19,10 @@ A source is rejected due to the [destination limit](https://github.com/WICG/attr
 #### `source-storage-limit`
 A source is rejected due to the [storage limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#storage-limits).
 
+#### `source-success`
+A source is successfully registered. Note that this is also sent when a source
+is rejected due to the [unattributed reporting origin limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits) to mitigate security concern.
+
 #### `source-unknown-error`
 System error.
 
@@ -108,7 +112,7 @@ otherwise the dictionary may include the following fields:
 
 This table defines the fields in the `body` dictionary.
 
-| `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | ` trigger_debug_key` |
+| `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | `trigger_debug_key` |
 | --- | --- | --- | --- | --- | --- | --- |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |


### PR DESCRIPTION
Source success verbose debug report will be sent when the source is registered successfully and when the unattributed reporting origin limit is hit to mitigate security concerns on reporting that error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/706.html" title="Last updated on Feb 22, 2023, 2:47 PM UTC (4e01204)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/706/4691370...linnan-github:4e01204.html" title="Last updated on Feb 22, 2023, 2:47 PM UTC (4e01204)">Diff</a>