### PR TITLE
Add configurable windows and maximum # of reports to spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1798,13 +1798,14 @@ and a [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
+1. Let |startDuration| be the result of running [=parse a duration=] with |values|, "`start_time`", and (0, infinity).
+1. If |startDuration| is greater than |defaultEndDuration|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
 1. If |endDurations| [=list/is empty=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
-1. Let |startDuration| be 0 seconds.
 1. [=list/iterate|For each=] |end| of |endDurations|:
     1. If |end| is not an integer, return an error.
     1. Let |endDuration| be |end| seconds.

--- a/index.bs
+++ b/index.bs
@@ -1865,11 +1865,9 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     1. Round |expiry| away from zero to the nearest day (86400 seconds).
     1. Set |triggerDataCardinality| to the user agent's
         [=event-source trigger data cardinality=].
-1. Let |maxAttributionsPerSource| be the result of running
-    [=parse an optional 64-bit signed integer=] with |value|, "`max_event_level_reports`", and
-    [=default event-level attributions per source=][|sourceType|].
-1. If |maxAttributionsPerSource| is an error, return null.
-1. If |maxAttributionsPerSource| is greater than [=max settable event-level attributions per source=], return null.
+1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
+1. Set |maxAttributionsPerSource| to |value|["`max_event_level_reports`"] if it [=map/exists=].
+1. If |maxAttributionsPerSource| is not a positive integer, or is greater than [=max settable event-level attributions per source=], return null.
 1. Let |eventReportWindow| be the result of running [=parse a duration=] with
     |value|, "`event_report_window`", and ([=min report window=], |expiry|).
 1. If |eventReportWindow| is an error, return null.

--- a/index.bs
+++ b/index.bs
@@ -1797,11 +1797,12 @@ and a [=list=] of [=event-level report windows=] |default|:
 1. If |start| is less than 0, return an error.
 1. Let |startDuration| be |start| seconds.
 1. If |startDuration| is greater than |defaultEndDuration|, return an error.
-1. If |values|["`end_times`"] does not [=map/exist=], return an error.
+1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
+    1. If |elt| is not a [=string=], return an error.
     1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
     1. If |end| is an error, return an error.
     1. Let |endDuration| be |end| seconds.

--- a/index.bs
+++ b/index.bs
@@ -1800,10 +1800,7 @@ and an [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |start| be the result of running [=parse an optional 64-bit signed integer=] with |values|, "`start_time`", and 0.
-1. If |start| is an error, return an error.
-1. If |start| is less than 0, return an error.
-1. Let |startDuration| be |start| seconds.
+1. Let |startDuration| be the result of running [=parse a duration=] with |values|, "`start_time`", and (0, infinity).
 1. If |startDuration| is greater than |defaultEndDuration|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].

--- a/index.bs
+++ b/index.bs
@@ -1793,9 +1793,8 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-and an [=report window list=] |default|:
+and a [=report window list=] |default|:
 
-1. [=Assert=]: |default| is not [=list/is empty|empty=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].

--- a/index.bs
+++ b/index.bs
@@ -736,11 +736,11 @@ A <dfn>report window</dfn> is a [=struct=] with the following items:
 </dl>
 
 
-An <dfn>event-level report window list</dfn> is a [=list=] of [=event-level report windows=].
+A <dfn>report window list</dfn> is a [=list=] of [=report windows=].
 It has the following constraints:
 
-* Elements are in ascending order based on their [=event-level report window/start=].
-* Every element's [=event-level report window/start=] is equal to the previous element's [=event-level report window/end=], if it exists.
+* Elements are in ascending order based on their [=report window/start=].
+* Every element's [=report window/start=] is equal to the previous element's [=report window/end=], if it exists.
 * There is at least one element in the list.
 
 <h3 dfn-type=dfn>Attribution source</h3>
@@ -763,7 +763,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>expiry</dfn>
 :: A [=duration=].
 : <dfn>event-level report windows</dfn>
-:: An [=event-level report window list=].
+:: A [=report window list=].
 : <dfn>aggregatable report window</dfn>
 :: A [=report window=].
 : <dfn>priority</dfn>
@@ -1793,10 +1793,10 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-and an [=event-level report window list=] |default|:
+and an [=report window list=] |default|:
 
 1. [=Assert=]: |default| is not [=list/is empty|empty=].
-1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=event-level report window/end=] of the last element of |default|.
+1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
@@ -1818,11 +1818,11 @@ and an [=event-level report window list=] |default|:
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
     1. If |endDuration| is less than 1 hour, set |endDuration| to 1 hour.
     1. If |endDuration| less than or equal to |startDuration|, return an error.
