### PR TITLE
Add issue for setting Attribution-Reporting-Eligible header on img/script

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -131,6 +131,11 @@ Issue: Consider allowing the user agent to limit the size of |tokens|.
 
 Issue: Specify when to make background attributionsrc requests for <{a}>.
 
+Issue: Monkeypatch <{img}> and <{script}> loading so that the presence of an
+{{HTMLAttributionSrcElementUtils/attributionSrc}} attribute causes the
+{{HTMLImageElement/src}} or {{HTMLScriptElement/src}} request to contain an
+"`Attribution-Reporting-Eligible`" header.
+
 <h3 id="monkeypatch-window-open">Window open steps</h4>
 
 Modify the [=tokenize the features argument=] as follows:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/763.html" title="Last updated on Apr 17, 2023, 1:25 PM UTC (b01b88c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/763/b7263ac...apasel422:b01b88c.html" title="Last updated on Apr 17, 2023, 1:25 PM UTC (b01b88c)">Diff</a>