### PR TITLE
Add aggregation coordinator identifier to aggregatable report

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -237,6 +237,9 @@ The report will be JSON encoded with the following scheme:
     },
   ],
 
+  // the deployment option for the aggregation service.
+  "aggregation_coordinator_identifier": "aws-cloud",
+
   // Optional debugging information (also present in event-level reports),
   // if the cookie `ar_debug` is present.
   "source_debug_key": "[64 bit unsigned integer]",

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -237,7 +237,7 @@ The report will be JSON encoded with the following scheme:
     },
   ],
 
-  // the deployment option for the aggregation service.
+  // The deployment option for the aggregation service.
   "aggregation_coordinator_identifier": "aws-cloud",
 
   // Optional debugging information (also present in event-level reports),

--- a/index.bs
+++ b/index.bs
@@ -326,7 +326,7 @@ An attribution trigger is a [=struct=] with the following items:
 : <dfn>debug reporting enabled</dfn>
 :: A [=boolean=].
 : <dfn>aggregation coordinator</dfn>
-:: Null or an [=aggregation coordinator=].
+:: An [=aggregation coordinator=].
 
 </dl>
 
@@ -635,6 +635,9 @@ delay to deliver an [=aggregatable report=].
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive [=duration=] that controls the
 random delay to deliver an [=aggregatable report=].
+
+<dfn>Default aggregation coordinator</dfn> is the [=aggregation coordinator=] that controls how to
+obtain the public key for encrypting an [=aggregatable report=] by default.
 
 # General Algorithms # {#general-algorithms}
 
@@ -1043,7 +1046,7 @@ a [=trigger state=] |triggerState|:
     : [=attribution trigger/debug reporting enabled=]
     :: false
     : [=attribution trigger/aggregation coordinator=]
-    :: null
+    :: [=default aggregation coordinator=]
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. Set |fakeReport|'s [=event-level report/report time=] to the result of
@@ -1368,7 +1371,7 @@ and a [=moment=] |triggerTime|:
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to value["`debug_reporting`"].
-1. Let |aggregationCoordinator| be null.
+1. Let |aggregationCoordinator| be [=default aggregation coordinator=].
 1. If |value|["`aggregation_coordinator_identifier`"] [=map/exists=]:
     1. If |value|["`aggregation_coordinator_identifier`"] is not a [=string=], return null.
     1. If |value|["`aggregation_coordinator_identifier`"] is not an [=aggregation coordinator=], return null.
@@ -2055,11 +2058,9 @@ of running the following steps:
 
 <h3 id="obtain-aggregatable-report-aggregation-service-payloads">Obtaining an aggregatable report's aggregation service payloads</h3>
 
-To <dfn>obtain the public key for encryption</dfn> given an optional [=aggregation coordinator=]
-|aggregationCoordinator|, asynchronously return a user-agent-determined public key
+To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordinator=]
+<var ignore=''>aggregationCoordinator</var>, asynchronously return a user-agent-determined public key
 or an error in the event that the user agent failed to obtain the public key.
-A user-agent-determined default [=aggregation coordinator=] should be used if
-|aggregationCoordinator| is null.
 
 Note: The user agent might enforce weekly key rotation. If there are multiple keys, the user agent
 might independently pick a key uniformly at random for every encryption operation.
@@ -2165,6 +2166,8 @@ To <dfn>serialize an [=aggregatable report=] </dfn> |report|, run the following 
     :: |report|'s [=aggregatable report/shared info=].
     : "`aggregation_service_payloads`"
     :: |aggregationServicePayloads|
+    : "`aggregation_coordinator_identifier`"
+    :: |report|'s [=aggregatable report/aggregation coordinator=]
 
 1. If |report|'s [=aggregatable report/source debug key=] is not null, [=map/set=]
     |data|["`source_debug_key`"] to |report|'s [=aggregatable report/source debug key=],

--- a/index.bs
+++ b/index.bs
@@ -292,12 +292,8 @@ An event-level trigger configuration is a [=struct=] with the following items:
 
 <h3 id="aggregation-coordinator-header">Aggregation coordinator</h3>
 
-An <dfn>aggregation coordinator</dfn> is one of the the following [=strings=] that specifies which
-aggregation service deployment to use:
-
-<ul dfn-for="aggregation coordinator">
-<li>"<dfn><code>aws-cloud</code></dfn>"
-</ul>
+An <dfn>aggregation coordinator</dfn> is one of a user-agent-determined [=set=]
+of [=strings=] that specifies which aggregation service deployment to use.
 
 <h3 dfn-type=dfn>Attribution trigger</h3>
 
