### PR TITLE
Extract constant for max destinations per source

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1118,6 +1118,10 @@ controls the maximum [=set/size=] of each [=map/value=] of an
 <dfn>Attribution rate-limit window</dfn> is a positive [=duration=] that
 controls the rate-limiting window for attribution. Its value is 30 days.
 
+<dfn>Max destinations per source</dfn> is a positive integer that controls the
+maximum [=set/size=] of an [=attribution source=]'s
+[=attribution source/attribution destinations=]. Its value is 3.
+
 # Vendor-Specific Values # {#vendor-specific-values}
 
 <dfn>Max aggregation keys per attribution</dfn> is a positive integer that
@@ -1639,7 +1643,8 @@ To <dfn>parse attribution destinations</dfn> from a [=map=] |map|:
     1. Let |destination| be the result of [=parse an attribution destination=] with |value|.
     1. If |destination| is null, return null.
     1. [=set/Append=] |destination| to |result|.
-1. If |result| [=set/is empty=] or its [=set/size=] is greater than 3, return null.
+1. If |result| [=set/is empty=] or its [=set/size=] is greater than the
+    [=max destinations per source=], return null.
 1. Return |result|.
 
 To <dfn>parse an expiry</dfn> given a [=map=] |map|, a [=string=] |key|, and a


### PR DESCRIPTION
For ease of linking and lookup.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/871.html" title="Last updated on Jun 27, 2023, 1:52 PM UTC (1fe0e52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/871/2f60ca5...apasel422:1fe0e52.html" title="Last updated on Jun 27, 2023, 1:52 PM UTC (1fe0e52)">Diff</a>