### PR TITLE
Fix use-before-def in "parse report windows" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1798,6 +1798,7 @@ and a [=report window list=] |default|:
 1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
+1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. Let |startDuration| be 0 seconds.
 1. If |map|["`start_time`"] [=map/exists=]:
     1. Let |start| be |map|["`start_time`"].
@@ -1809,7 +1810,6 @@ and a [=report window list=] |default|:
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
 1. If |endDurations| [=list/is empty=], return an error.
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
-1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. [=list/iterate|For each=] |end| of |endDurations|:
     1. If |end| is not an integer, return an error.
     1. Let |endDuration| be |end| seconds.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/893.html" title="Last updated on Jul 18, 2023, 12:54 PM UTC (e1f8bd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/893/e3c2036...apasel422:e1f8bd1.html" title="Last updated on Jul 18, 2023, 12:54 PM UTC (e1f8bd1)">Diff</a>