### PR TITLE
Use aggregation coordinator origin instead of identifier

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -304,7 +304,7 @@ shared.
 The encryption will use public keys specified by the aggregation service. The
 browser will encrypt payloads just before the report is sent by fetching the
 public key endpoint (the aggregation service coordinator origin at the path
- `.well-known/aggregation-service/publick-keys`) with an un-credentialed request. The processing origin will
+ `/.well-known/aggregation-service/public-keys`) with an un-credentialed request. The processing origin will
 respond with a set of keys which will be stored according to standard HTTP
 caching rules, i.e. using Cache-Control headers to dictate how long to store the
 keys for (e.g. following the [freshness
@@ -458,8 +458,8 @@ Currently the aggregation service can be deployed on Amazon Web Services (AWS). 
 
 Trigger registration will accept an optional string field `aggregation_coordinator_origin`
 to allow developers to specify the deployment option for the aggregation service
-supported by the browser, e.g. the origin for the aggregation service deloyed on
-AWS, and GCP and other platforms in the future.
+supported by the browser, e.g. the origin for the aggregation service deployed on
+AWS, GCP, and other platforms in the future.
 
 ```jsonc
 {

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -238,7 +238,7 @@ The report will be JSON encoded with the following scheme:
   ],
 
   // The deployment option for the aggregation service.
-  "aggregation_coordinator_identifier": "aws-cloud",
+  "aggregation_coordinator_origin": "https://publickeyservice.aws.privacysandboxservices.com",
 
   // Optional debugging information (also present in event-level reports),
   // if the cookie `ar_debug` is present.
@@ -303,7 +303,8 @@ shared.
 
 The encryption will use public keys specified by the aggregation service. The
 browser will encrypt payloads just before the report is sent by fetching the
-public key endpoint with an un-credentialed request. The processing origin will
+public key endpoint (the aggregation service coordinator origin at the path
+ `.well-known/aggregation-service/publick-keys`) with an un-credentialed request. The processing origin will
 respond with a set of keys which will be stored according to standard HTTP
 caching rules, i.e. using Cache-Control headers to dictate how long to store the
 keys for (e.g. following the [freshness
@@ -455,11 +456,20 @@ certain amount of noise will be added to each output key's aggregate value.
 
 Currently the aggregation service can be deployed on Amazon Web Services (AWS). We expect to support Google Cloud Platform (GCP) and other cloud providers in the future.
 
-Trigger registration will accept an optional string field `aggregation_coordinator_identifier` to allow developers to specify the deployment option for the aggregation service. The default value is `aws-cloud`. `gcp-cloud` and other values will be supported in the future.
+Trigger registration will accept an optional string field `aggregation_coordinator_origin`
+to allow developers to specify the deployment option for the aggregation service
+supported by the browser, e.g. the origin for the aggregation service deloyed on
+AWS, and GCP and other platforms in the future.
 
-```http
-Attribution-Reporting-Register-Trigger: {..., "aggregatable_trigger_data": ..., "aggregatable_values": ..., "aggregation_coordinator_identifier": "aws-cloud"}
+```jsonc
+{
+  ..., // existing fields
+  "aggregation_coordinator_origin": "https://publickeyservice.aws.privacysandboxservices.com",
+}
 ```
+
+TODO: Consider exposing the allowlist of aggregation service coordinator
+origins.
 
 ## Privacy considerations
 

--- a/header-validator/data.trigger.js
+++ b/header-validator/data.trigger.js
@@ -513,19 +513,27 @@ export const testCases = [
   },
 
   {
-    name: "aggregation-coordinator-identifier-wrong-type",
-    json: `{"aggregation_coordinator_identifier": 1}`,
+    name: "aggregation-coordinator-origin-wrong-type",
+    json: `{"aggregation_coordinator_origin": 1}`,
     expectedErrors: [{
-      path: ["aggregation_coordinator_identifier"],
+      path: ["aggregation_coordinator_origin"],
       msg: "must be a string",
     }],
   },
   {
-    name: "aggregation-coordinator-identifier-unknown-value",
-    json: `{"aggregation_coordinator_identifier": "AWS-CLOUD"}`,
+    name: "aggregation-coordinator-origin-not-url",
+    json: `{"aggregation_coordinator_origin": "a.test"}`,
     expectedErrors: [{
-      path: ["aggregation_coordinator_identifier"],
-      msg: "must match 'aws-cloud' (case-sensitive)",
+      path: ["aggregation_coordinator_origin"],
+      msg: "must contain a valid URL",
+    }],
+  },
+  {
+    name: "aggregation-coordinator-origin-untrustworthy",
+    json: `{"aggregation_coordinator_origin": "http://a.test"}`,
+    expectedErrors: [{
+      path: ["aggregation_coordinator_origin"],
+      msg: "must contain a potentially trustworthy URL",
     }],
   },
 

--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -192,6 +192,7 @@ const suitableUrl = string((state, url) => {
     state.warn('contains a fragment that will be ignored')
   }
 })
+
 const destinationList = list(suitableUrl, 3, 1)
 
 const destinationValue = (state, value) => {

--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -162,7 +162,7 @@ const hex128 = string((state, value) => {
   }
 })
 
-const destination = string((state, url) => {
+const suitableUrl = string((state, url) => {
   try {
     url = new URL(url)
   } catch {
@@ -192,11 +192,11 @@ const destination = string((state, url) => {
     state.warn('contains a fragment that will be ignored')
   }
 })
-const destinationList = list(destination, 3, 1)
+const destinationList = list(suitableUrl, 3, 1)
 
 const destinationValue = (state, value) => {
   if (typeof value === 'string') {
-    return destination(state, value)
+    return suitableUrl(state, value)
   }
   if (isArray(value)) {
     return destinationList(state, value)
@@ -285,14 +285,6 @@ const eventTriggerData = list(
       trigger_data: optional(uint64),
     }))
 
-const aggregationCoordinator = string((state, value) => {
-  const awsCloud = 'aws-cloud'
-  if (value === awsCloud) {
-    return
-  }
-  state.error(`must match '${awsCloud}' (case-sensitive)`)
-})
-
 const aggregatableDedupKeys = list(
   (state, value) =>
     state.validate(value, {
@@ -315,7 +307,7 @@ export function validateTrigger(trigger) {
   state.validate(trigger, {
     aggregatable_trigger_data: optional(aggregatableTriggerData),
     aggregatable_values: optional(aggregatableValues),
-    aggregation_coordinator_identifier: optional(aggregationCoordinator),
+    aggregation_coordinator_origin: optional(suitableUrl),
     debug_key: optional(uint64),
     debug_reporting: optional(bool),
     event_trigger_data: optional(eventTriggerData),

--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,7 @@ An event-level trigger configuration is a [=struct=] with the following items:
 <h3 id="aggregation-coordinator-header">Aggregation coordinator</h3>
 
 An <dfn>aggregation coordinator</dfn> is one of a user-agent-determined [=set=]
-of non-[=opaque origins=] that specifies which aggregation service deployment to use.
+of [=suitable origins=] that specifies which aggregation service deployment to use.
 
 <h3 id="aggregatable-source-registration-time-configuration-header">Aggregatable source registration time configuration</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,7 @@ An event-level trigger configuration is a [=struct=] with the following items:
 <h3 id="aggregation-coordinator-header">Aggregation coordinator</h3>
 
 An <dfn>aggregation coordinator</dfn> is one of a user-agent-determined [=set=]
-of [=origins=] that specifies which aggregation service deployment to use.
+of non-[=opaque origins=] that specifies which aggregation service deployment to use.
 
 <h3 id="aggregatable-source-registration-time-configuration-header">Aggregatable source registration time configuration</h3>
 
@@ -2904,15 +2904,13 @@ of running the following steps:
 
 To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordinator=] |aggregationCoordinator|:
 
-1. [=Assert=]: |aggregationCoordinator| is not an [=opaque origin=].
 1. Let |url| be a new [=URL record=].
 1. Set |url|'s [=url/scheme=] to |aggregationCoordinator|'s [=origin/scheme=].
 1. Set |url|'s [=url/host=] to |aggregationCoordinator|'s [=origin/host=].
 1. Set |url|'s [=url/port=] to |aggregationCoordinator|'s [=origin/port=].
-1. Let |path| be «"`.well-known`", "`aggregation-service`", "`public-keys`"».
-1. Set |url|'s [=url/path=] to |path|.
-1. Asynchronously return a user-agent-determined public key from |url| or an error in the event that the user
-    agent failed to obtain the public key from |url|.
+1. Set |url|'s [=url/path=]  to «"`.well-known`", "`aggregation-service`", "`public-keys`"».
+1. Return a user-agent-determined public key from |url| or an error in the event that the user
+    agent failed to obtain the public key from |url|. This step may be asynchronous.
 
 Note: The user agent might enforce weekly key rotation. If there are multiple keys, the user agent
 might independently pick a key uniformly at random for every encryption operation.

--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,7 @@ An event-level trigger configuration is a [=struct=] with the following items:
 <h3 id="aggregation-coordinator-header">Aggregation coordinator</h3>
 
 An <dfn>aggregation coordinator</dfn> is one of a user-agent-determined [=set=]
-of [=strings=] that specifies which aggregation service deployment to use.
+of [=origins=] that specifies which aggregation service deployment to use.
 
 <h3 id="aggregatable-source-registration-time-configuration-header">Aggregatable source registration time configuration</h3>
 
@@ -2041,10 +2041,12 @@ and a [=moment=] |triggerTime|:
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to value["`debug_reporting`"].
 1. Let |aggregationCoordinator| be [=default aggregation coordinator=].
-1. If |value|["`aggregation_coordinator_identifier`"] [=map/exists=]:
-    1. If |value|["`aggregation_coordinator_identifier`"] is not a [=string=], return null.
-    1. If |value|["`aggregation_coordinator_identifier`"] is not an [=aggregation coordinator=], return null.
-    1. Set |aggregationCoordinator| to |value|["`aggregation_coordinator_identifier`"].
+1. If |value|["`aggregation_coordinator_origin`"] [=map/exists=]:
+    1. If |value|["`aggregation_coordinator_origin`"] is not a [=string=], return null.
+    1. Let |url| be the result of running the [=URL parser=] on |value|["`aggregation_coordinator_origin`"].
+    1. If |url| is failure or null, return null.
+    1. If |url|'s [=url/origin=] is not an [=aggregation coordinator=], return null.
+    1. Set |aggregationCoordinator| to |url|'s [=url/origin=].
 1. Let |aggregatableSourceRegTimeConfig| be "<code>[=aggregatable source registration time configuration/exclude=]</code>".
 1. If |value|["`aggregatable_source_registration_time`"] [=map/exists=]:
     1. If |value|["`aggregatable_source_registration_time`"] is not a [=string=], return null.
@@ -2900,9 +2902,17 @@ of running the following steps:
 
 <h3 id="obtain-aggregatable-report-aggregation-service-payloads">Obtaining an aggregatable report's aggregation service payloads</h3>
 
-To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordinator=]
-<var ignore=''>aggregationCoordinator</var>, asynchronously return a user-agent-determined public key
-or an error in the event that the user agent failed to obtain the public key.
+To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordinator=] |aggregationCoordinator|:
+
+1. [=Assert=]: |aggregationCoordinator| is not an [=opaque origin=].
+1. Let |url| be a new [=URL record=].
+1. Set |url|'s [=url/scheme=] to |aggregationCoordinator|'s [=origin/scheme=].
+1. Set |url|'s [=url/host=] to |aggregationCoordinator|'s [=origin/host=].
+1. Set |url|'s [=url/port=] to |aggregationCoordinator|'s [=origin/port=].
+1. Let |path| be «"`.well-known`", "`aggregation-service`", "`public-keys`"».
+1. Set |url|'s [=url/path=] to |path|.
+1. Asynchronously return a user-agent-determined public key from |url| or an error in the event that the user
+    agent failed to obtain the public key from |url|.
 
 Note: The user agent might enforce weekly key rotation. If there are multiple keys, the user agent
 might independently pick a key uniformly at random for every encryption operation.
@@ -3008,8 +3018,8 @@ To <dfn>serialize an [=aggregatable report=] </dfn> |report|, run the following 
     :: |report|'s [=aggregatable report/shared info=]
     : "`aggregation_service_payloads`"
     :: |aggregationServicePayloads|
-    : "`aggregation_coordinator_identifier`"
-    :: |report|'s [=aggregatable report/aggregation coordinator=]
+    : "`aggregation_coordinator_origin`"
+    :: |report|'s [=aggregatable report/aggregation coordinator=], [=serialization of an origin|serialized=]
 
 1. If |report|'s [=aggregatable report/source debug key=] is not null, [=map/set=]
     |data|["`source_debug_key`"] to |report|'s [=aggregatable report/source debug key=],

--- a/index.bs
+++ b/index.bs
@@ -2912,6 +2912,8 @@ To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordi
 1. Return a user-agent-determined public key from |url| or an error in the event that the user
     agent failed to obtain the public key from |url|. This step may be asynchronous.
 
+Issue: Specify this in terms of [=fetch=].
+
 Note: The user agent might enforce weekly key rotation. If there are multiple keys, the user agent
 might independently pick a key uniformly at random for every encryption operation.
 The key should be uniquely identifiable.

--- a/schema/trigger.schema.json
+++ b/schema/trigger.schema.json
@@ -51,9 +51,9 @@
       },
       "default": []
     },
-    "aggregation_coordinator_identifier": {
-      "type": "string",
-      "$comment": "TODO: specify format and default value"
+    "aggregation_coordinator_origin": {
+      "$ref": "#/$defs/aggregation_coordinator_origin",
+      "$comment": "TODO: specify default value"
     },
     "aggregatable_source_registration_time": {
       "enum": ["exclude", "include"],
@@ -147,6 +147,10 @@
     "unsigned_base10_integer": {
       "type": "string",
       "pattern": "^[0-9]+$"
+    },
+    "aggregation_coordinator_origin": {
+      "type": "string",
+      "$comment": "TODO: specify format"
     }
   }
 }


### PR DESCRIPTION
To avoid a translation layer of vendor-specific identifier to origin.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/829.html" title="Last updated on May 31, 2023, 1:54 PM UTC (7cf1bde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/829/93010b0...linnan-github:7cf1bde.html" title="Last updated on May 31, 2023, 1:54 PM UTC (7cf1bde)">Diff</a>