### PR TITLE
Require end_times durations to be positive

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1811,7 +1811,7 @@ and a [=report window list=] |default|:
 1. Let |windows| be an [=list/is empty|empty=] [=list=].
 1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. [=list/iterate|For each=] |end| of |endDurations|:
-    1. If |end| is not an integer, return an error.
+    1. If |end| is not a positive integer, return an error.
     1. Let |endDuration| be |end| seconds.
     1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
     1. If |endDuration| is less than [=min report window=], set |endDuration| to [=min report window=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/894.html" title="Last updated on Jul 18, 2023, 1:09 PM UTC (eef5e9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/894/e3c2036...apasel422:eef5e9e.html" title="Last updated on Jul 18, 2023, 1:09 PM UTC (eef5e9e)">Diff</a>