### PR TITLE
Specify lookback window

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -713,7 +713,7 @@ A <dfn>filter config</dfn> is a [=struct=] with the following items:
 : <dfn>map</dfn>
 :: A [=filter map=].
 : <dfn>lookback window</dfn>
-:: A [=duration=].
+:: Null or a positive [=duration=].
 
 </dl>
 
@@ -1408,12 +1408,10 @@ To <dfn>parse filter config</dfn> given a |value|:
 
 1. If |value| is not a [=map=], return null.
 1. Let |lookbackWindow| be null.
-1. [=map/iterate|For each=] |filter| → |data| of |value|:
-    1. If |filter| is not equal to "`lookback-window`", [=iteration/continue=].
-    1. If |value| is not a non-negative integer, return null.
-    1. Set |lookbackWindow| to |value|.
-    1. [=map/Remove=] |value|[|filter|].
-    1. [=iteration/Break=].
+1. If |value|["`lookback-window`"] [=map/exists=]:
+    1. If |value|["`lookback_window`""] is not a non-negative integer, return null.
+    1. Let |lookbackWindow| be |value|["`lookback_window`""].
+    1. [=map/Remove=] |value|["`lookback_window`""].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.
 1. Let |filter| be a [=filter config=] with the items:
@@ -2465,12 +2463,12 @@ To <dfn>match [=filter values=] with negation</dfn> given a [=filter value=] |a|
 1. Return true.
 
 To <dfn>match an attribution source's filter data against a filter config</dfn> given an
-[=attribution source=] |source|, a [=filter config=] |filter|, and a [=boolean=]
+[=attribution source=] |source|, a [=filter config=] |filter|, a [=moment=] moment, and a [=boolean=]
 <dfn for="match an attribution source's filter data against a filter config"><var>isNegated</var></dfn>:
 
 1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].
 1. If |lookbackWindow| is not null:
-    1. If [=current wall time=] - |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
+    1. If |moment| - |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
         1. If |isNegated|, return true. Otherwise, return false. 
 
 1. Let |filterMap| be |filter|'s [=filter config/map=].
@@ -2491,21 +2489,21 @@ To <dfn>match an attribution source's filter data against a filter config</dfn> 
 1. Return true.
 
 To <dfn>match an attribution source's filter data against filters</dfn> given an
-[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, and a [=boolean=]
+[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, a [=moment=] |moment|, and a [=boolean=]
 <dfn for="match an attribution source's filter data against filters"><var>isNegated</var></dfn>:
 
 1. If |filters| [=list/is empty=], return true.
 1. [=list/iterate|For each=] |filter| of |filters|:
-    1. If the result of running [=match an attribution source's filter data against a filter config=] with |source|, |filter| and |isNegated| is true, return true.
+    1. If the result of running [=match an attribution source's filter data against a filter config=] with |source|, |filter|, |moment|, and |isNegated| is true, return true.
 1. Return false.
 
 To <dfn>match an attribution source's filter data against filters and negated filters</dfn> given an
-[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, and a [=list=] of [=filter configs=] |notFilters|:
+[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, a [=list=] of [=filter configs=] |notFilters|, and a [=moment=] |moment|:
 
 1. If the result of running [=match an attribution source's filter data against filters=] with
-    |source|, |filters|, and [=match an attribution source's filter data against filters/isNegated=] set to false is false, return false.
+    |source|, |filters|, |moment|, and [=match an attribution source's filter data against filters/isNegated=] set to false is false, return false.
 1. If the result of running [=match an attribution source's filter data against filters=] with
-    |source|, |notFilters|, and [=match an attribution source's filter data against filters/isNegated=] set to true is false, return false.
+    |source|, |notFilters|, |moment|, and [=match an attribution source's filter data against filters/isNegated=] set to true is false, return false.
 1. Return true.
 
 <h3 dfn id="should-block-attribution-for-attribution-limit">Should attribution be blocked by attribution rate limit</h3>
@@ -2576,9 +2574,10 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
 1. Let |aggregationKeys| be the result of [=map/clone|cloning=] |source|'s [=attribution source/aggregation keys=].
 1. [=list/iterate|For each=] |triggerData| of |trigger|'s [=attribution trigger/aggregatable trigger data=]:
     1. If the result of running [=match an attribution source's filter data against filters and negated filters=] with
-        |source|, |triggerData|'s [=aggregatable trigger data/filters=], and
-        |triggerData|'s [=aggregatable trigger data/negated filters=]
-        is false, [=iteration/continue=].
+        |source|, |triggerData|'s [=aggregatable trigger data/filters=],
+        |triggerData|'s [=aggregatable trigger data/negated filters=], and
+        |trigger|'s [=attribution trigger/trigger time=]
+        is false, [=iteration/continue=]:
     1. [=set/iterate|For each=] |sourceKey| of |triggerData|'s [=aggregatable trigger data/source keys=]:
         1. If |aggregationKeys|[|sourceKey|] does not [=map/exist=], [=iteration/continue=].
         1. [=map/Set=] |aggregationKeys|[|sourceKey|] to |aggregationKeys|[|sourceKey|] bitwise-OR |triggerData|'s
@@ -2703,8 +2702,9 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     [=attribution trigger/event-level trigger configurations=]:
     1. If the result of running
         [=match an attribution source's filter data against filters and negated filters=] with |sourceToAttribute|,
-        |config|'s [=event-level trigger configuration/filters=], and
-        |config|'s [=event-level trigger configuration/negated filters=] is true:
+        |config|'s [=event-level trigger configuration/filters=],
+        |config|'s [=event-level trigger configuration/negated filters=], and
+        |trigger|'s [=attribution trigger/trigger time=] is true:
         1. Set |matchedConfig| to |config|.
         1. [=iteration/Break=].
 1. If |matchedConfig| is null:
@@ -2796,8 +2796,9 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. Let |matchedDedupKey| be null.
 1. [=list/iterate|For each=] [=aggregatable dedup key=] |aggregatableDedupKey| of |trigger|'s [=attribution trigger/aggregatable dedup keys=]:
     1. If the result of running [=match an attribution source's filter data against filters and negated filters=]
-        with |sourceToAttribute|, |aggregatableDedupKey|'s [=aggregatable dedup key/filters=], and
-        |aggregatableDedupKey|'s [=aggregatable dedup key/negated filters=] is true:
+        with |sourceToAttribute|, |aggregatableDedupKey|'s [=aggregatable dedup key/filters=],
+        |aggregatableDedupKey|'s [=aggregatable dedup key/negated filters=], and 
+        |trigger|'s [=attribution trigger/trigger time=] is true:
         1. Set |matchedDedupKey| to |aggregatableDedupKey|'s [=aggregatable dedup key/dedup key=].
         1. [=iteration/Break=].
 1. If |matchedDedupKey| is not null and |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=]
@@ -2895,8 +2896,9 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 1. Let |sourceToAttribute| be |matchingSources|[0].
 1. If the result of running
     [=match an attribution source's filter data against filters and negated filters=] with
-    |sourceToAttribute|, |trigger|'s [=attribution trigger/filters=], and
-    |trigger|'s [=attribution trigger/negated filters=] is false,
+    |sourceToAttribute|, |trigger|'s [=attribution trigger/filters=],
+    |trigger|'s [=attribution trigger/negated filters=], and 
+    |trigger|'s [=attribution trigger/trigger time=] is false:
     1. Run [=obtain and deliver a debug report on trigger registration=]
         with "<code>[=trigger debug data type/trigger-no-matching-filter-data=]</code>",
         |trigger|, and |sourceToAttribute|.

--- a/index.bs
+++ b/index.bs
@@ -1408,9 +1408,9 @@ To <dfn>parse filter config</dfn> given a |value|:
 
 1. If |value| is not a [=map=], return null.
 1. Let |lookbackWindow| be null.
-1. If |value|["`lookback-window`"] [=map/exists=]:
-    1. If |value|["`lookback_window`""] is not a non-negative integer, return null.
-    1. Let |lookbackWindow| be the [=duration=] of |value|["`lookback_window`""] seconds.
+1. If |value|["`lookback_window`"] [=map/exists=]:
+    1. If |value|["`lookback_window`"] is not a non-negative integer, return null.
+    1. Set |lookbackWindow| be the [=duration=] of |value|["`lookback_window`"] seconds.
     1. [=map/Remove=] |value|["`lookback_window`""].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.

--- a/index.bs
+++ b/index.bs
@@ -707,6 +707,16 @@ A <dfn>filter value</dfn> is an [=ordered set=] of [=strings=].
 A <dfn>filter map</dfn> is an [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose
 [=map/value|values=] are [=filter values=].
 
+A <dfn>filter config</dfn> is a [=struct=] with the following items:
+
+<dl dfn-for="filter config">
+: <dfn>map</dfn>
+:: A [=filter map=].
+: <dfn>lookback window</dfn>
+:: A [=duration=].
+
+</dl>
+
 <h3 dfn-type=dfn>Suitable origin</h3>
 
 A suitable origin is an [=origin=] that is [=check if an origin is suitable|suitable=].
@@ -826,9 +836,9 @@ An aggregatable trigger data is a [=struct=] with the following items:
 : <dfn>source keys</dfn>
 :: An [=ordered set=] of [=strings=].
 : <dfn>filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 : <dfn>negated filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 
 </dl>
 
@@ -840,9 +850,9 @@ An aggregatable dedup key is a [=struct=] with the following items:
 : <dfn>dedup key</dfn>
 :: Null or a non-negative 64-bit integer.
 : <dfn>filters</dfn>
-:: A [=filter map=].
+:: A [=filter config=].
 : <dfn>negated filters</dfn>
-:: A [=filter map=].
+:: A [=filter config=].
 
 </dl>
 
@@ -858,9 +868,9 @@ An event-level trigger configuration is a [=struct=] with the following items:
 : <dfn>priority</dfn>
 :: A 64-bit integer.
 : <dfn>filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 : <dfn>negated filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 
 </dl>
 
@@ -894,9 +904,9 @@ An attribution trigger is a [=struct=] with the following items:
 : <dfn>reporting origin</dfn>
 :: A [=suitable origin=].
 : <dfn>filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 : <dfn>negated filters</dfn>
-:: A [=list=] of [=filter maps=].
+:: A [=list=] of [=filter configs=].
 : <dfn>debug key</dfn>
 :: Null or a non-negative 64-bit integer.
 : <dfn>event-level trigger configurations</dfn>
@@ -1394,21 +1404,40 @@ To <dfn>parse filter data</dfn> given a |value|:
 Issue: Determine whether to limit [=string/length=] or
 [=string/code point length=] for |filter| and |d| above.
 
+To <dfn>parse filter config</dfn> given a |value|:
+
+1. If |value| is not a [=map=], return null.
+1. Let |lookbackWindow| be null.
+1. [=map/iterate|For each=] |filter| → |data| of |value|:
+    1. If |filter| is not equal to "`lookback-window`", [=iteration/continue=].
+    1. If |value| is not a non-negative integer, return null.
+    1. Set |lookbackWindow| to |value|.
+    1. [=map/Remove=] |value|[|filter|].
+    1. [=iteration/Break=].
+1. Let |map| be the result of running [=parse filter data=] with |value|.
+1. If |map| is null, return null.
+1. Let |filter| be a [=filter config=] with the items:
+        : [=filter config/map=]
+        :: |map|
+        : [=filter config/lookback window=]
+        :: |lookbackWindow|
+1. Return |filter|.
+
 <h3 id="parsing-filters">Parsing filters</h3>
 
 To <dfn>parse filters</dfn> given a |value|:
 
 1. Let |filtersList| be a new [=list=].
 1. If |value| is a [=map=], then:
-    1. Let |filterMap| be the result of running [=parse filter values=] with |value|.
-    1. If |filterMap| is null, return null.
-    1. [=list/Append=] |filterMap| to |filtersList|.
+    1. Let |filterConfig| be the result of running [=parse filter config=] with |value|.
+    1. If |filterConfig| is null, return null.
+    1. [=list/Append=] |filterConfig| to |filtersList|.
     1. Return |filtersList|.
 1. If |value| is not a [=list=], return null.
 1. [=list/iterate|For each=] |data| of |value|:
-    1. Let |filterMap| be the result of running [=parse filter values=] with |data|.
-    1. If |filterMap| is null, return null.
-    1. [=list/Append=] |filterMap| to |filtersList|.
+    1. Let |filterConfig| be the result of running [=parse filter config=] with |data|.
+    1. If |filterConfig| is null, return null.
+    1. [=list/Append=] |filterConfig| to |filtersList|.
 1. Return |filtersList|.
 
 <h3 id="debug-keys">Cookie-based debugging</h3>
@@ -2200,12 +2229,12 @@ To <dfn>parse event triggers</dfn> given an [=ordered map=] |map|:
         [=parse an optional 64-bit signed integer=] with |value|, "`priority`",
         and 0.
     1. If |priority| is an error, return null.
-    1. Let |filters| be a [=list=] of [=filter maps=], initially empty.
+    1. Let |filters| be a [=list=] of [=filter configs=], initially empty.
     1. If |value|["`filters`"] [=map/exists=]:
         1. Set |filters| to the result of running [=parse filters=] with
             |value|["`filters`"].
         1. If |filters| is null, return null.
-    1. Let |negatedFilters| be a [=list=] of [=filter maps=], initially empty.
+    1. Let |negatedFilters| be a [=list=] of [=filter configs=], initially empty.
     1. If |value|["`not_filters`"] [=map/exists=]:
         1. Set |negatedFilters| to the result of running [=parse filters=]
             with |value|["`not_filters`"].
@@ -2244,12 +2273,12 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
         1. [=list/iterate|For each=] |sourceKey| of |value|["`source_keys`"]:
             1. If |sourceKey| is not a [=string=], return null.
             1. [=set/Append=] |sourceKey| to |sourceKeys|.
-    1. Let |filters| be a [=list=] of [=filter maps=], initially empty.
+    1. Let |filters| be a [=list=] of [=filter configs=], initially empty.
     1. If |value|["`filters`"] [=map/exists=]:
         1. Set |filters| to the result of running [=parse filters=] with
             |value|["`filters`"].
         1. If |filters| is null, return null.
-    1. Let |negatedFilters| be a [=list=] of [=filter maps=], initially empty.
+    1. Let |negatedFilters| be a [=list=] of [=filter configs=], initially empty.
     1. If |value|["`not_filters`"] [=map/exists=]:
         1. Set |negatedFilters| to the result of running [=parse filters=]
             with |value|["`not_filters`"].
@@ -2295,13 +2324,13 @@ To <dfn>parse aggregatable dedup keys</dfn> given an [=ordered map=] |map|:
         [=parse an optional 64-bit unsigned integer=] with |value|,
         "`deduplication_key`", and null.
     1. If |dedupKey| is an error, return null.
-    1. Let |filters| be a new [=filter map=].
+    1. Let |filters| be a new [=filter config=].
     1. If |values|["`filters`"] [=map/exists=]:
-        1. Set |filters| to the result of running [=parse filter data=] with |value|["`filters`"].
+        1. Set |filters| to the result of running [=parse filter config=] with |value|["`filters`"].
         1. If |filters| is null, return null.
-    1. Let |negatedFilters| be a new [=filter map=].
+    1. Let |negatedFilters| be a new [=filter config=].
     1. If |values|["`not_filters`"] [=map/exists=]:
-        1. Set |negatedFilters| to the result of running [=parse filter data=] with |value|["`not_filters`"].
+        1. Set |negatedFilters| to the result of running [=parse filter config=] with |value|["`not_filters`"].
         1. If |negatedFilters| is null, return null.
     1. Let  |aggregatableDedupKey| be a new [=aggregatable dedup key=] with the items:
         : [=aggregatable dedup key/dedup key=]
@@ -2354,12 +2383,12 @@ and a [=moment=] |triggerTime|:
 1. If |debugKey| is an error, set |debugKey| to null.
 1. If the result of running [=check if cookie-based debugging is allowed=] with
     |reportingOrigin| is <strong>blocked</strong>, set |debugKey| to null.
-1. Let |filters| be a [=list=] of [=filter maps=], initially empty.
+1. Let |filters| be a [=list=] of [=filter configs=], initially empty.
 1. If |value|["`filters`"] exists:
     1. Set |filters| to the result of running [=parse filters=] with
         |value|["`filters`"].
     1. If |filters| is null, return null.
-1. Let |negatedFilters| be a [=list=] of [=filter maps=], initially empty.
+1. Let |negatedFilters| be a [=list=] of [=filter configs=], initially empty.
 1. If |value|["`not_filters`"] exists:
     1. Set |negatedFilters| to the result of running [=parse filters=] with
         |value|["`not_filters`"].
@@ -2435,12 +2464,18 @@ To <dfn>match [=filter values=] with negation</dfn> given a [=filter value=] |a|
 1. If |i| is not [=set/is empty|empty=], then return false.
 1. Return true.
 
-To <dfn>match an attribution source's filter data against a filter map</dfn> given an
-[=attribution source=] |source|, a [=filter map=] |filter|, and a [=boolean=]
-<dfn for="match an attribution source's filter data against a filter map"><var>isNegated</var></dfn>:
+To <dfn>match an attribution source's filter data against a filter config</dfn> given an
+[=attribution source=] |source|, a [=filter config=] |filter|, and a [=boolean=]
+<dfn for="match an attribution source's filter data against a filter config"><var>isNegated</var></dfn>:
 
+1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].
+1. If |lookbackWindow| is not null:
+    1. If [=current wall time=] - |source|'s [=attribution source/source time=] is less than |lookbackWindow|:
+        1. If |isNegated|, return false. Otherwise, return true. 
+
+1. Let |filterMap| be |filter|'s [=filter config/map=].
 1. Let |sourceData| be |source|'s [=attribution source/filter data=].
-1. [=map/iterate|For each=] |key| → |filterValues| of |filter|:
+1. [=map/iterate|For each=] |key| → |filterValues| of |filterMap|:
     1. If |sourceData|[|key|] does not [=map/exist=], [=iteration/continue=].
     1. Let |sourceValues| be |sourceData|[|key|].
     1. If |isNegated| is:
@@ -2456,16 +2491,16 @@ To <dfn>match an attribution source's filter data against a filter map</dfn> giv
 1. Return true.
 
 To <dfn>match an attribution source's filter data against filters</dfn> given an
-[=attribution source=] |source|, a [=list=] of [=filter maps=] |filters|, and a [=boolean=]
+[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, and a [=boolean=]
 <dfn for="match an attribution source's filter data against filters"><var>isNegated</var></dfn>:
 
 1. If |filters| [=list/is empty=], return true.
 1. [=list/iterate|For each=] |filter| of |filters|:
-    1. If the result of running [=match an attribution source's filter data against a filter map=] with |source|, |filter| and |isNegated| is true, return true.
+    1. If the result of running [=match an attribution source's filter data against a filter config=] with |source|, |filter| and |isNegated| is true, return true.
 1. Return false.
 
 To <dfn>match an attribution source's filter data against filters and negated filters</dfn> given an
-[=attribution source=] |source|, a [=list=] of [=filter maps=] |filters|, and a [=list=] of [=filter maps=] |notFilters|:
+[=attribution source=] |source|, a [=list=] of [=filter configs=] |filters|, and a [=list=] of [=filter configs=] |notFilters|:
 
 1. If the result of running [=match an attribution source's filter data against filters=] with
     |source|, |filters|, and [=match an attribution source's filter data against filters/isNegated=] set to false is false, return false.

--- a/index.bs
+++ b/index.bs
@@ -1409,9 +1409,9 @@ To <dfn>parse filter config</dfn> given a |value|:
 1. If |value| is not a [=map=], return null.
 1. Let |lookbackWindow| be null.
 1. If |value|["`lookback_window`"] [=map/exists=]:
-    1. If |value|["`lookback_window`"] is not a non-negative integer, return null.
+    1. If |value|["`lookback_window`"] is not a positive integer, return null.
     1. Set |lookbackWindow| to the [=duration=] of |value|["`lookback_window`"] seconds.
-    1. [=map/Remove=] |value|["`lookback_window`""].
+    1. [=map/Remove=] |value|["`lookback_window`"].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.
 1. Let |filter| be a [=filter config=] with the items:
@@ -2468,7 +2468,7 @@ To <dfn>match an attribution source's filter data against a filter config</dfn> 
 
 1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].
 1. If |lookbackWindow| is not null:
-    1. If |moment| - |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
+    1. If the [=duration from=] |moment| and the |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
         1. If |isNegated|, return true. Otherwise, return false. 
 
 1. Let |filterMap| be |filter|'s [=filter config/map=].

--- a/index.bs
+++ b/index.bs
@@ -1883,6 +1883,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
         |value|["`filter_data`"].
     1. If |filterData| is null, return null.
     1. If |filterData|["`source_type`"] [=map/exists=], return null.
+    1. If |filterData|["`lookback_window`"] [=map/exists=], return null.
 1. [=map/Set=] |filterData|["`source_type`"] to « |sourceType| ».
 1. Let |debugKey| be the result of running
     [=parse an optional 64-bit unsigned integer=] with |value|, "`debug_key`",

--- a/index.bs
+++ b/index.bs
@@ -1410,7 +1410,7 @@ To <dfn>parse filter config</dfn> given a |value|:
 1. Let |lookbackWindow| be null.
 1. If |value|["`lookback_window`"] [=map/exists=]:
     1. If |value|["`lookback_window`"] is not a non-negative integer, return null.
-    1. Set |lookbackWindow| be the [=duration=] of |value|["`lookback_window`"] seconds.
+    1. Set |lookbackWindow| to the [=duration=] of |value|["`lookback_window`"] seconds.
     1. [=map/Remove=] |value|["`lookback_window`""].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.
@@ -2463,7 +2463,7 @@ To <dfn>match [=filter values=] with negation</dfn> given a [=filter value=] |a|
 1. Return true.
 
 To <dfn>match an attribution source's filter data against a filter config</dfn> given an
-[=attribution source=] |source|, a [=filter config=] |filter|, a [=moment=] moment, and a [=boolean=]
+[=attribution source=] |source|, a [=filter config=] |filter|, a [=moment=] |moment|, and a [=boolean=]
 <dfn for="match an attribution source's filter data against a filter config"><var>isNegated</var></dfn>:
 
 1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].

--- a/index.bs
+++ b/index.bs
@@ -1414,7 +1414,7 @@ To <dfn>parse filter config</dfn> given a |value|:
     1. Set |lookbackWindow| to |value|.
     1. [=map/Remove=] |value|[|filter|].
     1. [=iteration/Break=].
-1. Let |map| be the result of running [=parse filter data=] with |value|.
+1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.
 1. Let |filter| be a [=filter config=] with the items:
     : [=filter config/map=]

--- a/index.bs
+++ b/index.bs
@@ -1417,10 +1417,10 @@ To <dfn>parse filter config</dfn> given a |value|:
 1. Let |map| be the result of running [=parse filter data=] with |value|.
 1. If |map| is null, return null.
 1. Let |filter| be a [=filter config=] with the items:
-        : [=filter config/map=]
-        :: |map|
-        : [=filter config/lookback window=]
-        :: |lookbackWindow|
+    : [=filter config/map=]
+    :: |map|
+    : [=filter config/lookback window=]
+    :: |lookbackWindow|
 1. Return |filter|.
 
 <h3 id="parsing-filters">Parsing filters</h3>
@@ -2470,8 +2470,8 @@ To <dfn>match an attribution source's filter data against a filter config</dfn> 
 
 1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].
 1. If |lookbackWindow| is not null:
-    1. If [=current wall time=] - |source|'s [=attribution source/source time=] is less than |lookbackWindow|:
-        1. If |isNegated|, return false. Otherwise, return true. 
+    1. If [=current wall time=] - |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
+        1. If |isNegated|, return true. Otherwise, return false. 
 
 1. Let |filterMap| be |filter|'s [=filter config/map=].
 1. Let |sourceData| be |source|'s [=attribution source/filter data=].

--- a/index.bs
+++ b/index.bs
@@ -1410,7 +1410,7 @@ To <dfn>parse filter config</dfn> given a |value|:
 1. Let |lookbackWindow| be null.
 1. If |value|["`lookback-window`"] [=map/exists=]:
     1. If |value|["`lookback_window`""] is not a non-negative integer, return null.
-    1. Let |lookbackWindow| be |value|["`lookback_window`""].
+    1. Let |lookbackWindow| be the [=duration=] of |value|["`lookback_window`""] seconds.
     1. [=map/Remove=] |value|["`lookback_window`""].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.

--- a/index.bs
+++ b/index.bs
@@ -1408,10 +1408,10 @@ To <dfn>parse filter config</dfn> given a |value|:
 
 1. If |value| is not a [=map=], return null.
 1. Let |lookbackWindow| be null.
-1. If |value|["`lookback_window`"] [=map/exists=]:
-    1. If |value|["`lookback_window`"] is not a positive integer, return null.
-    1. Set |lookbackWindow| to the [=duration=] of |value|["`lookback_window`"] seconds.
-    1. [=map/Remove=] |value|["`lookback_window`"].
+1. If |value|["`_lookback_window`"] [=map/exists=]:
+    1. If |value|["`_lookback_window`"] is not a positive integer, return null.
+    1. Set |lookbackWindow| to the [=duration=] of |value|["`_lookback_window`"] seconds.
+    1. [=map/Remove=] |value|["`_lookback_window`"].
 1. Let |map| be the result of running [=parse filter values=] with |value|.
 1. If |map| is null, return null.
 1. Let |filter| be a [=filter config=] with the items:
@@ -1883,7 +1883,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
         |value|["`filter_data`"].
     1. If |filterData| is null, return null.
     1. If |filterData|["`source_type`"] [=map/exists=], return null.
-    1. If |filterData|["`lookback_window`"] [=map/exists=], return null.
+    1. If |filterData|["`_lookback_window`"] [=map/exists=], return null.
 1. [=map/Set=] |filterData|["`source_type`"] to « |sourceType| ».
 1. Let |debugKey| be the result of running
     [=parse an optional 64-bit unsigned integer=] with |value|, "`debug_key`",


### PR DESCRIPTION
Fix https://github.com/WICG/attribution-reporting-api/issues/769

Support lookback window by adding an optional reserved keyword "_lookback_window" to trigger's filters.

When set, the field is parsed as a duration in seconds.

To decide if a filter matches, we first check the lookback window. If available, the duration since the source was registered must be smaller or equal to the lookback window duration.

**Backward incompatibility**:  By introducing a new reserved keyword, we break source registrations which are currently using the "_lookback_window" key.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agarant/attribution-reporting-api/pull/914.html" title="Last updated on Aug 2, 2023, 5:43 PM UTC (da3c1bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/914/cad9329...agarant:da3c1bf.html" title="Last updated on Aug 2, 2023, 5:43 PM UTC (da3c1bf)">Diff</a>