### PR TITLE
Specify parsing for window.open attributionsrc feature

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -135,9 +135,6 @@ Issue: Specify when to make background attributionsrc requests for <{a}>.
 
 Modify the [=tokenize the features argument=] as follows:
 
-Add an optional [=boolean=] parameter |preserveCaseAndReturnEachValue|,
-defaulting to false.
-
 Replace the step
 
 > [=Collect a sequence of code points=] that are not [=feature separators=] code
@@ -147,9 +144,9 @@ Replace the step
 with
 
 [=Collect a sequence of code points=] that are not [=feature separators=] code
-points from |features| given |position|. If |preserveCaseAndReturnEachValue| is
-true, set |value| to the collected code points. Otherwise, set |value| to the
-collected code points, [=ASCII lowercase|converted to ASCII lowercase=].
+points from |features| given |position|. Set |value| to the collected code
+points, [=ASCII lowercase|converted to ASCII lowercase=]. Set
+|originalCaseValue| to the collected code points.
 
 Replace the step
 
@@ -159,7 +156,7 @@ Replace the step
 with the steps
 
 1. If |name| is not the empty string:
-    1. If |preserveCaseAndReturnEachValue| is:
+    1. If |name| is "`attributionsrc`":
         <dl class="switch">
         : false
         :: Set |tokenizedFeatures|[|name|] to |value|.
@@ -167,7 +164,7 @@ with the steps
         :: Run the following steps:
             1. If |tokenizedFeatures|[|name|] does not [=map/exists|exist=],
                 [=map/set=] |tokenizedFeatures|[|name|] to a new [=list=].
-            1. [=list/Append=] |value| to |tokenizedFeatures|[|name|].
+            1. [=list/Append=] |originalCaseValue| to |tokenizedFeatures|[|name|].
 
         </dl>
 
@@ -182,12 +179,10 @@ add the steps
 
 1. Let |attributionSrcUrls| be null.
 1. If |tokenizedFeatures|["`attributionsrc`"] [=map/exists=]:
-    1. Let |originalCaseMultiFeatures| be the result of
-        [=tokenize the features argument|tokenizing=] |features| with
-        |preserveCaseAndReturnEachValue| set to true.
+    1. [=Assert=]: |tokenizedFeatures|["`attributionsrc`"] is a [=list=].
     1. Set |attributionSrcUrls| to a new [=list=].
     1. [=list/iterate|For each=] |value| of
-        |originalCaseMultiFeatures|["`attributionsrc`"]:
+        |tokenizedFeatures|["`attributionsrc`"]:
         1. If |value| is the empty string, [=iteration/continue=].
         1. Let |decodedSrcBytes| be the result of
             [=string/percent-decode|percent-decoding=] |value|.
@@ -199,8 +194,9 @@ add the steps
             parsing failed, [=iteration/continue=].
         1. [=list/Append=] |urlRecord| to |attributionSrcUrls|.
 
-Issue: Modify the navigation request to permit navigation-source registration
-even if |attributionSrcUrls| [=list/is empty=].
+Issue: Modify the navigation request to permit
+"<code>[=eligibility/navigation-source=]</code>" registration even if
+|attributionSrcUrls| [=list/is empty=].
 
 Issue: Use |attributionSrcUrls| with [=make a background attributionsrc request=].
 

--- a/index.bs
+++ b/index.bs
@@ -18,6 +18,9 @@ Assume Explicit For: on
 <pre class=link-defaults>
 spec:html; type:element; text:a
 spec:html; type:element; text:script
+spec:html; type:dfn; text:feature separators
+spec:html; type:dfn; text:tokenize the features argument
+spec:html; type:dfn; text:window open steps
 </pre>
 <pre class="anchors">
 spec: clear-site-data; type: dfn; urlPrefix: https://w3c.github.io/webappsec-clear-site-data/
@@ -130,7 +133,76 @@ Issue: Specify when to make background attributionsrc requests for <{a}>.
 
 <h3 id="monkeypatch-window-open">Window open steps</h4>
 
