### PR TITLE
Include index of invalid item in OS-header-validation errors

### DIFF
--- a/header-validator/src/validate-os.test.ts
+++ b/header-validator/src/validate-os.test.ts
@@ -14,7 +14,7 @@ const tests = [
   {
     input: '"https://a.test/"; x=1',
     warnings: [{
-      path: ['x'],
+      path: [0, 'x'],
       msg: 'unknown parameter',
     }],
   },
@@ -27,16 +27,16 @@ const tests = [
 
   // Not a string
   {
-    input: 'x',
+    input: '"https://a.test", x',
     errors: [{
-      path: [],
+      path: [1],
       msg: 'must be a string',
     }],
   },
   {
     input: '("https://a.test/")',
     errors: [{
-      path: [],
+      path: [0],
       msg: 'must be a string',
     }],
   },
@@ -45,7 +45,7 @@ const tests = [
   {
     input: '"a.test"',
     errors: [{
-      path: [],
+      path: [0],
       msg: 'must contain a valid URL',
     }],
   },
@@ -54,16 +54,16 @@ const tests = [
   {
     input: '"http://a.test"',
     errors: [{
-      path: [],
+      path: [0],
       msg: 'must contain a potentially trustworthy URL',
     }],
   },
 
   // debug-reporting not a boolean
   {
-    input: '"https://a.test/"; debug-reporting=1',
+    input: '"https://b.test/", "https://a.test/"; debug-reporting=1',
     errors: [{
-      path: ['debug-reporting'],
+      path: [1, 'debug-reporting'],
       msg: 'must be a boolean',
     }],
   },

--- a/header-validator/src/validate-os.ts
+++ b/header-validator/src/validate-os.ts
@@ -62,22 +62,23 @@ function validate(str: string, paramChecks: ParamChecks): ValidationResult {
     return { errors, warnings }
   }
 
-  for (const [item, params] of list) {
-    const err = validateURL(item)
+  for (let i = 0; i < list.length; i++) {
+    const [member, params] = list[i]
+    const err = validateURL(member)
     if (err) {
-      errors.push({ msg: err, path: [] })
+      errors.push({ msg: err, path: [i] })
     }
 
     Object.entries(paramChecks).forEach(([param, check]) => {
       const err = check(params.get(param))
       if (err) {
-        errors.push({ msg: err, path: [param] })
+        errors.push({ msg: err, path: [i, param] })
       }
       params.delete(param)
     })
 
     for (const key of params.keys()) {
-      warnings.push({ msg: 'unknown parameter', path: [key] })
+      warnings.push({ msg: 'unknown parameter', path: [i, key] })
     }
   }
 


### PR DESCRIPTION
Now that these headers may contain lists of URLs, the index helps pinpoint the problem.