### PR TITLE
Source throttling on destinations is per reporting site

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -956,7 +956,7 @@ Strawman: 200 distinct destination sites per-{source site, 1 minute}
 
 Additionally, to prevent one origin from using up the budget in the limit above, the browser can also limit the number of `destination` eTLD+1s per reporting origin.
 
-Strawman: 50 distinct destination sites per-{source site, reporting origin, 1 minute}
+Strawman: 50 distinct destination sites per-{source site, reporting site, 1 minute}
 
 ### Differential privacy
 


### PR DESCRIPTION
https://wicg.github.io/attribution-reporting-api/#max-source-reporting-origins-per-source-reporting-site