### PR TITLE
Add non-normative section for flex-event specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3810,3 +3810,23 @@ Possible mitigations:
     presence from the reporting origin. Compared to the previous mitigation, the
     proxy server could itself handle the [=event-level report/trigger priority=]
     functionality, at the cost of increased complexity in the proxy.
+
+# Flexible event-level configurations # {#flexible-event-level-configurations}
+
+*This section is non-normative.*
+
+This is a more formal description of
+<a href="https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md">the proposal of the same name</a>
+and may or may not be incorporated into the normative sections in the future.
+
+## Structures ## {#flexible-event-level-structures}
+
+A <dfn>summary window operator</dfn> is one of the following:
+
+<dl dfn-for="summary window operator">
+: "<dfn><code>count</code></dfn>"
+:: Contributions are counted.
+: "<dfn><code>value_sum</code></dfn>"
+:: Contribution values are summed.
+
+</dl>

--- a/index.bs
+++ b/index.bs
@@ -3825,8 +3825,8 @@ A <dfn>summary window operator</dfn> is one of the following:
 
 <dl dfn-for="summary window operator">
 : "<dfn><code>count</code></dfn>"
-:: Contributions are counted.
+:: Within a reporting window, triggers are counted.
 : "<dfn><code>value_sum</code></dfn>"
-:: Contribution values are summed.
+:: Within a reporting window, trigger values are summed.
 
 </dl>


### PR DESCRIPTION
I would add even more definitions here for the trigger spec structure itself, but a lot of that is dependent on choices for fixed-width arithmetic and reusing parts of #856.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/890.html" title="Last updated on Jul 13, 2023, 4:31 PM UTC (9d9f44e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/890/892ff4d...apasel422:9d9f44e.html" title="Last updated on Jul 13, 2023, 4:31 PM UTC (9d9f44e)">Diff</a>