### PR TITLE
Move aggregation-key limit to vendor-specific values

### DIFF
--- a/header-validator/src/index.ts
+++ b/header-validator/src/index.ts
@@ -52,6 +52,7 @@ function header(): string {
 }
 
 const ChromiumVsv: VendorSpecificValues = {
+  maxAggregationKeysPerAttribution: 20,
   triggerDataCardinality: {
     [SourceType.event]: 2n,
     [SourceType.navigation]: 8n,
@@ -59,7 +60,9 @@ const ChromiumVsv: VendorSpecificValues = {
 }
 
 function validate(): void {
-  const vsv = useChromiumVsvCheckbox.checked ? ChromiumVsv : undefined
+  const vsv: Partial<VendorSpecificValues> = useChromiumVsvCheckbox.checked
+    ? ChromiumVsv
+    : {}
 
   let result
   switch (header()) {

--- a/header-validator/src/source.test.ts
+++ b/header-validator/src/source.test.ts
@@ -273,7 +273,23 @@ runAll(validateSource, [
       },
     ],
   },
-  // TODO: add tests for exceeding size limits
+  {
+    name: 'aggregation-keys-too-many',
+    json: `{
+      "destination": "https://a.test",
+      "aggregation_keys": {
+        "a": "0x1",
+        "b": "0x2"
+      }
+    }`,
+    vsv: { maxAggregationKeysPerAttribution: 1 },
+    expectedErrors: [
+      {
+        path: ['aggregation_keys'],
+        msg: 'exceeds the maximum number of keys (1)',
+      },
+    ],
+  },
 
   {
     name: 'source-event-id-wrong-type',

--- a/header-validator/src/trigger.test.ts
+++ b/header-validator/src/trigger.test.ts
@@ -263,7 +263,17 @@ runAll(validateTrigger, [
       },
     ],
   },
-  // TODO: add tests for exceeding size limits
+  {
+    name: 'aggregatable-values-too-many',
+    json: `{"aggregatable_values": {"a": 1, "b": 2}}`,
+    vsv: { maxAggregationKeysPerAttribution: 1 },
+    expectedErrors: [
+      {
+        path: ['aggregatable_values'],
+        msg: 'exceeds the maximum number of keys (1)',
+      },
+    ],
+  },
 
   {
     name: 'debug-reporting-wrong-type',
@@ -613,6 +623,22 @@ runAll(validateTrigger, [
       {
         path: ['aggregatable_trigger_data', 0, 'source_keys', 2],
         msg: 'duplicate value a',
+      },
+    ],
+  },
+  {
+    name: 'source-keys-too-many',
+    json: `{"aggregatable_trigger_data": [
+      {
+        "key_piece": "0x1",
+        "source_keys": ["a", "b"]
+      }
+    ]}`,
+    vsv: { maxAggregationKeysPerAttribution: 1 },
+    expectedErrors: [
+      {
+        path: ['aggregatable_trigger_data', 0, 'source_keys'],
+        msg: 'length must be in the range [0, 1]',
       },
     ],
   },

--- a/header-validator/src/validate-json.test.ts
+++ b/header-validator/src/validate-json.test.ts
@@ -4,11 +4,13 @@ import { ValueCheck, VendorSpecificValues, validateJSON } from './validate-json'
 export type TestCase = testutil.TestCase & {
   name: string
   json: string
-  vsv?: VendorSpecificValues
+  vsv?: Partial<VendorSpecificValues>
 }
 
 export function runAll(validate: ValueCheck, tcs: TestCase[]) {
   tcs.forEach((tc) =>
-    testutil.run(tc, tc.name, () => validateJSON(tc.json, validate, tc.vsv))
+    testutil.run(tc, tc.name, () =>
+      validateJSON(tc.json, validate, tc.vsv ?? {})
+    )
   )
 }


### PR DESCRIPTION
Per the spec, the value is not fixed at 20:
https://wicg.github.io/attribution-reporting-api/#max-aggregation-keys-per-attribution