### PR TITLE
Add links to Structured Headers RFC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -254,8 +254,9 @@ given an optional {{AttributionReportingRequestOptions}} |options|:
 
 Issue: Check permissions policy.
 
-"<code><dfn>Attribution-Reporting-Eligible</dfn></code>" is a Dictionary
-Structured Header set on a [=request=] that indicates which registrations, if
+"<code><dfn>Attribution-Reporting-Eligible</dfn></code>" is a
+<a href="https://httpwg.org/specs/rfc8941.html#dictionary">Dictionary Structured
+Header</a> set on a [=request=] that indicates which registrations, if
 any, are allowed on the corresponding [=response=]. Its values are not specified
 and its <dfn lt="eligible key">allowed keys</dfn> are:
 
@@ -268,8 +269,6 @@ and its <dfn lt="eligible key">allowed keys</dfn> are:
 :: A [=attribution trigger|trigger=] may be registered.
 
 </dl>
-
-Issue: Add links to Structured Header RFC.
 
 To <dfn>set Attribution Reporting headers</dfn> given a
 [=header list=] |headers| and an [=eligibility=] |eligibility|:
@@ -2937,12 +2936,11 @@ To <dfn>get supported registrars</dfn>:
     to |supportedRegistrars|.
 1. Return |supportedRegistrars|.
 
-"<code><dfn>Attribution-Reporting-Support</dfn></code>" is a Dictionary
-Structured Header set on a [=request=] that indicates which registrars, if
+"<code><dfn>Attribution-Reporting-Support</dfn></code>" is a
+<a href="https://httpwg.org/specs/rfc8941.html#dictionary">Dictionary Structured
+Header</a> set on a [=request=] that indicates which registrars, if
 any, the corresponding [=response=] can use. Its values are not specified and
 its allowed keys are the [=registrars=].
-
-Issue: Add links to Structured Header RFC.
 
 To <dfn noexport>set an OS-support header</dfn> given a [=header list=]
 |headers|:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/781.html" title="Last updated on May 5, 2023, 12:26 PM UTC (3461290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/781/0ce6de7...apasel422:3461290.html" title="Last updated on May 5, 2023, 12:26 PM UTC (3461290)">Diff</a>