### PR TITLE
Warn about duplicate filter-data values

### DIFF
--- a/header-validator/src/source.data.test.ts
+++ b/header-validator/src/source.data.test.ts
@@ -178,6 +178,20 @@ export const testCases = [
       msg: "is prohibited because it is implicitly set",
     }],
   },
+  {
+    name: "filter-data-duplicate-value",
+    json: `{
+      "destination": "https://a.test",
+      "filter_data": {
+        "a": ["x", "y", "x"],
+        "b": ["y"]
+      }
+    }`,
+    expectedWarnings: [{
+      path: ["filter_data", "a", 2],
+      msg: "duplicate value x",
+    }],
+  },
   // TODO: add tests for exceeding size limits
 
   {

--- a/header-validator/src/validate-json.ts
+++ b/header-validator/src/validate-json.ts
@@ -289,6 +289,17 @@ function listOrKeyValues(f: ValueCheck, listMaxLength: number = Infinity, listMi
   }
 }
 
+function unique(): StringCheck {
+  const set = new Set()
+  return (state, value) => {
+    if (set.has(value)) {
+      state.warn(`duplicate value ${value}`)
+    } else {
+      set.add(value)
+    }
+  }
+}
+
 // TODO: Check length of strings.
 const filterData = () =>
   keyValues((state, filter, values) => {
@@ -297,7 +308,7 @@ const filterData = () =>
       return
     }
 
-    list(string(), limits.maxValuesPerFilterDataEntry)(state, values)
+    list(string(unique()), limits.maxValuesPerFilterDataEntry)(state, values)
   }, limits.maxEntriesPerFilterData)
 
 const filters = () =>
@@ -306,7 +317,7 @@ const filters = () =>
       positiveInteger(state, values);
       return
     }
-    
+
     list(string())(state, values)
   })
 


### PR DESCRIPTION
Filter-data values are effectively a set, so there's no benefit to specifying the same one multiple times.