### PR TITLE
Update explainer and spec to allow Attribution-Reporting-Support to indicate no web support

### DIFF
--- a/app_to_web.md
+++ b/app_to_web.md
@@ -44,10 +44,16 @@ sequenceDiagram
 ```
 See Android's [Attribution reporting: cross app and web measurement proposal](https://developer.android.com/design-for-safety/privacy-sandbox/attribution-app-to-web) for one example of an OS API that a browser can integrate with to do cross app and web measurement.
 
-The existing API involves sending requests to the reporting origin to register events. These requests will have a new request header `Attribution-Reporting-Eligible`. On requests with this header, the browser will additionally broadcast possible OS-level support for attribution to the reporting origin’s server via a new [dictionary structured request header](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-3.2):
+The existing API involves sending requests to the reporting origin to register events. These requests will have a new request header `Attribution-Reporting-Eligible`. On requests with this header, the browser will additionally broadcast possible web or OS-level support for attribution to the reporting origin's server via a new [dictionary structured request header](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-3.2):
 ```
 Attribution-Reporting-Support: os, web
 ```
+
+Note that if there is neither web nor OS-level support for attribution, no
+background requests will be made and the browser will not set
+`Attribution-Reporting-Eligible` header on `<a>`, `window.open`, `<img>`, or
+`<script>` requests.
+
 For subresource requests without the `Attribution-Reporting-Eligible` header,
 the server can optionally respond to the request with a [boolean structured header](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-15#section-3.3.6):
 ```http

--- a/index.bs
+++ b/index.bs
@@ -2785,8 +2785,15 @@ To <dfn noexport>get an OS-registration URL from a header list</dfn> given a
 To <dfn noexport>set an OS-support header</dfn> given a [=header list=]
 |headers|:
 
-1. Let |value| be "`web`".
-1. If the user agent supports OS registrations, set |value| to "`web, os`".
+1. Let |value| be "``".
+1. If the user agent supports:
+    <dl class="switch">
+    : web registrations only
+    :: Set |value| to "`web`".
+    : OS registrations only
+    :: Set |value| to "`os`".
+    : both web and OS registrations:
+    :: Set |value| to "`os, web`".
 1. [=header list/Set=] ("`Attribution-Reporting-Support`", |value|) in |headers|.
 
 Issue: Consider replacing these string values with structured-field algorithms.

--- a/index.bs
+++ b/index.bs
@@ -2785,7 +2785,7 @@ To <dfn noexport>get an OS-registration URL from a header list</dfn> given a
 To <dfn noexport>set an OS-support header</dfn> given a [=header list=]
 |headers|:
 
-1. Let |value| be "``".
+1. Let |value| be "".
 1. If the user agent supports:
     <dl class="switch">
     : web registrations only

--- a/index.bs
+++ b/index.bs
@@ -2794,6 +2794,8 @@ To <dfn noexport>set an OS-support header</dfn> given a [=header list=]
     :: Set |value| to "`os`".
     : both web and OS registrations:
     :: Set |value| to "`os, web`".
+
+    </dl>
 1. [=header list/Set=] ("`Attribution-Reporting-Support`", |value|) in |headers|.
 
 Issue: Consider replacing these string values with structured-field algorithms.


### PR DESCRIPTION
Web attribution may not be supported on some platforms, e.g. WebView, which may be useful to be indicated in the Attribution-Reporting-Support header.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/758.html" title="Last updated on Apr 24, 2023, 3:34 PM UTC (22572a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/758/11466a5...linnan-github:22572a3.html" title="Last updated on Apr 24, 2023, 3:34 PM UTC (22572a3)">Diff</a>