### PR TITLE
Remove erroneous 30-day report window from default navigation config

### DIFF
--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -175,7 +175,7 @@ Here are the default configurations for event and navigation sources. Especially
   {
     "trigger_data": [0, 1, 2, 3, 4, 5, 6, 7],
     "event_report_windows": {
-      "end_times": [<2 days>, <7 days>, <30 days>]
+      "end_times": [<2 days>, <7 days>]
     }
   }],
   "max_event_level_reports": 3


### PR DESCRIPTION
Presumably this 30-day value was meant to represent the reporting window corresponding to the source's expiry, but that window is implicit, as indicated in the correctly defined default configuration for event sources .