### PR TITLE
Fix erroneous treatment of JSON null as object

### DIFF
--- a/header-validator/src/source.data.test.ts
+++ b/header-validator/src/source.data.test.ts
@@ -70,6 +70,14 @@ export const testCases = [
       msg: "must be an object",
     }],
   },
+  {
+    name: "wrong-root-type-null",
+    json: `null`,
+    expectedErrors: [{
+      path: [],
+      msg: "must be an object",
+    }],
+  },
 
   {
     name: "destination-missing",
@@ -109,6 +117,17 @@ export const testCases = [
     json: `{
       "destination": "https://a.test",
       "filter_data": 1
+    }`,
+    expectedErrors: [{
+      path: ["filter_data"],
+      msg: "must be an object",
+    }],
+  },
+  {
+    name: "filter-data-wrong-type-null",
+    json: `{
+      "destination": "https://a.test",
+      "filter_data": null
     }`,
     expectedErrors: [{
       path: ["filter_data"],

--- a/header-validator/src/validate-json.ts
+++ b/header-validator/src/validate-json.ts
@@ -93,7 +93,7 @@ function bool(state: State, value: any): void {
 }
 
 function isObject(value: any): boolean {
-  return typeof value === 'object' && value.constructor === Object
+  return value !== null && typeof value === 'object' && value.constructor === Object
 }
 
 type RecordCheck = (state: State, value: object) => void
@@ -325,7 +325,7 @@ export function validateSource(source: any): ValidationResult {
     source_event_id: optional(uint64),
     max_event_level_reports: optional(maxEventLevelReports),
   })
-  if (typeof source === 'object' && 'event_report_window' in source && 'event_report_windows' in source) {
+  if (isObject(source) && 'event_report_window' in source && 'event_report_windows' in source) {
     state.error('event_report_window and event_report_windows in the same source')
   }
   return state.result()


### PR DESCRIPTION
Without this change, certain inputs crash the validator on `null`.