### PR TITLE
Specify defer trigger attribution logic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1267,8 +1267,7 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
                 |destinationSite|, |reportingOrigin|, |privateStateTokens|, and
                 |context|'s [=current wall time=].
             1. If |trigger| is not null:
-                1. [=Maybe defer trigger attribution=] with |trigger|.
-                1. [=Trigger attribution=] with |trigger|.
+                1. [=Maybe defer and then complete trigger attribution=] with |trigger|.
         1. If |osSourceURLs| is not null and the user agent supports OS
             registrations, process |osSourceURLs| according to an
             [=implementation-defined=] algorithm.
@@ -2618,13 +2617,15 @@ and an optional [=aggregatable report=] <dfn for="generate null reports and assi
 
 <h3 id="deferring-trigger-attribution">Deferring trigger attribution</h3>
 
-To <dfn>maybe defer trigger attribution</dfn> given an [=attribution trigger=] |trigger|:
+To <dfn>maybe defer and then complete trigger attribution</dfn> given an [=attribution trigger=] |trigger|
+, run the following steps [=in parallel=]:
 
-1. Let |navigation| be the navigation that landed on the document from which |trigger|'s registration was initiated.
-1. If |navigation| is empty, return.
-1. Let |sources| be source registrations originating from background attributionsrc requests initiated by |navigation|.
+1. Let |navigation| be the navigation that landed on the [=document=] from which |trigger|'s registration was initiated.
+1. If |navigation| is null, return.
+1. Let |sources| be all source registrations originating from background attributionsrc requests initiated by |navigation|.
 1. If |sources| is empty, return.
 1. Wait until all |sources| are [=process an attribution source|processed=].
+1. [=Trigger attribution=] with |trigger|.
 
 Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents">Navigation</a>
 

--- a/index.bs
+++ b/index.bs
@@ -1267,8 +1267,8 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
                 |destinationSite|, |reportingOrigin|, |privateStateTokens|, and
                 |context|'s [=current wall time=].
             1. If |trigger| is not null:
-                1. [=maybe defer trigger attribution=] with |trigger|.
-                1. [=trigger attribution=] with |trigger|.
+                1. [=Maybe defer trigger attribution=] with |trigger|.
+                1. [=Trigger attribution=] with |trigger|.
         1. If |osSourceURLs| is not null and the user agent supports OS
             registrations, process |osSourceURLs| according to an
             [=implementation-defined=] algorithm.
@@ -2621,12 +2621,12 @@ and an optional [=aggregatable report=] <dfn for="generate null reports and assi
 To <dfn>maybe defer trigger attribution</dfn> given an [=attribution trigger=] |trigger|:
 
 1. Let |navigation| be the navigation that landed on the document from which |trigger|'s registration was initiated.
-1. If |navigation| is empty, Return.
-1. Let |sources| be all source registrations initiated alongside |navigation|.
-1. If |sources| is empty, Return.
+1. If |navigation| is empty, return.
+1. Let |sources| be source registrations originating from a background attributionsrc initiated by |navigation|.
+1. If |sources| is empty, return.
 1. Wait until all |sources| are [=process an attribution source|processed=].
 
-Issue:  Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents">Navigation</a>
+Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents">Navigation</a>
 
 # Report delivery # {#report-delivery}
 

--- a/index.bs
+++ b/index.bs
@@ -2616,7 +2616,7 @@ and an optional [=aggregatable report=] <dfn for="generate null reports and assi
     1. [=list/Append=] |report| to |reports|.
 1. Run [=assign private state tokens=] with |reports| and |trigger|.
 
-<h3 id="maybe-defer-trigger-attribution">Maybe defer trigger attribution</h3>
+<h3 id="deferring-trigger-attribution">Deferring trigger attribution</h3>
 
 To <dfn>maybe defer trigger attribution</dfn> given an [=attribution trigger=] |trigger|:
 

--- a/index.bs
+++ b/index.bs
@@ -2622,7 +2622,7 @@ To <dfn>maybe defer trigger attribution</dfn> given an [=attribution trigger=] |
 
 1. Let |navigation| be the navigation that landed on the document from which |trigger|'s registration was initiated.
 1. If |navigation| is empty, return.
-1. Let |sources| be source registrations originating from a background attributionsrc initiated by |navigation|.
+1. Let |sources| be source registrations originating from background attributionsrc requests initiated by |navigation|.
 1. If |sources| is empty, return.
 1. Wait until all |sources| are [=process an attribution source|processed=].
 

--- a/index.bs
+++ b/index.bs
@@ -2617,8 +2617,8 @@ and an optional [=aggregatable report=] <dfn for="generate null reports and assi
 
 <h3 id="deferring-trigger-attribution">Deferring trigger attribution</h3>
 
-To <dfn>maybe defer and then complete trigger attribution</dfn> given an [=attribution trigger=] |trigger|
-, run the following steps [=in parallel=]:
+To <dfn>maybe defer and then complete trigger attribution</dfn> given an [=attribution trigger=] |trigger|,
+run the following steps [=in parallel=]:
 
 1. Let |navigation| be the navigation that landed on the [=document=] from which |trigger|'s registration was initiated.
 1. If |navigation| is null, return.

--- a/index.bs
+++ b/index.bs
@@ -1266,7 +1266,9 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
                 [=create an attribution trigger=] with |triggerHeader|
                 |destinationSite|, |reportingOrigin|, |privateStateTokens|, and
                 |context|'s [=current wall time=].
-            1. If |trigger| is not null, [=trigger attribution=] with |trigger|.
+            1. If |trigger| is not null:
+                1. [=maybe defer trigger attribution=] with |trigger|.
+                1. [=trigger attribution=] with |trigger|.
         1. If |osSourceURLs| is not null and the user agent supports OS
             registrations, process |osSourceURLs| according to an
             [=implementation-defined=] algorithm.
@@ -2613,6 +2615,18 @@ and an optional [=aggregatable report=] <dfn for="generate null reports and assi
 1. If |report| is not null:
     1. [=list/Append=] |report| to |reports|.
 1. Run [=assign private state tokens=] with |reports| and |trigger|.
+
+<h3 id="maybe-defer-trigger-attribution">Maybe defer trigger attribution</h3>
+
+To <dfn>maybe defer trigger attribution</dfn> given an [=attribution trigger=] |trigger|:
+
+1. Let |navigation| be the navigation that landed on the document from which |trigger|'s registration was initiated.
+1. If |navigation| is empty, Return.
+1. Let |sources| be all source registrations initiated alongside |navigation|.
+1. If |sources| is empty, Return.
+1. Wait until all |sources| are [=process an attribution source|processed=].
+
+Issue:  Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents">Navigation</a>
 
 # Report delivery # {#report-delivery}
 


### PR DESCRIPTION
Goal is to mitigate a race condition where a user clicks on an ad which initiates a source registration and navigates to a page that initiates a trigger registration that matches the source. 

If the trigger registration completes before the source, the attribution would be dropped.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agarant/attribution-reporting-api/pull/784.html" title="Last updated on May 30, 2023, 2:19 PM UTC (a7967b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/784/9debabb...agarant:a7967b5.html" title="Last updated on May 30, 2023, 2:19 PM UTC (a7967b5)">Diff</a>