### PR TITLE
Fix attributionsrc links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -114,16 +114,15 @@ run the following steps:
     [=split a string on ASCII whitespace|splitting=] |attributionSrc| on ASCII
     whitespace.
 1. [=list/iterate|For each=] |token| of |tokens|:
-    1. Parse |token|, relative to |element|'s node document. If that is not
-        successful, [=iteration/continue=]. Otherwise, let |url| be the
-        resulting [=URL record=].
+    1. <a spec="HTML" lt="parse a URL">Parse</a> |token|, relative to
+        |element|'s [=Node/node document=]. If that is not successful,
+        [=iteration/continue=]. Otherwise, let |url| be the resulting
+        [=URL record=].
     1. Run [=make a background attributionsrc request=] with |url|,
         |contextOrigin|, "<code>[=eligibility/event-source, trigger=]</code>",
-        and |element|'s node document's [=relevant settings object=].
+        and |element|'s [=Node/node document=]'s [=relevant settings object=].
 
 Issue: Set |contextOrigin| properly.
-
-Issue: Add links to "Parse" and "node document".
 
 Issue: Consider allowing the user agent to limit the size of |tokens|.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/760.html" title="Last updated on Apr 14, 2023, 3:40 PM UTC (c270188)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/760/b64f45a...apasel422:c270188.html" title="Last updated on Apr 14, 2023, 3:40 PM UTC (c270188)">Diff</a>