### PR TITLE
Set source_registration_time to 0 if it's excluded

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2685,10 +2685,16 @@ of running the following steps:
 
 1. If |report|'s [=aggregatable report/debug mode=] is <strong>enabled</strong>,
     set |sharedInfo|["`debug_mode`"] to "`enabled`".
-1. If |report|'s [=aggregatable report/source registration time configuration=] is
-    "<code>[=aggregatable source registration time configuration/include=]</code>",
-    set |sharedInfo|["`source_registration_time`"] to the result of [=obtaining rounded source time=]
-    with |report|'s [=aggregatable report/source time=], [=serialize an integer|serialized=].
+1. If |report|'s [=aggregatable report/source registration time configuration=] is:
+    <dl class="switch">
+    : "<code>[=aggregatable source registration time configuration/include=]</code>"</dt>
+    :: Set |sharedInfo|["`source_registration_time`"] to the result of [=obtaining rounded source time=]
+        with |report|'s [=aggregatable report/source time=], [=serialize an integer|serialized=].
+    : "<code>[=aggregatable source registration time configuration/exclude=]</code>"
+    :: Set |sharedInfo|["`source_registration_time`"] to the result of [=serialize an integer|serializing=] 0.
+
+    </dl>
+
 1. Return the [=string=] resulting from executing [=serialize an infra value to a json string=] on |sharedInfo|.
 
 <h3 id="obtain-aggregatable-report-aggregation-service-payloads">Obtaining an aggregatable report's aggregation service payloads</h3>
@@ -2821,7 +2827,7 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
 
     <dt>[=aggregatable report=]</dt>
     <dd>Return the result of running [=serialize an aggregatable report=] with |report|.</dd>
-    <dl>
+    </dl>
 
 Note: The inclusion of "`report_id`" in the report body is intended to allow the report recipient
 to perform deduplication and prevent double counting, in the event that the user agent retries

--- a/index.bs
+++ b/index.bs
@@ -2691,7 +2691,7 @@ of running the following steps:
     :: Set |sharedInfo|["`source_registration_time`"] to the result of [=obtaining rounded source time=]
         with |report|'s [=aggregatable report/source time=], [=serialize an integer|serialized=].
     : "<code>[=aggregatable source registration time configuration/exclude=]</code>"
-    :: Set |sharedInfo|["`source_registration_time`"] to the result of [=serialize an integer|serializing=] 0.
+    :: Set |sharedInfo|["`source_registration_time`"] to "`0`".
 
     </dl>
 


### PR DESCRIPTION
Instead of omitting the field, a default value 0 will be set for this field.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/790.html" title="Last updated on May 12, 2023, 12:00 PM UTC (495f499)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/790/2aa8f51...linnan-github:495f499.html" title="Last updated on May 12, 2023, 12:00 PM UTC (495f499)">Diff</a>