### PR TITLE
Allow source expiry and report_window durations to be integers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1744,7 +1744,9 @@ To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, and a
 tuple of [=durations=] (|clampStart|, |clampEnd|):
 
 1. [=Assert=]: |clampStart| < |clampEnd|.
-1. Let |seconds| be the result of running
+1. Let |seconds| be null.
+1. If |map|[|key|] [=map/exists=] and is a non-negative integer, set |seconds| to |map|[|key|].
+1. Otherwise, set |seconds| to the result of running
     [=parse an optional 64-bit unsigned integer=] with |map|, |key|, and null.
 1. If |seconds| is an error, return an error.
 1. If |seconds| is null, return |clampEnd|.


### PR DESCRIPTION
Their values are constrained to the ranges [86400, 2592000] and [3600, 2592000], respectively, and the corresponding fields in #856 are integers, not strings.

Part of #888.

We will update the header validator and JSON schema separately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/895.html" title="Last updated on Jul 18, 2023, 2:29 PM UTC (fa6b44e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/895/412bdd6...apasel422:fa6b44e.html" title="Last updated on Jul 18, 2023, 2:29 PM UTC (fa6b44e)">Diff</a>