### PR TITLE
Describe multiple-background-request syntax for window.open attributionsrc

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -160,8 +160,17 @@ navigates. For `<img>` and `<script>`, background requests are made when the
 `attributionsrc` attribute is set on the DOM element.
 
 In JavaScript, `window.open` also supports an empty or non-empty
-`attributionsrc` feature, though it **does not yet support multiple values** due
-to complexity in parsing the feature string.
+`attributionsrc` feature. The feature may appear multiple times with a value to
+indicate that multiple background requests should be made:
+
+```javascript
+const url1 = encodeURIComponent('https://adtech1.example');
+const url2 = encodeURIComponent('https://adtech2.example');
+window.open(
+  'https://advertier.example/landing',
+  '_blank',
+  `attributionsrc=${url1} attributionsrc=${url2}`);
+```
 
 `event` sources can also be registered using existing JavaScript request
 APIs by setting the `Attribution-Reporting-Eligible` header manually:

--- a/EVENT.md
+++ b/EVENT.md
@@ -167,7 +167,7 @@ indicate that multiple background requests should be made:
 const url1 = encodeURIComponent('https://adtech1.example');
 const url2 = encodeURIComponent('https://adtech2.example');
 window.open(
-  'https://advertier.example/landing',
+  'https://advertiser.example/landing',
   '_blank',
   `attributionsrc=${url1} attributionsrc=${url2}`);
 ```


### PR DESCRIPTION
Since we have to monkeypatch window.open's feature-tokenization anyway in order to retain the original case of the URL, we allow the feature to appear multiple times and be accumulated into a list instead of using only the last instance.

#748 