### PR TITLE
Remove issue for fake reports with storage limit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1868,8 +1868,6 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the
 privacy budget of all possible destinations.
 
-Issue: Should fake reports respect the user agent's [=max event-level reports per attribution destination=]?
-
 # Triggering Algorithms # {#trigger-algorithms}
 
 <h3 algorithm id="attribution-trigger-creation">Creating an attribution trigger</h3>


### PR DESCRIPTION
Similar to rate limits, fake reports will contribute to the storage limit but not check it before storage.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/836.html" title="Last updated on Jun 8, 2023, 3:26 PM UTC (843bec7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/836/59892b2...linnan-github:843bec7.html" title="Last updated on Jun 8, 2023, 3:26 PM UTC (843bec7)">Diff</a>