### PR TITLE
Set report requests to be 'same-origin'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2978,6 +2978,8 @@ and a [=header list=] |newHeaders| (defaults to an empty [=list=]):
     :: "`no-referrer`"
     :   [=request/client=]
     ::  `null`
+    :   [=request/origin=]
+    ::  |url|'s [=url/origin=]
     :   [=request/window=]
     ::  "`no-window`"
     :   [=request/service-workers mode=]
@@ -2985,7 +2987,7 @@ and a [=header list=] |newHeaders| (defaults to an empty [=list=]):
     :   [=request/initiator=]
     ::  ""
     :   [=request/mode=]
-    ::  "`cors`"
+    ::  "`same-origin`"
     :   [=request/unsafe-request flag=]
     ::  set
     :   [=request/credentials mode=]


### PR DESCRIPTION
This obsoletes #547. The consequences for this change is that the report request will fail if it redirects across origins.

Fixes #546.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/817.html" title="Last updated on May 18, 2023, 2:00 AM UTC (71d3942)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/817/4b138b0...71d3942.html" title="Last updated on May 18, 2023, 2:00 AM UTC (71d3942)">Diff</a>