### PR TITLE
Spec destination rate-limits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1592,7 +1592,7 @@ To <dfn>check if an [=attribution source=] exceeds the time-based destination li
 1. Let |sameReportingDestinations| be the [=set=] of every [=attribution rate-limit record/attribution destination=] in |matchingSameReportingSources|,
     [=set/union|unioned=] with |source|'s [=attribution source/attribution destinations=].
 1. Let |hitRateLimit| be whether |destinations|'s [=set/size=] is greater than [=max destinations per rate-limit window=][0].
-1. Let |hitSameReportingRateLimit| be whether |sameReportingDestinations|'s [=set/size=] is greater than [=max destinations per rate-limit window=].
+1. Let |hitSameReportingRateLimit| be whether |sameReportingDestinations|'s [=set/size=] is greater than [=max destinations per rate-limit window=][1].
 1. If (|hitRateLimit|, |hitSameReportingRateLimit|) is
     <dl class="switch">
     : (false, false)
@@ -1606,9 +1606,9 @@ To <dfn>check if an [=attribution source=] exceeds the time-based destination li
 
     </dl>
 
-Note: We do not emit an [=attribution debug report=] for "<code>[=destination rate-limit result/hit global limit=]</code>",
-so when both limits are hit, just interpret it as "<code>[=destination rate-limit result/hit reporting limit=]</code>" to ensure
-that report is sent.
+Note: We do not emit an explicit [=source debug data type=] for "<code>[=destination rate-limit result/hit global limit=]</code>",
+we only emit a [=source debug data type/source-success=] type. For this reason, when both limits are hit, just interpret
+it as "<code>[=destination rate-limit result/hit reporting limit=]</code>" to ensure that the most useful report is sent.
 
 To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an
 [=attribution source=] |source|, run the following steps:
@@ -1675,6 +1675,7 @@ and a [=suitable origin=] |reportingOrigin|:
 1. If |dataType| is:
     <dl class="switch">
     : "<code>[=source debug data type/source-destination-limit=]</code>"
+    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
     :: Return <strong>allowed</strong>.
     : "<code>[=source debug data type/source-noised=]</code>"
     : "<code>[=source debug data type/source-storage-limit=]</code>"
@@ -1704,6 +1705,9 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
     <dl class="switch">
     : "<code>[=source debug data type/source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
+         [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
          [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-storage-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],

--- a/index.bs
+++ b/index.bs
@@ -1723,7 +1723,9 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
     1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
     1. Return.
-1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>", return.
+1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>" and |source|.
+    1. Return.
 1. Let |cache| be the user agent's [=attribution source cache=].
 1. [=list/Remove=] all [=attribution sources=] |entry| in |cache| where |entry|'s [=attribution source/expiry time=] is less than |source|'s [=attribution source/source time=].
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all

--- a/index.bs
+++ b/index.bs
@@ -852,6 +852,7 @@ Possible values are:
 
 <ul dfn-for="source debug data type">
 <li>"<dfn><code>source-destination-limit</code></dfn>"
+<li>"<dfn><code>source-destination-rate-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
@@ -926,6 +927,17 @@ A triggering result is a [=tuple=] with the following items:
 :: Null or an [=attribution debug data=].
 
 </dl>
+
+<h3 dfn-type=dfn>Destination rate limit result</h3>
+
+A destination rate limit result is one of the following:
+
+<ul dfn-for="destination rate limit result">
+<li>"<dfn><code>allowed</code></dfn>"
+<li>"<dfn><code>hit global limit</code></dfn>"
+<li>"<dfn><code>hit reporting limit</code></dfn>"
+</ul>
+
 
 # Storage # {#storage}
 
@@ -1018,6 +1030,16 @@ can be created by [=attribution triggers=] attributed to a single [=attribution 
 <dfn>Max destinations covered by unexpired sources</dfn> is a positive
 integer that controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
 for unexpired [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=]).
+
+<dfn>Destination rate-limit window</dfn> is a positive [=duration=] that
+controls the rate-limiting window for destinations.
+
+<dfn>Max destinations per rate-limit window</dfn> is a [=tuple=] consisting of two integers. The first
+controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
+for [=attribution sources=] with a given [=attribution source/source site=] per [=destination rate-limit window=].
+The second controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
+for [=attribution sources=] with a given ([=attribution source/source site=],[=attribution source/reporting origin=] [=site=])
+per [=destination rate-limit window=].
 
 <dfn>Attribution rate-limit window</dfn> is a positive [=duration=] that
 controls the rate-limiting window for attribution.
@@ -1553,6 +1575,41 @@ Issue: Determine proper charset-handling for the JSON header value.
 
 <h3 id="processing-an-attribution-source">Processing an attribution source</h3>
 
+To <dfn>check if an [=attribution source=] exceeds the time-based destination limits</dfn> given an
+[=attribution source=] |source|, run the following steps:
+
+1. Let |matchingSources| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
+     * |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/source=]</code>"
+     * |record|'s [=attribution rate-limit record/source site=] and |source|'s [=attribution source/source site=] are equal
+     * |record|'s [=attribution rate-limit record/expiry time=] is greater than |source|'s [=attribution source/source time=]
+     * The [=duration from=] |record|'s [=attribution rate-limit record/time=] and |source|'s [=attribution source/source time=]
+        is less than [=destination rate-limit window=] 
+1. Let |matchingSameReportingSources| be all the [=attribution rate-limit records|records=] in |matchingSources|
+    whose associated [=attribution rate-limit record/reporting origin=] is [=same site=] with |source|'s 
+    [=attribution source/reporting origin=].
+1. Let |destinations| be the [=set=] of every [=attribution rate-limit record/attribution destination=] in |matchingSources|,
+    [=set/union|unioned=] with |source|'s [=attribution source/attribution destinations=].
+1. Let |sameReportingDestinations| be the [=set=] of every [=attribution rate-limit record/attribution destination=] in |matchingSameReportingSources|,
+    [=set/union|unioned=] with |source|'s [=attribution source/attribution destinations=].
+1. Let |hitRateLimit| be whether |destinations|'s [=set/size=] is greater than [=max destinations per rate-limit window=][0].
+1. Let |hitSameReportingRateLimit| be whether |sameReportingDestinations|'s [=set/size=] is greater than [=max destinations per rate-limit window=].
+1. If (|hitRateLimit|, |hitSameReportingRateLimit|) is
+    <dl class="switch">
+    : (false, false)
+    :: Return "<code>[=destination rate limit result/allowed=]</code>".
+    : (false, true)
+    :: Return "<code>[=destination rate limit result/hit reporting limit=]</code>".
+    : (true, false)
+    :: Return "<code>[=destination rate limit result/hit global limit=]</code>".
+    : (true, true)
+    :: Return "<code>[=destination rate limit result/hit reporting limit=]</code>".
+
+    </dl>
+
+Note: we do not emit an [=attribution debug report=] for "<code>[=destination rate limit result/hit global limit=]</code>",
+so when both limits are hit, just interpret it as "<code>[=destination rate limit result/hit reporting limit=]</code>" to ensure
+that report is sent.
+
 To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an
 [=attribution source=] |source|, run the following steps:
 
