### PR TITLE
Restrict attributionSrc HTML attribute to secure contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -69,7 +69,7 @@ in time.
 
 <pre class="idl">
 interface mixin HTMLAttributionSrcElementUtils {
-    [CEReactions] attribute USVString attributionSrc;
+    [CEReactions, SecureContext] attribute USVString attributionSrc;
 };
 
 HTMLAnchorElement includes HTMLAttributionSrcElementUtils;


### PR DESCRIPTION
The attribute already has no effect in insecure contexts, but with this IDL change it won't even exist in the DOM in insecure contexts, which makes feature-detection more precise via `'attributionSrc' in HTMLImageElement.prototype`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/759.html" title="Last updated on Apr 14, 2023, 2:34 PM UTC (513567c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/759/8993abb...apasel422:513567c.html" title="Last updated on Apr 14, 2023, 2:34 PM UTC (513567c)">Diff</a>