### PR TITLE
Move "make background attributionsrc requests" out of HTML monkeypatches

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -137,27 +137,6 @@ The IDL attribute {{HTMLAttributionSrcElementUtils/attributionSrc}}
 must <a spec=html>reflect</a> the respective content attribute of the same
 name.
 
-To <dfn>make background attributionsrc requests</dfn> given an
-{{HTMLAttributionSrcElementUtils}} |element| and an [=eligibility=]
-|eligibility|:
-
-1. Let |attributionSrc| be |element|'s
-    {{HTMLAttributionSrcElementUtils/attributionSrc}}.
-1. Let |tokens| be the result of
-    [=split a string on ASCII whitespace|splitting=] |attributionSrc| on ASCII
-    whitespace.
-1. [=list/iterate|For each=] |token| of |tokens|:
-    1. <a spec="HTML" lt="parse a URL">Parse</a> |token|, relative to
-        |element|'s [=Node/node document=]. If that is not successful,
-        [=iteration/continue=]. Otherwise, let |url| be the resulting
-        [=URL record=].
-    1. Run [=make a background attributionsrc request=] with |url|,
-        |contextOrigin|, |eligibility|, and |element|'s [=Node/node document=].
-
-Issue: Set |contextOrigin| properly.
-
-Issue: Consider allowing the user agent to limit the size of |tokens|.
-
 Whenever an <{img}> or a <{script}> |element| is created or |element|'s
 {{HTMLAttributionSrcElementUtils/attributionSrc}} attribute is set or changed,
 run [=make background attributionsrc requests=] with |element| and
@@ -1344,6 +1323,27 @@ Issue: Audit other properties on |request| and set them properly.
 Issue: Support header-processing on redirects.
 
 Issue: Check for transient activation with "<code>[=eligibility/navigation-source=]</code>".
+
+To <dfn>make background attributionsrc requests</dfn> given an
+{{HTMLAttributionSrcElementUtils}} |element| and an [=eligibility=]
+|eligibility|:
+
+1. Let |attributionSrc| be |element|'s
+    {{HTMLAttributionSrcElementUtils/attributionSrc}}.
+1. Let |tokens| be the result of
+    [=split a string on ASCII whitespace|splitting=] |attributionSrc| on ASCII
+    whitespace.
+1. [=list/iterate|For each=] |token| of |tokens|:
+    1. <a spec="HTML" lt="parse a URL">Parse</a> |token|, relative to
+        |element|'s [=Node/node document=]. If that is not successful,
+        [=iteration/continue=]. Otherwise, let |url| be the resulting
+        [=URL record=].
+    1. Run [=make a background attributionsrc request=] with |url|,
+        |contextOrigin|, |eligibility|, and |element|'s [=Node/node document=].
+
+Issue: Set |contextOrigin| properly.
+
+Issue: Consider allowing the user agent to limit the size of |tokens|.
 
 To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
 |contextOrigin|, an [=eligibility=] |eligibility|, an


### PR DESCRIPTION
Fixes #805


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/826.html" title="Last updated on May 30, 2023, 3:29 PM UTC (18b61f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/826/0e16b7f...apasel422:18b61f1.html" title="Last updated on May 30, 2023, 3:29 PM UTC (18b61f1)">Diff</a>