### PR TITLE
Fix typo for setting report url path

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3015,7 +3015,7 @@ To <dfn>generate a report URL</dfn> given a [=suitable origin=] |reportingOrigin
 1. Set |reportUrl|'s [=url/port=] to |reportingOrigin|'s [=origin/port=].
 1. Let |fullPath| be «"`.well-known`", "`attribution-reporting`"».
 1. [=list/Append=] |path| to |fullPath|.
-1. Set |reportUrl|'s [=url/path=] to |path|.
+1. Set |reportUrl|'s [=url/path=] to |fullPath|.
 1. Return |reportUrl|.
 
 To <dfn>generate an attribution report URL</dfn> given an [=attribution report=] |report| and an optional


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/823.html" title="Last updated on May 23, 2023, 5:17 PM UTC (bdb246e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/823/8b9c5b7...linnan-github:bdb246e.html" title="Last updated on May 23, 2023, 5:17 PM UTC (bdb246e)">Diff</a>