### PR TITLE
Lookback window within negated filter

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -581,9 +581,13 @@ Unlike other filter keys whose values must be a list of strings, the
 `_lookback_window` value must be a positive integer that represents a positive
 duration in seconds.
 
-When available on a filter, the duration since the source was registered must be
-less than or equal to the parsed lookback window duration for the filter to
-match.
+When available on a filter (in `filters`), the duration since the source was
+registered must be less than or equal to the parsed lookback window duration for
+the filter to match. i.e. it must be inside the lookback window.
+
+When available on a negated filter (in `not filters`), the duration since the
+source was registered must be greater than the parsed lookback window duration
+for the filter to match. i.e. it must be outside the lookback window.
 
 ### Optional: transitional debugging reports
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -581,11 +581,11 @@ Unlike other filter keys whose values must be a list of strings, the
 `_lookback_window` value must be a positive integer that represents a positive
 duration in seconds.
 
-When available on a filter (in `filters`), the duration since the source was
+When present on a filter (in `filters`), the duration since the source was
 registered must be less than or equal to the parsed lookback window duration for
 the filter to match, i.e., it must be inside the lookback window.
 
-When available on a negated filter (in `not_filters`), the duration since the
+When present on a negated filter (in `not_filters`), the duration since the
 source was registered must be greater than the parsed lookback window duration
 for the filter to match, i.e., it must be outside the lookback window.
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -583,11 +583,11 @@ duration in seconds.
 
 When available on a filter (in `filters`), the duration since the source was
 registered must be less than or equal to the parsed lookback window duration for
-the filter to match. i.e. it must be inside the lookback window.
+the filter to match, i.e., it must be inside the lookback window.
 
 When available on a negated filter (in `not_filters`), the duration since the
 source was registered must be greater than the parsed lookback window duration
-for the filter to match. i.e. it must be outside the lookback window.
+for the filter to match, i.e., it must be outside the lookback window.
 
 ### Optional: transitional debugging reports
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -585,7 +585,7 @@ When available on a filter (in `filters`), the duration since the source was
 registered must be less than or equal to the parsed lookback window duration for
 the filter to match. i.e. it must be inside the lookback window.
 
-When available on a negated filter (in `not filters`), the duration since the
+When available on a negated filter (in `not_filters`), the duration since the
 source was registered must be greater than the parsed lookback window duration
 for the filter to match. i.e. it must be outside the lookback window.
 

--- a/index.bs
+++ b/index.bs
@@ -2501,7 +2501,10 @@ To <dfn>match an attribution source's filter data against a filter config</dfn> 
 1. If |lookbackWindow| is not null:
     1. If the [=duration from=] |moment| and the |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
         1. If |isNegated| is false, return false.
-    1. Else if |isNegated| is true, return false. 
+    1. Else if |isNegated| is true, return false.
+    
+    Note: If non-negated, the source must have been registered inside of the
+    lookback window. If negated, it must be outside of the lookback window.
 
 1. Let |filterMap| be |filter|'s [=filter config/map=].
 1. Let |sourceData| be |source|'s [=attribution source/filter data=].

--- a/index.bs
+++ b/index.bs
@@ -2500,7 +2500,8 @@ To <dfn>match an attribution source's filter data against a filter config</dfn> 
 1. Let |lookbackWindow| be |filter|'s [=filter config/lookback window=].
 1. If |lookbackWindow| is not null:
     1. If the [=duration from=] |moment| and the |source|'s [=attribution source/source time=] is greater than |lookbackWindow|:
-        1. If |isNegated|, return true. Otherwise, return false. 
+        1. If |isNegated| is false, return false.
+    1. Else if |isNegated| is true, return false. 
 
 1. Let |filterMap| be |filter|'s [=filter config/map=].
 1. Let |sourceData| be |source|'s [=attribution source/filter data=].


### PR DESCRIPTION
Enhances #914 

At a high level, the currently spec logic is the following:
```
Negated filter true = (no lookback_window || outside lookback_window) || (has empty intersection for all matching keys)
```

This behavior is incoherent with other filtering logic, since as soon as a source is outside of the lookback window, the negated filter would match even if some matching keys have non-empty intersections. It also means that it can still match even if outside of the lookback window so long as it has empty intersection for all matching keys.

This PR updates the logic to the following:
```
Negated filter true = (no lookback_window || outside lookback_window)  &&  (has empty intersection for all matching keys)
```

This is more coherent and being able to match when outside of the lookback window adds capabilities to the API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agarant/attribution-reporting-api/pull/958.html" title="Last updated on Aug 25, 2023, 1:05 PM UTC (da2214c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/958/e3e14b2...agarant:da2214c.html" title="Last updated on Aug 25, 2023, 1:05 PM UTC (da2214c)">Diff</a>