-    1. Let |window| be a new [=event-level report window=] whose items are
+    1. Let |window| be a new [=report window=] whose items are
 
-        : [=event-level report window/start=]
+        : [=report window/start=]
         :: |sourceTime| + |startDuration|
-        : [=event-level report window/end=]
+        : [=report window/end=]
         :: |sourceTime| + |endDuration|
 
     1. [=list/Append=] |window| to |windows|.
@@ -2911,8 +2911,8 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 To <dfn>check whether a moment falls within a window</dfn> given a [=moment=] |moment| and
 a [=report window=] |window|:
 
-1. Return whether |moment| is greater than or equal to [=event-level report window/start=]
-    and |moment| is less than |window|'s [=event-level report window/end=].
+1. Return whether |moment| is greater than or equal to [=report window/start=]
+    and |moment| is less than |window|'s [=report window/end=].
 
 To <dfn>obtain a report time from a window</dfn> given a [=moment=] |sourceTime| and
 a [=report window=] |window|:

--- a/index.bs
+++ b/index.bs
@@ -1792,7 +1792,7 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-and a [=event-level report window list=] |default|:
+and an [=event-level report window list=] |default|:
 
 1. [=Assert=]: |default| is not [=list/is empty|empty=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=event-level report window/end=] of the last element of |default|.

--- a/index.bs
+++ b/index.bs
@@ -1219,11 +1219,11 @@ many [=aggregatable reports=] can be in the [=aggregatable report cache=] per
 
 <dfn>Default event-level attributions per source</dfn> is a [=map=] that
 controls how many times a single [=attribution source=] can create an [=event-level report=] by default.
-The keys are «[=source type/navigation=],[=source type/event=]».
+The keys are «[=source type/navigation=], [=source type/event=]». The values are non-negative integers.
 
 <dfn>Max event-level channel capacity per source</dfn> is a [=map=] that
 controls how many bits of information can be exposed associated with a single [=attribution source=].
-The keys are «[=source type/navigation=],[=source type/event=]».
+The keys are «[=source type/navigation=], [=source type/event=]». The values are non-negative integers.
 
 <dfn>Max aggregatable reports per source</dfn> is a positive integer that controls how many [=aggregatable reports=]
 can be created by [=attribution triggers=] attributed to a single [=attribution source=].
@@ -1776,30 +1776,31 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
     1. Set |lastEnd| to |lastEnd| + |deadline|.
 1. Return |windows|.
 
-To <dfn>parse report windows</dfn> given an [=ordered map=] |map|, a [=moment=] |sourceTime|,
+To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
 and a [=list=] of [=event-level report windows=] |default|:
 
+1. [=Assert=]: |default| is not [=list/is empty|empty=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=event-level report window/end=] of the last element of |default|.
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
-1. If |values| is not a [=map=], return error.
+1. If |values| is not a [=map=], return an error.
 1. Let |startDuration| be 0 seconds.
 1. If |values|["`start_time`"] [=map/exists=]:
     1. Set |start| to the result of applying the <a spec="html">rules for parsing integers</a> with |values|["`start_time`"].
-    1. If |start| is an error, return error.
-    1. If |start| is less than 0, return error.
+    1. If |start| is an error, return an error.
+    1. If |start| is less than 0, return an error.
     1. Set |startDuration| to |start| seconds.
