### PR TITLE
Add same-origin policy considerations for debug reports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3286,7 +3286,7 @@ cannot be reported explicitly and may be reported as a [=source debug data type/
 [=attribution debug report=]. This is a tradeoff between security and utility, and mitigates the
 security concern with respect to the Same-Origin Policy. The risk is of less concern for
 trigger registrations as [=attribution sources=] have to be registered to start with and
-it requires a user journey between pages.
+it requires browsing activity on multiple sites.
 
 ## Opting in to the API ## {#opting-in-to-the-api}
 

--- a/index.bs
+++ b/index.bs
@@ -3281,7 +3281,9 @@ and the [=attribution debug data=] sent to a given [=origin=] may encode non-Sam
 data that are generated from grouping together data submitted by multiple [=origins=],
 e.g. failures due to rate-limits that are not fully compliant with the Same-Origin Policy.
 This is of greater concern for source registrations as the [=attribution source/source origin=]
-could intentionally hit a rate-limit to identify sensitive user data. These [=attribution debug data=]
+could intentionally hit a rate-limit to identify sensitive user data. The risk is of
+less concern for trigger registrations as [=attribution sources=] have to be registered
+to start with and it requires a user journey between pages. These [=attribution debug data=]
 cannot be reported explicitly and may be reported as a [=source debug data type/source-success=]
 [=attribution debug report=]. This is a tradeoff between security and utility, and mitigates the
 security concern with respect to the Same-Origin Policy.

--- a/index.bs
+++ b/index.bs
@@ -3281,12 +3281,12 @@ and the [=attribution debug data=] sent to a given [=origin=] may encode non-Sam
 data that are generated from grouping together data submitted by multiple [=origins=],
 e.g. failures due to rate-limits that are not fully compliant with the Same-Origin Policy.
 This is of greater concern for source registrations as the [=attribution source/source origin=]
-could intentionally hit a rate-limit to identify sensitive user data. The risk is of
-less concern for trigger registrations as [=attribution sources=] have to be registered
-to start with and it requires a user journey between pages. These [=attribution debug data=]
+could intentionally hit a rate-limit to identify sensitive user data. These [=attribution debug data=]
 cannot be reported explicitly and may be reported as a [=source debug data type/source-success=]
 [=attribution debug report=]. This is a tradeoff between security and utility, and mitigates the
-security concern with respect to the Same-Origin Policy.
+security concern with respect to the Same-Origin Policy. The risk is of less concern for
+trigger registrations as [=attribution sources=] have to be registered to start with and
+it requires a user journey between pages.
 
 ## Opting in to the API ## {#opting-in-to-the-api}
 

--- a/index.bs
+++ b/index.bs
@@ -3275,7 +3275,16 @@ This trades off security for privacy, in that the limits are there to reduce the
 of many origins colluding together to violate privacy. API deployments should monitor
 for abuse using these vectors to evaluate the trade-off.
 
-Issue: Discuss Same-Origin Policy with respect to debug reports.
+The generation of [=attribution debug reports=] involves reads to the [=attribution source cache=],
+[=event-level report cache=], [=aggregatable report cache=], and [=attribution rate-limit cache=],
+and the [=attribution debug data=] sent to a given [=origin=] may encode non-Same-Origin
+data that are generated from grouping together data submitted by multiple [=origins=],
+e.g. failures due to rate-limits that are not fully compliant with the Same-Origin Policy.
+This is of greater concern for source registrations as the [=attribution source/source origin=]
+could intentionally hit a rate-limit to identify sensitive user data. These [=attribution debug data=]
+cannot be reported explicitly and may be reported as a [=source debug data type/source-success=]
+[=attribution debug report=]. This is a tradeoff between security and utility, and mitigates the
+security concern with respect to the Same-Origin Policy.
 
 ## Opting in to the API ## {#opting-in-to-the-api}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/832.html" title="Last updated on Jun 2, 2023, 3:18 PM UTC (386c6c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/832/138c8b0...linnan-github:386c6c2.html" title="Last updated on Jun 2, 2023, 3:18 PM UTC (386c6c2)">Diff</a>