### PR TITLE
Warn about duplicate source keys

### DIFF
--- a/header-validator/src/trigger.data.test.ts
+++ b/header-validator/src/trigger.data.test.ts
@@ -422,6 +422,23 @@ export const testCases = [
       msg: "must be a string",
     }],
   },
+  {
+    name: "source-keys-duplicate-value",
+    json: `{"aggregatable_trigger_data": [
+      {
+        "key_piece": "0x1",
+        "source_keys": ["a", "x", "a"]
+      },
+      {
+        "key_piece": "0x2",
+        "source_keys": ["x"]
+      }
+    ]}`,
+    expectedWarnings: [{
+      path: ["aggregatable_trigger_data", 0, "source_keys", 2],
+      msg: "duplicate value a",
+    }],
+  },
 
   {
     name: "key-piece-missing",

--- a/header-validator/src/validate-json.ts
+++ b/header-validator/src/validate-json.ts
@@ -356,7 +356,7 @@ const aggregatableTriggerData = list(
       filters: optional(orFilters),
       key_piece: required(hex128),
       not_filters: optional(orFilters),
-      source_keys: optional(list(string(), limits.maxAggregationKeys)),
+      source_keys: optional(list(string(unique()), limits.maxAggregationKeys)),
     }))
 
 // TODO: check length of key


### PR DESCRIPTION
Per the spec, this field is effectively a set, so there is no benefit to specifying the same value multiple times.