### PR TITLE
Allow or-filters in aggregatable dedup keys

### DIFF
--- a/header-validator/src/trigger.test.ts
+++ b/header-validator/src/trigger.test.ts
@@ -275,6 +275,13 @@ runAll(validateTrigger, [
       msg: "must be a uint64 (must match /^[0-9]+$/)",
     }],
   },
+  {
+    name: "aggregatable-deduplication-key-or-filters",
+    json: `{"aggregatable_deduplication_keys": [{
+      "filters": [],
+      "not_filters": []
+    }]}`,
+  },
 
   {
     name: "event-trigger-data-wrong-type",

--- a/header-validator/src/validate-json.ts
+++ b/header-validator/src/validate-json.ts
@@ -380,8 +380,8 @@ const eventTriggerData = list((ctx, value) => validate(ctx, value, {
 
 const aggregatableDedupKeys = list((ctx, value) => validate(ctx, value, {
   deduplication_key: optional(uint64),
-  filters: optional(filters()),
-  not_filters: optional(filters()),
+  filters: optional(orFilters),
+  not_filters: optional(orFilters),
 }))
 
 const aggregatableSourceRegistrationTime = string((ctx, value) => {


### PR DESCRIPTION
This is already supported in Chromium, but was omitted from the validator unintentionally. (Same problem as in #963.)