-    1. If |startDuration| is greater than |defaultEndDuration|, return error.
-1. If |values|["`end_times`"] does not [=map/exist=], return error.
+    1. If |startDuration| is greater than |defaultEndDuration|, return an error.
+1. If |values|["`end_times`"] does not [=map/exist=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
-1. If the [=list/size=] of |endDurations| is greater than 5, return error.
+1. If the [=list/size=] of |endDurations| is greater than 5, return an error.
 1. Let |windows| be an [=list/is empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
     1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
-    1. If |end| is an error, return error
+    1. If |end| is an error, return an error.
     1. Let |endDuration| be |end| seconds.
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
-    1. If |endDuration| <= |startDuration|, return error.
+    1. If |endDuration| <= |startDuration|, return an error.
     1. Let |window| be a new [=event-level report window=] whose items are
 
         : [=event-level report window/start=]
@@ -1807,9 +1808,9 @@ and a [=list=] of [=event-level report windows=] |default|:
         : [=event-level report window/end=]
         :: |sourceTime| + |endDuration|
 
-    1. [=list/append=] |window| to |windows|.
+    1. [=list/Append=] |window| to |windows|.
     1. Set |startDuration| to |endDuration|.
-1. Return |windows|
+1. Return |windows|.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
@@ -1870,7 +1871,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 
 1. Let |eventReportWindows| be the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
 1. If |value|["`event_report_window`"] does not [=map/exist=]:
-    1. Let |eventReportWindows| be the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
+    1. Set |eventReportWindows| to the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
 1. If |eventReportWindows| is an error, return null.
 1. Let |aggregatableReportWindow| be a new [=report window=] with the following items:
 

--- a/index.bs
+++ b/index.bs
@@ -1798,10 +1798,12 @@ and a [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |start| be |map|["`start_time`"]
-1. If |start| is not a non-negative integer, return an error.
-1. Let |startDuration| be |start| seconds.
-1. If |startDuration| is greater than |defaultEndDuration|, return an error.
+1. Let |startDuration| be 0 seconds.
+1. If |map|["`start_time`"] [=map/exists=]:
+    1. Let |start| be |map|["`start_time`"].
+    1. If |start| is not a non-negative integer, return an error.
+    1. Set |startDuration| to |start| seconds.
+    1. If |startDuration| is greater than |defaultEndDuration|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -1808,7 +1808,7 @@ and an [=event-level report window list=] |default|:
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
-1. If |endDurations| is [=list/empty=], return an error.
+1. If |endDurations| [=list/is empty=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
     1. If |elt| is not a [=string=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -1798,7 +1798,9 @@ and a [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |startDuration| be the result of running [=parse a duration=] with |values|, "`start_time`", and (0, infinity).
+1. Let |start| be |map|["`start_time`"]
+1. If |start| is not a non-negative integer, return an error.
+1. Let |startDuration| be |start| seconds.
 1. If |startDuration| is greater than |defaultEndDuration|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
@@ -1867,7 +1869,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
         [=event-source trigger data cardinality=].
 1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
 1. Set |maxAttributionsPerSource| to |value|["`max_event_level_reports`"] if it [=map/exists=].
-1. If |maxAttributionsPerSource| is not a positive integer, or is greater than [=max settable event-level attributions per source=], return null.
+1. If |maxAttributionsPerSource| is not a non-negative integer, or is greater than [=max settable event-level attributions per source=], return null.
 1. Let |eventReportWindow| be the result of running [=parse a duration=] with
     |value|, "`event_report_window`", and ([=min report window=], |expiry|).
 1. If |eventReportWindow| is an error, return null.

--- a/index.bs
+++ b/index.bs
@@ -1166,6 +1166,14 @@ controls the rate-limiting window for attribution. Its value is 30 days.
 maximum [=set/size=] of an [=attribution source=]'s
 [=attribution source/attribution destinations=]. Its value is 3.
 
+<dfn>Max settable event-level attributions per source</dfn> is a positive integer that
+controls the maximum value of [=attribution source/max number of event-level reports=].
+Its value is 20.
+
+<dfn>Max settable event-level report windows</dfn> is a positive integer that
+controls the maximum [=list/size=] of [=attribution source/event-level report windows=].
+Its value is 5.
+
 # Vendor-Specific Values # {#vendor-specific-values}
 
 <dfn>Max aggregation keys per attribution</dfn> is a positive integer that
@@ -1784,23 +1792,21 @@ and a [=list=] of [=event-level report windows=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |startDuration| be 0 seconds.
-1. If |values|["`start_time`"] [=map/exists=]:
-    1. Set |start| to the result of applying the <a spec="html">rules for parsing integers</a> with |values|["`start_time`"].
-    1. If |start| is an error, return an error.
-    1. If |start| is less than 0, return an error.
-    1. Set |startDuration| to |start| seconds.
-    1. If |startDuration| is greater than |defaultEndDuration|, return an error.
+1. Let |start| be the result of running [=parse an optional 64-bit signed integer=] with |values|, "`start_time`", and 0.
+1. If |start| is an error, return an error.
+1. If |start| is less than 0, return an error.
+1. Let |startDuration| be |start| seconds.
+1. If |startDuration| is greater than |defaultEndDuration|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
-1. If the [=list/size=] of |endDurations| is greater than 5, return an error.
+1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
     1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
     1. If |end| is an error, return an error.
     1. Let |endDuration| be |end| seconds.
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
-    1. If |endDuration| <= |startDuration|, return an error.
+    1. If |endDuration| less than or equal to |startDuration|, return an error.
     1. Let |window| be a new [=event-level report window=] whose items are
 
         : [=event-level report window/start=]
@@ -1858,7 +1864,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     [=parse an optional 64-bit signed integer=] with |value|, "`max_event_level_reports`", and
     [=default event-level attributions per source=][|sourceType|].
 1. If |maxAttributionsPerSource| is an error, return null.
-1. If |maxAttributionsPerSource| is greater than 20, return null.
+1. If |maxAttributionsPerSource| is greater than [=max settable event-level attributions per source=], return null.
 1. Let |eventReportWindow| be the result of running [=parse a duration=] with
     |value|, "`event_report_window`", and ([=min report window=], |expiry|).
 1. If |eventReportWindow| is an error, return null.

--- a/index.bs
+++ b/index.bs
@@ -1800,8 +1800,7 @@ and an [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |startDuration| be the result of running [=parse a duration=] with |values|, "`start_time`", and (0, infinity).
-1. If |startDuration| is greater than |defaultEndDuration|, return an error.
+1. Let |startDuration| be 0 seconds.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -764,6 +764,8 @@ An attribution source is a [=struct=] with the following items:
 :: A [=moment=].
 : <dfn>number of event-level reports</dfn>
 :: Number of [=event-level reports=] created for this [=attribution source=].
+: <dfn>Max number of event-level reports</dfn>
+:: The maximum number of [=event-level reports=] that can be created for this [=attribution source=].
 : <dfn>event-level attributable</dfn> (default true)
 :: A [=boolean=].
 : <dfn>dedup keys</dfn>
@@ -1215,15 +1217,13 @@ controls how many [=event-level reports=] can be in the
 many [=aggregatable reports=] can be in the [=aggregatable report cache=] per
 [=aggregatable report/effective attribution destination=].
 
-<dfn>Max attributions per navigation source</dfn> is a positive integer that
-controls how many times a single [=attribution source=] whose
-[=attribution source/source type=] is "<code>[=source type/navigation=]</code>" can create an
-[=event-level report=].
+<dfn>Default event-level attributions per source</dfn> is a [=map=] that
+controls how many times a single [=attribution source=] can create an [=event-level report=] by default.
+The keys are «[=source type/navigation=],[=source type/event=]».
 
-<dfn>Max attributions per event source</dfn> is a positive integer that
-controls how many times a single [=attribution source=] whose
-[=attribution source/source type=] is "<code>[=source type/event=]</code>" can create an
-[=event-level report=].
+<dfn>Max event-level channel capacity per source</dfn> is a [=map=] that
+controls how many bits of information can be exposed associated with a single [=attribution source=].
+The keys are «[=source type/navigation=],[=source type/event=]».
 
 <dfn>Max aggregatable reports per source</dfn> is a positive integer that controls how many [=aggregatable reports=]
 can be created by [=attribution triggers=] attributed to a single [=attribution source=].
@@ -1687,6 +1687,17 @@ To <dfn>obtain a randomized source response</dfn> given a [=randomized response 
 1. Return the result of [=obtaining a randomized response=] with null, |possibleValues|, and
     |pickRate|.
 
+
+<h3 algorithm id="computing-channel-capacity">Computing channel capacity</h3>
+
+To <dfn>compute the channel capacity of a source</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
+1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
+1. Let |p| be |pickRate| * (|states| - 1) / |states|.
+1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
+
+Note: This algorithm computes the channel capacity [[CHAN]] of a q-ary symmetric channel [[Q-SC]].
+
 <h3 algorithm id="parsing-source-registration">Parsing source-registration JSON</h3>
 
 To <dfn>parse an attribution destination</dfn> from a [=string=] |str|:
@@ -1745,7 +1756,7 @@ To <dfn>parse aggregation keys</dfn> given an [=ordered map=] |map|:
 
 Issue: Determine whether to limit [=string/length=] or [=string/code point length=] for |key| above.
 
-To <dfn>obtain effective windows</dfn> given a [=source type=] |sourceType|,
+To <dfn>obtain default effective windows</dfn> given a [=source type=] |sourceType|,
 a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 
 1. Let |deadlines| be «» if |sourceType| is "<code>[=source type/event=]</code>", else « 2 days, 7 days ».
@@ -1764,6 +1775,41 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
     1. [=list/Append=] |window| to |windows|.
     1. Set |lastEnd| to |lastEnd| + |deadline|.
 1. Return |windows|.
+
+To <dfn>parse report windows</dfn> given an [=ordered map=] |map|, a [=moment=] |sourceTime|,
+and a [=list=] of [=event-level report windows=] |default|:
+
+1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=event-level report window/end=] of the last element of |default|.
+1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
+1. Let |values| be |map|["`event_report_windows`"].
+1. If |values| is not a [=map=], return error.
+1. Let |startDuration| be 0 seconds.
+1. If |values|["`start_time`"] [=map/exists=]:
+    1. Set |start| to the result of applying the <a spec="html">rules for parsing integers</a> with |values|["`start_time`"].
+    1. If |start| is an error, return error.
+    1. If |start| is less than 0, return error.
+    1. Set |startDuration| to |start| seconds.
+    1. If |startDuration| is greater than |defaultEndDuration|, return error.
+1. If |values|["`end_times`"] does not [=map/exist=], return error.
+1. Let |endDurations| be |values|["`end_times`"].
+1. If the [=list/size=] of |endDurations| is greater than 5, return error.
+1. Let |windows| be an [=list/is empty=] [=list=].
+1. [=list/iterate|For each=] |elt| of |endDurations|:
+    1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
+    1. If |end| is an error, return error
+    1. Let |endDuration| be |end| seconds.
+    1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
+    1. If |endDuration| <= |startDuration|, return error.
+    1. Let |window| be a new [=event-level report window=] whose items are
+
+        : [=event-level report window/start=]
+        :: |sourceTime| + |startDuration|
+        : [=event-level report window/end=]
+        :: |sourceTime| + |endDuration|
+
+    1. [=list/append=] |window| to |windows|.
+    1. Set |startDuration| to |endDuration|.
+1. Return |windows|
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
@@ -1803,14 +1849,15 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. If |aggregationKeys| is null, return null.
 1. Let |triggerDataCardinality| be the user agent's
     [=navigation-source trigger data cardinality=].
-1. Let |maxAttributionsPerSource| be the user agent's
-    [=max attributions per navigation source=].
 1. If |sourceType| is "<code>[=source type/event=]</code>":
     1. Round |expiry| away from zero to the nearest day (86400 seconds).
     1. Set |triggerDataCardinality| to the user agent's
         [=event-source trigger data cardinality=].
-    1. Set |maxAttributionsPerSource| to the user agent's
-        [=max attributions per event source=].
+1. Let |maxAttributionsPerSource| be the result of running
+    [=parse an optional 64-bit signed integer=] with |value|, "`max_event_level_reports`", and
+    [=default event-level attributions per source=][|sourceType|].
+1. If |maxAttributionsPerSource| is an error, return null.
+1. If |maxAttributionsPerSource| is greater than 20, return null.
 1. Let |eventReportWindow| be the result of running [=parse a duration=] with
     |value|, "`event_report_window`", and ([=min report window=], |expiry|).
 1. If |eventReportWindow| is an error, return null.
@@ -1821,7 +1868,10 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to |value|["`debug_reporting`"].
 
-1. Let |eventReportWindows| be the result of [=obtaining effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
+1. Let |eventReportWindows| be the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
+1. If |value|["`event_report_window`"] does not [=map/exist=]:
+    1. Let |eventReportWindows| be the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
+1. If |eventReportWindows| is an error, return null.
 1. Let |aggregatableReportWindow| be a new [=report window=] with the following items:
 
     : [=report window/start=]
@@ -1839,6 +1889,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |triggerDataCardinality|
 
 1. Let |epsilon| be the user agent's [=randomized response epsilon=].
+1. If the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon| is greater than
+    [=max event-level channel capacity per source=][|sourceType|], return null.
 
 1. Let |source| be a new [=attribution source=] struct whose items are:
 
@@ -1864,6 +1916,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |sourceTime|
     : [=attribution source/source type=]
     :: |sourceType|
+    : [=attribution source/max number of event-level reports=]
+    :: |maxAttributionsPerSource|
     : [=attribution source/randomized response=]
     :: The result of [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
     : [=attribution source/randomized trigger rate=]
@@ -2623,11 +2677,8 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
          with "<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |trigger|, |sourceToAttribute| and |report|.
      1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. Let |maxAttributionsPerSource| be the user agent's [=max attributions per navigation source=].
-1. If |sourceToAttribute|'s [=attribution source/source type=] is "<code>[=source type/event=]</code>", set
-    |maxAttributionsPerSource| to the user agent's [=max attributions per event source=].
 1. If |sourceToAttribute|'s [=attribution source/number of event-level reports=] value is equal to
-    |maxAttributionsPerSource|, then:
+    |sourceToAttribute|'s [=attribution source/max number of event-level reports=], then:
     1. Let |matchingReports| be all entries in the [=event-level report cache=] where all of the following are true:
          * entry's [=event-level report/report time=] and |report|'s [=event-level report/report time=] are equal.
          * entry's [=event-level report/source identifier=] [=string/is=] |report|'s [=event-level report/source identifier=]
@@ -3659,15 +3710,13 @@ a particular [=attribution source=]. We model this using the notion of channel c
 it is possible to model its output as a noisy channel. The number of input/output symbols is governed by its associated
 [=obtain a set of possible trigger states|set of possible trigger states=]. With the randomized response mechanism,
 this allows us to analyze the output as a q-ary symmetric channel [[Q-SC]], with `q` equal to the [=set/size=] of the
-[=obtain a set of possible trigger states|set of possible trigger states=].
-
-The channel capacity of a q-ary symmetric channel is equal to `log2(q) - h(p) - p log2(q - 1)` where
-`h` is the binary entropy function [[BIN-ENT]] and `p = p'(q-1) / q` where `p'` is the
-[=obtain a randomized source response pick rate|pick rate=].
+[=obtain a set of possible trigger states|set of possible trigger states=]. This is normatively defined in the
+[=compute the channel capacity of a source=] algorithm.
 
 Note that [=source type/navigation=] [=attribution sources=] and [=source type/event=] [=attribution sources=] may
 have different channel capacities, given that [=source type/event=] [=attribution sources=] can be registered without
-[=user activation=] or top-level navigation.
+[=user activation=] or top-level navigation. Maximum capacity for each type is governed by the vendor-defined
+[=max event-level channel capacity per source=].
 
 ### Aggregatable reports ### {#cross-site-information-disclosure-aggregatable-reports}
 

--- a/index.bs
+++ b/index.bs
@@ -741,6 +741,7 @@ It has the following constraints:
 
 * Elements are in ascending order based on their [=event-level report window/start=].
 * Every element's [=event-level report window/start=] is equal to the previous element's [=event-level report window/end=], if it exists.
+* There is at least one element in the list.
 
 <h3 dfn-type=dfn>Attribution source</h3>
 
@@ -1807,6 +1808,7 @@ and an [=event-level report window list=] |default|:
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
+1. If |endDurations| is [=list/empty=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
     1. If |elt| is not a [=string=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -1816,6 +1816,7 @@ and an [=event-level report window list=] |default|:
     1. If |end| is an error, return an error.
     1. Let |endDuration| be |end| seconds.
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
+    1. If |endDuration| is less than 1 hour, set |endDuration| to 1 hour.
     1. If |endDuration| less than or equal to |startDuration|, return an error.
     1. Let |window| be a new [=event-level report window=] whose items are
 
@@ -1823,8 +1824,6 @@ and an [=event-level report window list=] |default|:
         :: |sourceTime| + |startDuration|
         : [=event-level report window/end=]
         :: |sourceTime| + |endDuration|
-
-    Issue: Set a stricter minimum for |endDuration|.
 
     1. [=list/Append=] |window| to |windows|.
     1. Set |startDuration| to |endDuration|.

--- a/index.bs
+++ b/index.bs
@@ -1794,7 +1794,7 @@ and a [=list=] of [=event-level report windows=] |default|:
 1. If |values|["`end_times`"] does not [=map/exist=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than 5, return an error.
-1. Let |windows| be an [=list/is empty=] [=list=].
+1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |elt| of |endDurations|:
     1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
     1. If |end| is an error, return an error.

--- a/index.bs
+++ b/index.bs
@@ -735,6 +735,13 @@ A <dfn>report window</dfn> is a [=struct=] with the following items:
 
 </dl>
 
+
+An <dfn>event-level report window list</dfn> is a [=list=] of [=event-level report windows=].
+It has the following constraints:
+
+* Elements are in ascending order based on their [=event-level report window/start=].
+* Every element's [=event-level report window/start=] is equal to the previous element's [=event-level report window/end=], if it exists.
+
 <h3 dfn-type=dfn>Attribution source</h3>
 
 An attribution source is a [=struct=] with the following items:
@@ -755,7 +762,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>expiry</dfn>
 :: A [=duration=].
 : <dfn>event-level report windows</dfn>
-:: A [=list=] of [=report windows=].
+:: An [=event-level report window list=].
 : <dfn>aggregatable report window</dfn>
 :: A [=report window=].
 : <dfn>priority</dfn>
@@ -1785,7 +1792,7 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-and a [=list=] of [=event-level report windows=] |default|:
+and a [=event-level report window list=] |default|:
 
 1. [=Assert=]: |default| is not [=list/is empty|empty=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=event-level report window/end=] of the last element of |default|.
@@ -1814,6 +1821,8 @@ and a [=list=] of [=event-level report windows=] |default|:
         :: |sourceTime| + |startDuration|
         : [=event-level report window/end=]
         :: |sourceTime| + |endDuration|
+
+    Issue: Set a stricter minimum for |endDuration|.
 
     1. [=list/Append=] |window| to |windows|.
     1. Set |startDuration| to |endDuration|.
@@ -1877,8 +1886,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     |debugReportingEnabled| to |value|["`debug_reporting`"].
 
 1. Let |eventReportWindows| be the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
-1. If |value|["`event_report_window`"] does not [=map/exist=]:
-    1. Set |eventReportWindows| to the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
+1. If both |value|["`event_report_window`"] and |value|["`event_report_windows`"] [=map/exist=], return null.
+1. Set |eventReportWindows| to the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
 1. If |eventReportWindows| is an error, return null.
 1. Let |aggregatableReportWindow| be a new [=report window=] with the following items:
 
@@ -2901,8 +2910,8 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 To <dfn>check whether a moment falls within a window</dfn> given a [=moment=] |moment| and
 a [=report window=] |window|:
 
-1. Return |moment| >= [=report window/start=]
-    and |moment| < |window|'s [=report window/end=].
+1. Return whether |moment| is greater than or equal to [=event-level report window/start=]
+    and |moment| is less than |window|'s [=event-level report window/end=].
 
 To <dfn>obtain a report time from a window</dfn> given a [=moment=] |sourceTime| and
 a [=report window=] |window|:

--- a/index.bs
+++ b/index.bs
@@ -1795,23 +1795,21 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
 and a [=report window list=] |default|:
 
-1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |startDuration| be 0 seconds.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
 1. If |endDurations| [=list/is empty=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
-1. [=list/iterate|For each=] |elt| of |endDurations|:
-    1. If |elt| is not a [=string=], return an error.
-    1. Let |end| be the result of applying the <a spec="html">rules for parsing integers</a> to |elt|.
-    1. If |end| is an error, return an error.
+1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
+1. Let |startDuration| be 0 seconds.
+1. [=list/iterate|For each=] |end| of |endDurations|:
+    1. If |end| is not an integer, return an error.
     1. Let |endDuration| be |end| seconds.
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
-    1. If |endDuration| is less than 1 hour, set |endDuration| to 1 hour.
+    1. If |endDuration| is less than [=min report window=], set |endDuration| to [=min report window=].
     1. If |endDuration| less than or equal to |startDuration|, return an error.
     1. Let |window| be a new [=report window=] whose items are
 


### PR DESCRIPTION
This PR depends on https://github.com/WICG/attribution-reporting-api/pull/855. This PR specifies a partial version of https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md, i.e. everything except the `trigger_specs` behavior.

In particular, this allows for a wider range of configurability in the event-level reports, in the form of:
- Allows specifying anywhere between 1 and 5 reporting windows, with (mostly) arbitrary times
- Allows specifying anywhere between 1 and 20 total reports

Fixes #736
Fixes #730 
Addresses #849 % channel capacity limits


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/856.html" title="Last updated on Jul 17, 2023, 4:10 PM UTC (51dbcd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/856/b5d8bdf...51dbcd8.html" title="Last updated on Jul 17, 2023, 4:10 PM UTC (51dbcd8)">Diff</a>