### PR TITLE
Add caveat about event-level trigger priority to reporting-delay-concern mitigations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3809,4 +3809,4 @@ Possible mitigations:
     effectively hide both the user's IP address and their online-offline
     presence from the reporting origin. Compared to the previous mitigation, the
     proxy server could itself handle the [=event-level report/trigger priority=]
-    functionality.
+    functionality, at the cost of increased complexity in the proxy.

--- a/index.bs
+++ b/index.bs
@@ -3773,7 +3773,9 @@ Possible mitigations:
     reporting origin for attribution to the report, which weakens the
     attribution-side privacy controls of the API. In particular,
     this destroys the differential privacy framework we have
-    for event-level reports.
+    for event-level reports. It would also make the
+    [=event-level report/trigger priority=] functionality impossible, as there
+    would be no way to replace a lower-priority report that was already sent.
 1. Use a trusted proxy server to send reports: This effectively moves the
     reporting origin into the report body, so only the proxy server would be
     visible to the network administrator.
@@ -3799,8 +3801,12 @@ Possible mitigations:
     as the original request made to the reporting origin is in close temporal
     proximity to the report request. However, it increases the likelihood that
     the reporting origin can correlate the two requests, which weakens the
-    attribution-side privacy controls of the API.
+    attribution-side privacy controls of the API. It would also make the
+    [=event-level report/trigger priority=] functionality impossible, as there
+    would be no way to replace a lower-priority report that was already sent.
 1. Send reports immediately to a trusted proxy server, which would itself send
     the report to the reporting origin with additional delay. This would
     effectively hide both the user's IP address and their online-offline
-    presence from the reporting origin.
+    presence from the reporting origin. Compared to the previous mitigation, the
+    proxy server could itself handle the [=event-level report/trigger priority=]
+    functionality.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/881.html" title="Last updated on Jul 6, 2023, 4:58 PM UTC (8e40595)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/881/5176031...apasel422:8e40595.html" title="Last updated on Jul 6, 2023, 4:58 PM UTC (8e40595)">Diff</a>