### PR TITLE
Specify limiting number of aggregatable reports per source

### DIFF
--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -3,7 +3,7 @@ const int64Regex = /^-?[0-9]+$/
 const hex128Regex = /^0[xX][0-9A-Fa-f]{1,32}$/
 
 const limits = {
-  maxAggregationKeys: 50,
+  maxAggregationKeys: 20,
   maxEntriesPerFilterData: 50,
   maxValuesPerFilterDataEntry: 50,
 }

--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -3,7 +3,7 @@ const int64Regex = /^-?[0-9]+$/
 const hex128Regex = /^0[xX][0-9A-Fa-f]{1,32}$/
 
 const limits = {
-  maxAggregationKeys: 20,
+  maxAggregationKeys: 50,
   maxEntriesPerFilterData: 50,
   maxValuesPerFilterDataEntry: 50,
 }

--- a/index.bs
+++ b/index.bs
@@ -501,6 +501,8 @@ An attribution source is a [=struct=] with the following items:
 :: [=ordered set=] of [=aggregatable dedup key/dedup key|aggregatable dedup key values=] associated with this [=attribution source=].
 : <dfn>debug reporting enabled</dfn>
 :: A [=boolean=].
+: <dfn>number of aggregatable reports</dfn>
+:: Number of [=aggregatable reports=] created for this [=attribution source=].
 
 </dl>
 
@@ -744,6 +746,7 @@ Possible values are:
 
 <ul dfn-for="trigger debug data type">
 <li>"<dfn><code>trigger-aggregate-deduplicated</code></dfn>"
+<li>"<dfn><code>trigger-aggregate-excessive-reports</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-no-contributions</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-insufficient-budget</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-storage-limit</code></dfn>"
@@ -891,6 +894,9 @@ controls how many times a single [=attribution source=] whose
 controls how many times a single [=attribution source=] whose
 [=attribution source/source type=] is "<code>[=source type/event=]</code>" can create an
 [=event-level report=].
+
+<dfn>Max aggregatable reports per source</dfn> is a positive integer that controls how many times a
+single [=attribution source=] can create an [=aggregatable report=].
 
 <dfn>Max destinations covered by unexpired sources</dfn> is a positive
 integer that controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
@@ -2018,6 +2024,8 @@ an optional [=attribution source=] <dfn for="obtain debug data body on trigger r
     : "<code>[=trigger debug data type/trigger-aggregate-insufficient-budget=]</code>"
     :: [=map/Set=] |body|["`limit`"] to [=allowed aggregatable budget per source=],
          [=serialize an integer|serialized=].
+    : "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to [=max aggregatable reports per source=],
     : "<code>[=trigger debug data type/trigger-event-low-priority=]</code>"
     : "<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>"
     ::
@@ -2202,6 +2210,10 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. If the result of running [=should attribution be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
     return it.
+1. If |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value is equal to [=max aggregatable reports per source=], then:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=] with
+        "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", |trigger|, |sourceToAttribute| and |report|.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]
     with |report| and |sourceToAttribute| is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -2209,6 +2221,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. Add |report| to the [=aggregatable report cache=].
+1. Increment |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value by 1.
 1. Increment |sourceToAttribute|'s [=attribution source/aggregatable budget consumed=] value by
     |report|'s [=aggregatable report/required aggregatable budget=].
 1. If |matchedDedupKey| is not null, [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].

--- a/index.bs
+++ b/index.bs
@@ -895,8 +895,8 @@ controls how many times a single [=attribution source=] whose
 [=attribution source/source type=] is "<code>[=source type/event=]</code>" can create an
 [=event-level report=].
 
-<dfn>Max aggregatable reports per source</dfn> is a positive integer that controls how many times a
-single [=attribution source=] can create an [=aggregatable report=].
+<dfn>Max aggregatable reports per source</dfn> is a positive integer that controls how many [=aggregatable reports=]
+can be created by [=attribution triggers=] attributed to a single [=attribution source=].
 
 <dfn>Max destinations covered by unexpired sources</dfn> is a positive
 integer that controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]

--- a/index.bs
+++ b/index.bs
@@ -2212,7 +2212,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     return it.
 1. If |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value is equal to [=max aggregatable reports per source=], then:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=] with
-        "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", |trigger|, |sourceToAttribute| and |report|.
+        "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", |trigger|, |sourceToAttribute|, and |report|.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]
     with |report| and |sourceToAttribute| is false:

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -132,6 +132,7 @@ This table defines the fields in the `body` dictionary.
 | [`trigger-event-storage-limit`](#trigger-event-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-report-window-passed`](#trigger-event-report-window-passed) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-aggregate-deduplicated`](#trigger-aggregate-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
+| [`trigger-aggregate-excessive-reports`](#trigger-aggregate-excessive-reports) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-aggregate-no-contributions`](#trigger-aggregate-no-contributions) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-aggregate-insufficient-budget`](#trigger-aggregate-insufficient-budget) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-aggregate-storage-limit`](#trigger-aggregate-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -70,6 +70,9 @@ An aggregatable report is not created due to [deduplication](https://github.com/
 #### `trigger-aggregate-no-contributions`
 An aggregatable report is not created as no [histogram contributions](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#attribution-trigger-registration) are created.
 
+#### `trigger-aggregate-excessive reports`
+An aggregatable report is dropped as the [maximum number of reports](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#hide-the-true-number-of-attribution-reports) have been scheduled for the source.
+
 #### `trigger-aggregate-insufficient-budget`
 An aggregatable report is dropped due to [insufficient budget](https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#contribution-bounding-and-budgeting).
 


### PR DESCRIPTION
Spec for https://github.com/WICG/attribution-reporting-api/pull/774


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/778.html" title="Last updated on May 3, 2023, 7:51 PM UTC (6b5c895)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/778/c83fa51...linnan-github:6b5c895.html" title="Last updated on May 3, 2023, 7:51 PM UTC (6b5c895)">Diff</a>