### PR TITLE
Simplify "obtain an event-level report delivery time"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2787,11 +2787,11 @@ To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution 
 |source| and a [=moment=] |triggerTime|:
 
 1. Let |windows| be |source|'s [=attribution source/event-level report windows=].
-1. Let |windowToUse| be the last item in |windows|.
 1. [=list/iterate|For each=] |window| of |windows|:
-    1. If |triggerTime| [=check whether a moment falls within a window|falls within=] |window|, set |windowToUse| to |window|.
-1. Return the result of running [=obtain a report time from a window=] with
-    |source|'s [=attribution source/source time=] and |window|.
+    1. If |triggerTime| [=check whether a moment falls within a window|falls within=] |window|,
+        return to the result of running [=obtain a report time from a window=] with |source|'s
+        [=attribution source/source time=] and |window|.
+1. [=Assert=]: not reached.
 
 To <dfn>obtain an aggregatable report delivery time</dfn> given a [=moment=]
 |triggerTime|, perform the following steps. They return a [=moment=].

--- a/index.bs
+++ b/index.bs
@@ -2789,7 +2789,7 @@ To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution 
 1. Let |windows| be |source|'s [=attribution source/event-level report windows=].
 1. [=list/iterate|For each=] |window| of |windows|:
     1. If |triggerTime| [=check whether a moment falls within a window|falls within=] |window|,
-        return to the result of running [=obtain a report time from a window=] with |source|'s
+        return the result of running [=obtain a report time from a window=] with |source|'s
         [=attribution source/source time=] and |window|.
 1. [=Assert=]: not reached.
 


### PR DESCRIPTION
The current algorithm hedges and falls back to the last window if no windows match. This shouldn't be possible, so assert that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/869.html" title="Last updated on Jun 26, 2023, 9:25 PM UTC (f3be61c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/869/0a5b869...f3be61c.html" title="Last updated on Jun 26, 2023, 9:25 PM UTC (f3be61c)">Diff</a>