### PR TITLE
Set the min event-report-window to 1 hour

### DIFF
--- a/header-validator/data.source.js
+++ b/header-validator/data.source.js
@@ -11,13 +11,13 @@ export const testCases = [
   {
     name: "all-fields",
     json: `{
-      "aggregatable_report_window": "-1",
+      "aggregatable_report_window": "1",
       "aggregation_keys": {"a": "0xf"},
       "debug_key": "1",
       "debug_reporting": true,
       "destination": "https://a.test",
-      "event_report_window": "-2",
-      "expiry": "-3",
+      "event_report_window": "2",
+      "expiry": "3",
       "filter_data": {"b": ["c"]},
       "priority": "2",
       "source_event_id": "3"
@@ -272,7 +272,18 @@ export const testCases = [
     }`,
     expectedErrors: [{
       path: ["aggregatable_report_window"],
-      msg: "must be an int64 (must match /^-?[0-9]+$/)",
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
+    }],
+  },
+  {
+    name: "aggregatable-report-window-wrong-sign",
+    json: `{
+      "destination": "https://a.test",
+      "aggregatable_report_window": "-1"
+    }`,
+    expectedErrors: [{
+      path: ["aggregatable_report_window"],
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
     }],
   },
 
@@ -295,10 +306,20 @@ export const testCases = [
     }`,
     expectedErrors: [{
       path: ["event_report_window"],
-      msg: "must be an int64 (must match /^-?[0-9]+$/)",
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
     }],
   },
-
+  {
+    name: "event-report-window-wrong-sign",
+    json: `{
+      "destination": "https://a.test",
+      "event_report_window": "-1"
+    }`,
+    expectedErrors: [{
+      path: ["event_report_window"],
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
+    }],
+  },
   {
     name: "expiry-wrong-type",
     json: `{
@@ -318,7 +339,18 @@ export const testCases = [
     }`,
     expectedErrors: [{
       path: ["expiry"],
-      msg: "must be an int64 (must match /^-?[0-9]+$/)",
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
+    }],
+  },
+  {
+    name: "expiry-wrong-sign",
+    json: `{
+      "destination": "https://a.test",
+      "expiry": "-1"
+    }`,
+    expectedErrors: [{
+      path: ["expiry"],
+      msg: "must be a uint64 (must match /^[0-9]+$/)",
     }],
   },
 

--- a/header-validator/validate-json.js
+++ b/header-validator/validate-json.js
@@ -245,13 +245,13 @@ const aggregationKeys = object((state, key, value) => {
 export function validateSource(source) {
   const state = new State()
   state.validate(source, {
-    aggregatable_report_window: optional(int64),
-    event_report_window: optional(int64),
+    aggregatable_report_window: optional(uint64),
+    event_report_window: optional(uint64),
     aggregation_keys: optional(aggregationKeys),
     debug_key: optional(uint64),
     debug_reporting: optional(bool),
     destination: required(destinationValue),
-    expiry: optional(int64),
+    expiry: optional(uint64),
     filter_data: optional(filterData()),
     priority: optional(int64),
     source_event_id: optional(uint64),

--- a/index.bs
+++ b/index.bs
@@ -1690,19 +1690,18 @@ To <dfn>parse attribution destinations</dfn> from a [=map=] |map|:
     [=max destinations per source=], return null.
 1. Return |result|.
 
-To <dfn>parse an expiry</dfn> given a [=map=] |map|, a [=string=] |key|, and a
-positive [=duration=] |default|:
+To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, a
+tuple of [=durations=] (|clampStart|, |clampEnd|):
 
-1. [=Assert=]: |default| is greater than or equal to 1 day.
-1. [=Assert=]: |default| is less than or equal to the [=max source expiry=].
 1. Let |seconds| be the result of running
     [=parse an optional 64-bit signed integer=] with |map|, |key|, and null.
 1. If |seconds| is an error, return an error.
-1. If |seconds| is null, return |default|.
-1. Let |expiry| be |seconds| seconds.
-1. If |expiry| is less than 1 day, return 1 day.
-1. If |expiry| is greater than |default|, return |default|.
-1. Return |expiry|.
+1. If |seconds| is null, return |clampEnd|.
+1. If |seconds| is less than 0, return an error.
+1. Let |duration| be the [=duration=] of |seconds| seconds.
+1. If |duration| is less than |clampStart|, return |clampStart|.
+1. If |duration| is greater than |clampEnd|, return |clampEnd|.
+1. Return |duration|.
 
 Issue: Consider rejecting out-of-bounds values instead of silently clamping.
 
@@ -1757,8 +1756,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     [=parse an optional 64-bit unsigned integer=] with |value|,
     "`source_event_id`", and 0.
 1. If |sourceEventId| is an error, return null.
-1. Let |expiry| be the result of running [=parse an expiry=] with |value|,
-    "`expiry`", and the [=max source expiry=].
+1. Let |expiry| be the result of running [=parse a duration=] with |value|,
+    "`expiry`", and (1 day, [=max source expiry=]).
 1. If |expiry| is an error, return null.
 1. Let |priority| be the result of running
     [=parse an optional 64-bit signed integer=] with |value|, "`priority`", and
@@ -1789,11 +1788,11 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
         [=event-source trigger data cardinality=].
     1. Set |maxAttributionsPerSource| to the user agent's
         [=max attributions per event source=].
-1. Let |eventReportWindow| be the result of running [=parse an expiry=] with
-    |value|, "`event_report_window`", and |expiry|.
+1. Let |eventReportWindow| be the result of running [=parse a duration=] with
+    |value|, "`event_report_window`", and (1 hour, |expiry|).
 1. If |eventReportWindow| is an error, return null.
-1. Let |aggregatableReportWindowEnd| be the result of running [=parse an expiry=]
-    with |value|, "`aggregatable_report_window`", and |expiry|.
+1. Let |aggregatableReportWindowEnd| be the result of running [=parse a duration=]
+    with |value|, "`aggregatable_report_window`", and (1 hour, |expiry|).
 1. If |aggregatableReportWindowEnd| is an error, return null.
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set

--- a/index.bs
+++ b/index.bs
@@ -1131,9 +1131,15 @@ However attribution data is inherently cross-site, and operations on storage wou
 
 # Constants # {#constants}
 
-<dfn>Max source expiry</dfn> is a positive [=duration=] that controls the
-maximum value that can be used as an [=attribution source/expiry=]. Its value is
-30 days.
+<dfn>Valid source expiry range</dfn> is a 2-tuple of positive [=durations=] that controls the
+minimum and maximum value that can be used as an [=attribution source/expiry=], respectively.
+Its value is (1 day, 30 days).
+
+<dfn>Min report window</dfn> is a positive [=duration=] that controls the
+minimum [=duration from=] an [=attribution source's=] [=attribution source/source time=]
+and any [=report window/end=] in [=attribution source/aggregatable report window=] or
+[=attribution source/event-level report windows=].
+Its value is 1 hour.
 
 <dfn>Max entries per filter data</dfn> is a positive integer that controls the
 maximum [=map/size=] of an [=attribution source=]'s [=attribution source/filter data=].
@@ -1695,10 +1701,9 @@ tuple of [=durations=] (|clampStart|, |clampEnd|):
 
 1. [=Assert=]: |clampStart| < |clampEnd|.
 1. Let |seconds| be the result of running
-    [=parse an optional 64-bit signed integer=] with |map|, |key|, and null.
+    [=parse an optional 64-bit unsigned integer=] with |map|, |key|, and null.
 1. If |seconds| is an error, return an error.
 1. If |seconds| is null, return |clampEnd|.
-1. If |seconds| is less than 0, return an error.
 1. Let |duration| be the [=duration=] of |seconds| seconds.
 1. If |duration| is less than |clampStart|, return |clampStart|.
 1. If |duration| is greater than |clampEnd|, return |clampEnd|.
@@ -1758,7 +1763,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     "`source_event_id`", and 0.
 1. If |sourceEventId| is an error, return null.
 1. Let |expiry| be the result of running [=parse a duration=] with |value|,
-    "`expiry`", and (1 day, [=max source expiry=]).
+    "`expiry`", and [=valid source expiry range=].
 1. If |expiry| is an error, return null.
 1. Let |priority| be the result of running
     [=parse an optional 64-bit signed integer=] with |value|, "`priority`", and
@@ -1790,10 +1795,10 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     1. Set |maxAttributionsPerSource| to the user agent's
         [=max attributions per event source=].
 1. Let |eventReportWindow| be the result of running [=parse a duration=] with
-    |value|, "`event_report_window`", and (1 hour, |expiry|).
+    |value|, "`event_report_window`", and ([=min report window=], |expiry|).
 1. If |eventReportWindow| is an error, return null.
 1. Let |aggregatableReportWindowEnd| be the result of running [=parse a duration=]
-    with |value|, "`aggregatable_report_window`", and (1 hour, |expiry|).
+    with |value|, "`aggregatable_report_window`", and ([=min report window=], |expiry|).
 1. If |aggregatableReportWindowEnd| is an error, return null.
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
@@ -2996,7 +3001,7 @@ To <dfn>generate null reports</dfn> given an [=attribution trigger=] |trigger| a
         1. [=set/Append=] |nullReport| to the [=aggregatable report cache=].
         1. [=list/Append=] |nullReport| to |nullReports|.
 1. Otherwise:
-    1. Let |maxSourceExpiry| be [=max source expiry=].
+    1. Let |maxSourceExpiry| be [=valid source expiry range=][1].
     1. Round |maxSourceExpiry| away from zero to the nearest day (86400 seconds).
     1. Let |roundedAttributedSourceTime| be null.
     1. If |report| is not null, set |roundedAttributedSourceTime| to the result of [=obtaining rounded source time=] with |report|'s

--- a/index.bs
+++ b/index.bs
@@ -1690,9 +1690,10 @@ To <dfn>parse attribution destinations</dfn> from a [=map=] |map|:
     [=max destinations per source=], return null.
 1. Return |result|.
 
-To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, a
+To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, and a
 tuple of [=durations=] (|clampStart|, |clampEnd|):
 
+1. [=Assert=]: |clampStart| < |clampEnd|.
 1. Let |seconds| be the result of running
     [=parse an optional 64-bit signed integer=] with |map|, |key|, and null.
 1. If |seconds| is an error, return an error.

--- a/schema/source.schema.json
+++ b/schema/source.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "aggregatable_report_window": {
-      "$ref": "#/$defs/signed_duration_in_seconds"
+      "$ref": "#/$defs/unsigned_duration_in_seconds"
     },
     "aggregation_keys": {
       "type": "object",
@@ -40,10 +40,10 @@
       ]
     },
     "event_report_window": {
-      "$ref": "#/$defs/signed_duration_in_seconds"
+      "$ref": "#/$defs/unsigned_duration_in_seconds"
     },
     "expiry": {
-      "$ref": "#/$defs/signed_duration_in_seconds"
+      "$ref": "#/$defs/unsigned_duration_in_seconds"
     },
     "filter_data": {
       "type": "object",
@@ -86,8 +86,8 @@
       "type": "string",
       "pattern": "^-?[0-9]+$"
     },
-    "signed_duration_in_seconds": {
-      "$ref": "#/$defs/signed_base10_integer",
+    "unsigned_duration_in_seconds": {
+      "$ref": "#/$defs/unsigned_base10_integer",
       "description": "Seconds",
       "default": "2592000"
     },


### PR DESCRIPTION
Fixes #561. Because this change only addresses the report windows and not the expiry, the privacy attack outlined in https://github.com/WICG/attribution-reporting-api/issues/561#issuecomment-1262347679 is not possible.

This PR also makes one behavior change: if durations are passed in with negative values, we error out rather than clamping.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/876.html" title="Last updated on Jun 29, 2023, 2:34 PM UTC (558b39b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/876/fe4f2a4...558b39b.html" title="Last updated on Jun 29, 2023, 2:34 PM UTC (558b39b)">Diff</a>