### PR TITLE
Remove concept of source event ID cardinality

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -512,9 +512,6 @@ However attribution data is inherently cross-site, and operations on storage wou
 
 # Vendor-Specific Values # {#vendor-specific-values}
 
-<dfn>Source event ID cardinality</dfn> is a positive integer that controls the
-maximum value that can be used as an [=attribution source/event id=].
-
 <dfn>Max source expiry</dfn> is a positive [=duration=] that controls the
 maximum value that can be used as an [=attribution source/expiry=]. It must be
 greater than or equal to 30 days.
@@ -882,8 +879,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=string=]
 1. If |value|["`source_event_id`"] [=map/exists=] and is a [=string=]:
     1. Set |sourceEventId| to the result of applying the
         <a spec="html">rules for parsing non-negative integers</a> to
-        |value|["`source_event_id`"] modulo the user agent's
-        [=source event ID cardinality=].
+        |value|["`source_event_id`"].
     1. If |sourceEventId| is an error, set |sourceEventId| to 0.
 1. If |value|["`destination`"] does not [=map/exists|exist=], return null.
 1. Let |attributionDestinations| be the result of running


### PR DESCRIPTION
It is unused in the implementation and merely complicates things.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/711.html" title="Last updated on Feb 27, 2023, 10:32 PM UTC (dc16561)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/711/bca95e1...apasel422:dc16561.html" title="Last updated on Feb 27, 2023, 10:32 PM UTC (dc16561)">Diff</a>