### PR TITLE
Use current wall time instead of the one on environment settings object

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1469,8 +1469,7 @@ To <dfn>make a background attributionsrc request</dfn> given a [=URL=] |url|, an
     :   [=request/Attribution Reporting eligibility=]
     ::  |eligibility|
 1. [=Fetch=] |request| with [=fetch/processResponse=] being
-    [=process an attributionsrc response=] with |contextOrigin|, |eligibility|,
-    and |context|.
+    [=process an attributionsrc response=] with |contextOrigin| and |eligibility|.
 
 Issue: Audit other properties on |request| and set them properly.
 
@@ -1501,8 +1500,7 @@ To <dfn>make background attributionsrc requests</dfn> given an
 Issue: Consider allowing the user agent to limit the size of |tokens|.
 
 To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
-|contextOrigin|, an [=eligibility=] |eligibility|, an
-[=environment settings objects=] |context|, and a [=response=] |response|:
+|contextOrigin|, an [=eligibility=] |eligibility|, and a [=response=] |response|:
 
 1. [=Validate a background attributionsrc eligibility|Validate=] |eligibility|.
 1. Let |reportingOrigin| be |response|'s [=response/URL=]'s [=url/origin=].
@@ -1531,8 +1529,7 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
             1. Let |source| be the result of running
                 [=parse source-registration JSON=] with |sourceHeader|,
                 |contextOrigin|, |reportingOrigin|,
-                "<code>[=source type/navigation=]</code>", and |context|'s
-                [=current wall time=].
+                "<code>[=source type/navigation=]</code>", and [=current wall time=].
             1. If |source| is not null, [=process an attribution source|process=]
                 |source|.
         1. If |osSourceURLs| is not null and the user agent supports OS
@@ -1546,8 +1543,7 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
             1. Let |source| be the result of running
                 [=parse source-registration JSON=] with |sourceHeader|,
                 |contextOrigin|, |reportingOrigin|,
-                "<code>[=source type/event=]</code>", and |context|'s
-                [=current wall time=].
+                "<code>[=source type/event=]</code>", and [=current wall time=].
             1. If |source| is not null,
                 [=process an attribution source|process=] |source|.
         1. If |triggerHeader| is not null:
@@ -1556,8 +1552,7 @@ To <dfn>process an attributionsrc response</dfn> given a [=suitable origin=]
             1. Let |privateStateTokens| be an [=list/is empty|empty=] [=list=].
             1. Let |trigger| be the result of running
                 [=create an attribution trigger=] with |triggerHeader|
-                |destinationSite|, |reportingOrigin|, |privateStateTokens|, and
-                |context|'s [=current wall time=].
+                |destinationSite|, |reportingOrigin|, |privateStateTokens|, and [=current wall time=].
             1. If |trigger| is not null:
                 1. [=Maybe defer and then complete trigger attribution=] with |trigger|.
         1. If |osSourceURLs| is not null and the user agent supports OS
@@ -2979,16 +2974,15 @@ Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/
 The user agent MUST periodically [=set/iterate=] over its [=event-level report cache=] and
 [=aggregatable report cache=] and run [=queue a report for delivery=] on each item.
 
-To <dfn>queue a report for delivery</dfn> given an [=attribution report=] |report|
-and an [=environment settings objects=] |context|, run the following steps [=in parallel=]:
+To <dfn>queue a report for delivery</dfn> given an [=attribution report=] |report|, run the following steps [=in parallel=]:
 
 1. If |report|'s [=attribution report/delivered=] value is true, return.
 1. Set |report|'s [=attribution report/delivered=] value to true.
-1. If |report|'s [=attribution report/report time=] is less than |context|'s [=current wall time=], add an [=implementation-defined=] random non-negative [=duration=] to |report|'s [=attribution report/report time=].
+1. If |report|'s [=attribution report/report time=] is less than [=current wall time=], add an [=implementation-defined=] random non-negative [=duration=] to |report|'s [=attribution report/report time=].
 
     Note: On startup, it is possible the user agent will need to send many reports whose report times passed while the browser was
      closed. Adding random delay prevents temporal joining of reports from different [=attribution source/source origin=]s.
-1. Wait until |context|'s [=current wall time=] is equal to |report|'s [=attribution report/report time=].
+1. Wait until [=current wall time=] is equal to |report|'s [=attribution report/report time=].
 1. Optionally, wait a further [=implementation-defined=] [=duration=].
 
     Note: This is intended to allow user agents to optimize device resource usage.


### PR DESCRIPTION
The implementation uses base::Time::Now() which doesn't consider cross origin isolated contexts as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/858.html" title="Last updated on Jun 22, 2023, 12:53 PM UTC (451d320)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/858/d91215b...linnan-github:451d320.html" title="Last updated on Jun 22, 2023, 12:53 PM UTC (451d320)">Diff</a>