### PR TITLE
Update the spec to not sending attribution success debug reports if reports are dropped for noise

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2430,9 +2430,10 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
     [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
-1. If |report|'s [=event-level report/source debug key=] is not null and |report|'s
-    [=event-level report/trigger debug key=] is not null, [=queue a task=] to
-    [=attempt to deliver a debug report=] with |report|.
+1. If |triggeringStatus| is "<code>[=triggering status/attributed=]</code>":
+    1. If |report|'s [=event-level report/source debug key=] is not null and |report|'s
+        [=event-level report/trigger debug key=] is not null, [=queue a task=] to
+        [=attempt to deliver a debug report=] with |report|.
 1. Return the [=triggering result=] (|triggeringStatus|, |debugData|).
 
 <h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>

--- a/index.bs
+++ b/index.bs
@@ -2430,10 +2430,10 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
     [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
-1. If |triggeringStatus| is "<code>[=triggering status/attributed=]</code>":
-    1. If |report|'s [=event-level report/source debug key=] is not null and |report|'s
-        [=event-level report/trigger debug key=] is not null, [=queue a task=] to
-        [=attempt to deliver a debug report=] with |report|.
+1. If |triggeringStatus| is "<code>[=triggering status/attributed=]</code>" and
+    |report|'s [=event-level report/source debug key=] is not null and |report|'s
+    [=event-level report/trigger debug key=] is not null, [=queue a task=] to
+    [=attempt to deliver a debug report=] with |report|.
 1. Return the [=triggering result=] (|triggeringStatus|, |debugData|).
 
 <h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>


### PR DESCRIPTION
Such that attribution success debug reports are 1-1 correspondence with the actual reports.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/840.html" title="Last updated on Jun 8, 2023, 5:23 PM UTC (01a8184)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/840/2ddc02b...linnan-github:01a8184.html" title="Last updated on Jun 8, 2023, 5:23 PM UTC (01a8184)">Diff</a>