### PR TITLE
Allow attributionsrc requests to be made to untrustworthy origins

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -693,11 +693,16 @@ To <dfn>serialize [=event-level report/attribution destinations=]</dfn> |destina
 1. If |destinationStrings|'s [=set/size=] is equal to 1, return |destinationStrings|[0].
 1. Return |destinationStrings|.
 
+To <dfn>check if a scheme is suitable</dfn> given a [=string=] |scheme|:
+
+1. If |scheme| is "`http`" or "`https`", return true.
+1. Return false.
 
 To <dfn>check if an origin is suitable</dfn> given an [=origin=] |origin|:
 
 1. If |origin| is not a [=potentially trustworthy origin=], return false.
-1. If |origin|'s [=origin/scheme=] is not "`http`" or "`https`", return false.
+1. If |origin|'s [=origin/scheme=] is not
+    [=check if a scheme is suitable|suitable=], return false.
 1. Return true.
 
 <h3 id="parsing-filter-data">Parsing filter data</h3>
@@ -838,7 +843,7 @@ To <dfn>make a background attributionsrc request</dfn> given a [=URL=] |url|, a
 [=suitable origin=] |contextOrigin|, an [=eligibility=] |eligibility|, and an
 [=environment settings objects=] |context|:
 
-1. If |url|'s [=url/origin=] is not [=check if an origin is suitable|suitable=],
+1. If |url|'s [=url/scheme=] is not [=check if a scheme is suitable|suitable=],
     return.
 1. Let |request| be a new [=request=] with the following properties:
     :   [=request/method=]


### PR DESCRIPTION
Without this, the handling of untrustworthy origins within a redirect chain is inconsistent: The initial request is never made if the first URL is untrustworthy, but intermediate untrustworthy origins are silently ignored.

Note that we still require an origin to be trustworthy in order for its registrations to be processed; this just affects whether any request is made to untrustworthy ones.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/755.html" title="Last updated on Apr 11, 2023, 4:20 PM UTC (775df4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/755/814f787...apasel422:775df4f.html" title="Last updated on Apr 11, 2023, 4:20 PM UTC (775df4f)">Diff</a>