@@ -639,6 +635,9 @@ delay to deliver an [=aggregatable report=].
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive [=duration=] that controls the
 random delay to deliver an [=aggregatable report=].
+
+<dfn>Default aggregation coordinator</dfn> is the [=aggregation coordinator=] that controls how to
+obtain the public key for encrypting an [=aggregatable report=] by default.
 
 # General Algorithms # {#general-algorithms}
 
@@ -1047,7 +1046,7 @@ a [=trigger state=] |triggerState|:
     : [=attribution trigger/debug reporting enabled=]
     :: false
     : [=attribution trigger/aggregation coordinator=]
-    :: "<code>[=aggregation coordinator/aws-cloud=]</code>"
+    :: [=default aggregation coordinator=]
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. Set |fakeReport|'s [=event-level report/report time=] to the result of
@@ -1372,7 +1371,7 @@ and a [=moment=] |triggerTime|:
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to value["`debug_reporting`"].
-1. Let |aggregationCoordinator| be "<code>[=aggregation coordinator/aws-cloud=]</code>".
+1. Let |aggregationCoordinator| be [=default aggregation coordinator=].
 1. If |value|["`aggregation_coordinator_identifier`"] [=map/exists=]:
     1. If |value|["`aggregation_coordinator_identifier`"] is not a [=string=], return null.
     1. If |value|["`aggregation_coordinator_identifier`"] is not an [=aggregation coordinator=], return null.

--- a/index.bs
+++ b/index.bs
@@ -292,8 +292,12 @@ An event-level trigger configuration is a [=struct=] with the following items:
 
 <h3 id="aggregation-coordinator-header">Aggregation coordinator</h3>
 
-An <dfn>aggregation coordinator</dfn> is one of a user-agent-determined [=set=]
-of [=strings=] that specifies which aggregation service deployment to use.
+An <dfn>aggregation coordinator</dfn> is one of the the following [=strings=] that specifies which
+aggregation service deployment to use:
+
+<ul dfn-for="aggregation coordinator">
+<li>"<dfn><code>aws-cloud</code></dfn>"
+</ul>
 
 <h3 dfn-type=dfn>Attribution trigger</h3>
 
@@ -635,9 +639,6 @@ delay to deliver an [=aggregatable report=].
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive [=duration=] that controls the
 random delay to deliver an [=aggregatable report=].
-
-<dfn>Default aggregation coordinator</dfn> is the [=aggregation coordinator=] that controls how to
-obtain the public key for encrypting an [=aggregatable report=] by default.
 
 # General Algorithms # {#general-algorithms}
 
@@ -1046,7 +1047,7 @@ a [=trigger state=] |triggerState|:
     : [=attribution trigger/debug reporting enabled=]
     :: false
     : [=attribution trigger/aggregation coordinator=]
-    :: [=default aggregation coordinator=]
+    :: "<code>[=aggregation coordinator/aws-cloud=]</code>"
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. Set |fakeReport|'s [=event-level report/report time=] to the result of
@@ -1371,7 +1372,7 @@ and a [=moment=] |triggerTime|:
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to value["`debug_reporting`"].
-1. Let |aggregationCoordinator| be [=default aggregation coordinator=].
+1. Let |aggregationCoordinator| be "<code>[=aggregation coordinator/aws-cloud=]</code>".
 1. If |value|["`aggregation_coordinator_identifier`"] [=map/exists=]:
     1. If |value|["`aggregation_coordinator_identifier`"] is not a [=string=], return null.
     1. If |value|["`aggregation_coordinator_identifier`"] is not an [=aggregation coordinator=], return null.
@@ -2163,7 +2164,7 @@ To <dfn>serialize an [=aggregatable report=] </dfn> |report|, run the following 
 1. Let |data| be a [=map=] of the following key/value pairs:
 
     : "`shared_info`"
-    :: |report|'s [=aggregatable report/shared info=].
+    :: |report|'s [=aggregatable report/shared info=]
     : "`aggregation_service_payloads`"
     :: |aggregationServicePayloads|
     : "`aggregation_coordinator_identifier`"


### PR DESCRIPTION
This may be used by ad-techs during cloud migration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/728.html" title="Last updated on Mar 23, 2023, 6:37 PM UTC (d470398)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/728/f371279...linnan-github:d470398.html" title="Last updated on Mar 23, 2023, 6:37 PM UTC (d470398)">Diff</a>