@@ -1662,6 +1719,11 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
 
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
+1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
+1. If |destinationRateLimitResult| is "<code>[=destination rate limit result/hit reporting limit=]</code>":
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
+    1. Return.
+1. If |destinationRateLimitResult| is "<code>[=destination rate limit result/hit global limit=]</code>", return.
 1. Let |cache| be the user agent's [=attribution source cache=].
 1. [=list/Remove=] all [=attribution sources=] |entry| in |cache| where |entry|'s [=attribution source/expiry time=] is less than |source|'s [=attribution source/source time=].
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all

--- a/index.bs
+++ b/index.bs
@@ -928,11 +928,11 @@ A triggering result is a [=tuple=] with the following items:
 
 </dl>
 
-<h3 dfn-type=dfn>Destination rate limit result</h3>
+<h3 dfn-type=dfn>Destination rate-limit result</h3>
 
-A destination rate limit result is one of the following:
+A destination rate-limit result is one of the following:
 
-<ul dfn-for="destination rate limit result">
+<ul dfn-for="destination rate-limit result">
 <li>"<dfn><code>allowed</code></dfn>"
 <li>"<dfn><code>hit global limit</code></dfn>"
 <li>"<dfn><code>hit reporting limit</code></dfn>"
@@ -1038,7 +1038,7 @@ controls the rate-limiting window for destinations.
 controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
 for [=attribution sources=] with a given [=attribution source/source site=] per [=destination rate-limit window=].
 The second controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
-for [=attribution sources=] with a given ([=attribution source/source site=],[=attribution source/reporting origin=] [=site=])
+for [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=])
 per [=destination rate-limit window=].
 
 <dfn>Attribution rate-limit window</dfn> is a positive [=duration=] that
@@ -1596,18 +1596,18 @@ To <dfn>check if an [=attribution source=] exceeds the time-based destination li
 1. If (|hitRateLimit|, |hitSameReportingRateLimit|) is
     <dl class="switch">
     : (false, false)
-    :: Return "<code>[=destination rate limit result/allowed=]</code>".
+    :: Return "<code>[=destination rate-limit result/allowed=]</code>".
     : (false, true)
-    :: Return "<code>[=destination rate limit result/hit reporting limit=]</code>".
+    :: Return "<code>[=destination rate-limit result/hit reporting limit=]</code>".
     : (true, false)
-    :: Return "<code>[=destination rate limit result/hit global limit=]</code>".
+    :: Return "<code>[=destination rate-limit result/hit global limit=]</code>".
     : (true, true)
-    :: Return "<code>[=destination rate limit result/hit reporting limit=]</code>".
+    :: Return "<code>[=destination rate-limit result/hit reporting limit=]</code>".
 
     </dl>
 
-Note: we do not emit an [=attribution debug report=] for "<code>[=destination rate limit result/hit global limit=]</code>",
-so when both limits are hit, just interpret it as "<code>[=destination rate limit result/hit reporting limit=]</code>" to ensure
+Note: We do not emit an [=attribution debug report=] for "<code>[=destination rate-limit result/hit global limit=]</code>",
+so when both limits are hit, just interpret it as "<code>[=destination rate-limit result/hit reporting limit=]</code>" to ensure
 that report is sent.
 
 To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an
@@ -1720,10 +1720,10 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
 1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
-1. If |destinationRateLimitResult| is "<code>[=destination rate limit result/hit reporting limit=]</code>":
+1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
     1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
     1. Return.
-1. If |destinationRateLimitResult| is "<code>[=destination rate limit result/hit global limit=]</code>", return.
+1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>", return.
 1. Let |cache| be the user agent's [=attribution source cache=].
 1. [=list/Remove=] all [=attribution sources=] |entry| in |cache| where |entry|'s [=attribution source/expiry time=] is less than |source|'s [=attribution source/source time=].
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all


### PR DESCRIPTION
Note that this spec doesn't quite match up with the Chromium implementation, which just keeps everything in memory (and doesn't look at things like expiry). Still, with the window short enough it shouldn't make a large difference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/819.html" title="Last updated on May 19, 2023, 10:40 PM UTC (4937df1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/819/0e687a2...4937df1.html" title="Last updated on May 19, 2023, 10:40 PM UTC (4937df1)">Diff</a>