-Issue: Monkeypatch `window.open()`.
+Modify the [=tokenize the features argument=] as follows:
+
+Add an optional [=boolean=] parameter |preserveCaseAndReturnEachValue|,
+defaulting to false.
+
+Replace the step
+
+> [=Collect a sequence of code points=] that are not [=feature separators=] code
+> points from |features| given |position|. Set |value| to the collected code
+> points, [=ASCII lowercase|converted to ASCII lowercase=].
+
+with
+
+[=Collect a sequence of code points=] that are not [=feature separators=] code
+points from |features| given |position|. If |preserveCaseAndReturnEachValue| is
+true, set |value| to the collected code points. Otherwise, set |value| to the
+collected code points, [=ASCII lowercase|converted to ASCII lowercase=].
+
+Replace the step
+
+> If |name| is not the empty string, then set |tokenizedFeatures|[|name|] to
+> |value|.
+
+with the steps
+
+1. If |name| is not the empty string:
+    1. If |preserveCaseAndReturnEachValue| is:
+        <dl class="switch">
+        : false
+        :: Set |tokenizedFeatures|[|name|] to |value|.
+        : true
+        :: Run the following steps:
+            1. If |tokenizedFeatures|[|name|] does not [=map/exists|exist=],
+                [=map/set=] |tokenizedFeatures|[|name|] to a new [=list=].
+            1. [=list/Append=] |value| to |tokenizedFeatures|[|name|].
+
+        </dl>
+
+Modify the [=window open steps=] as follows:
+
+After the step
+
+> Let |tokenizedFeatures| be the result of
+> [=tokenize the features argument|tokenizing=] |features|.
+
+add the steps
+
+1. Let |attributionSrcUrls| be null.
+1. If |tokenizedFeatures|["`attributionsrc`"] [=map/exists=]:
+    1. Let |originalCaseMultiFeatures| be the result of
+        [=tokenize the features argument|tokenizing=] |features| with
+        |preserveCaseAndReturnEachValue| set to true.
+    1. Set |attributionSrcUrls| to a new [=list=].
+    1. [=list/iterate|For each=] |value| of
+        |originalCaseMultiFeatures|["`attributionsrc`"]:
+        1. If |value| is the empty string, [=iteration/continue=].
+        1. Let |decodedSrcBytes| be the result of
+            [=string/percent-decode|percent-decoding=] |value|.
+        1. Let |decodedSrc| be the [=UTF-8 decode without BOM=] of
+            |decodedSrcBytes|.
+        1. <a spec="HTML" lt="parse a URL">Parse</a> |decodedSrc| relative to
+            the <a spec="HTML" lt="entry settings object">entry settings object</a>,
+            and set |urlRecord| to the resulting [=URL record=], if any. If
+            parsing failed, [=iteration/continue=].
+        1. [=list/Append=] |urlRecord| to |attributionSrcUrls|.
+
+Issue: Modify the navigation request to permit navigation-source registration
+even if |attributionSrcUrls| [=list/is empty=].
+
+Issue: Use |attributionSrcUrls| with [=make a background attributionsrc request=].
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
@@ -865,6 +937,8 @@ Issue: Audit other properties on |request| and set them properly.
 
 Issue: Support header-processing on redirects.
 
+Issue: Check for transient activation with "<code>[=eligibility/navigation-source=]</code>".
+
 To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
 |contextOrigin|, an [=eligibility=] |eligibility|, an
 [=environment settings objects=] |context|, and a [=response=] |response|:
@@ -957,19 +1031,6 @@ To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element
 1. Return null.
 
 Issue: Specify the steps for making attributionsrc request.
-
-<h3 algorithm id="obtaining-attribution-source-window-features">Obtaining an attribution source from window features</h3>
-
-To <dfn>obtain an attribution source from window features</dfn> given an [=ordered map=] |tokenizedFeatures|:
-
-1. If |tokenizedFeatures|["attributionsrc"] does not [=map/exists|exist=], return null.
-1. Let |decodedSrcBytes| be the result of [=string/percent-decode|percent-decoding=] |tokenizedFeatures|["attributionsrc"].
-1. Let |decodedSrc| be the [=UTF-8 decode without BOM=] of |decodedSrcBytes|.
-1. Return null.
-
-Issue: Check for transient activation.
-
-Issue: Specify the steps for making an attributionsrc request with |decodedSrc|.
 
 <h3 algorithm id="parsing-source-registration">Parsing source-registration JSON</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -156,15 +156,15 @@ Replace the step
 with the steps
 
 1. If |name| is not the empty string:
-    1. If |name| is "`attributionsrc`":
+    1. Switch on |name|:
         <dl class="switch">
-        : false
-        :: Set |tokenizedFeatures|[|name|] to |value|.
-        : true
+        : "`attributionsrc`"
         :: Run the following steps:
             1. If |tokenizedFeatures|[|name|] does not [=map/exists|exist=],
                 [=map/set=] |tokenizedFeatures|[|name|] to a new [=list=].
             1. [=list/Append=] |originalCaseValue| to |tokenizedFeatures|[|name|].
+        : Anything else
+        :: Set |tokenizedFeatures|[|name|] to |value|.
 
         </dl>
 


### PR DESCRIPTION
Fixes #748


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/761.html" title="Last updated on Apr 14, 2023, 7:34 PM UTC (f277697)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/761/e7d6d7d...apasel422:f277697.html" title="Last updated on Apr 14, 2023, 7:34 PM UTC (f277697)">Diff</a>