### PR TITLE
Remove aggregation keys size limit on trigger registration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1247,12 +1247,9 @@ Its value is 5.
 
 # Vendor-Specific Values # {#vendor-specific-values}
 
-<dfn>Max aggregation keys per attribution</dfn> is a positive integer that
+<dfn>Max aggregation keys per source registration</dfn> is a positive integer that
 controls the maximum [=map/size=] of an [=attribution source=]'s
-[=attribution source/aggregation keys=], the maximum [=set/size=] of an
-[=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=],
-and the maximum [=map/size=] of an [=attribution trigger=]'s
-[=attribution trigger/aggregatable values=].
+[=attribution source/aggregation keys=].
 
 <dfn>Max pending sources per source origin</dfn> is a positive integer that
 controls how many [=attribution sources=] can be in the
@@ -1861,7 +1858,7 @@ To <dfn>parse aggregation keys</dfn> given an [=ordered map=] |map|:
 1. Let |values| be |map|["`aggregation_keys`"].
 1. If |values| is not an [=ordered map=], return null.
 1. If |values|'s [=map/size=] is greater than the user agent's
-    [=max aggregation keys per attribution=], return null.
+    [=max aggregation keys per source registration=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
     1. If |value| is not a [=string=], return null.
     1. Let |keyPiece| be the result of running [=parse an aggregation key piece=] with |value|.
@@ -2326,8 +2323,6 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
     1. Let |sourceKeys| be a new [=ordered set=].
     1. If |value|["`source_keys`"] [=map/exists=]:
         1. If |value|["`source_keys`"] is not a [=list=], return null.
-        1. If |value|["`source_keys`"]'s [=list/size=] is greater than the user agent's
-            [=max aggregation keys per attribution=], return null.
         1. [=list/iterate|For each=] |sourceKey| of |value|["`source_keys`"]:
             1. If |sourceKey| is not a [=string=], return null.
             1. [=set/Append=] |sourceKey| to |sourceKeys|.
@@ -2353,8 +2348,6 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=], return null.
-1. If |values|'s [=map/size=] is greater than the user agent's
-    [=max aggregation keys per attribution=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
      1. If |value| is not an integer, return null.
      1. If |value| is less than or equal to 0, return null.

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -33,7 +33,7 @@ Chromium's implementation assigns the following values:
 | [Max information gain for event sources][] | [6.5 bits][max information gain for events value] |
 
 [Max aggregation keys per source registration]: https://wicg.github.io/attribution-reporting-api/#max-aggregation-keys-per-source-registration
-[max aggregation keys per attribution value]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/attribution_reporting/constants.h;l=19;drc=b646f894a92491033bde5d1e75aba6f44c524f0e
+[max aggregation keys per source registration value]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/attribution_reporting/constants.h;l=19;drc=b646f894a92491033bde5d1e75aba6f44c524f0e
 [Max pending sources per source origin]: https://wicg.github.io/attribution-reporting-api/#max-pending-sources-per-source-origin
 [max pending sources per source origin value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=122;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Navigation-source trigger data cardinality]: https://wicg.github.io/attribution-reporting-api/#navigation-source-trigger-data-cardinality

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -7,7 +7,7 @@ Chromium's implementation assigns the following values:
 
 | Name | Value |
 | ---- | ----- |
-| [Max aggregation keys per attribution][] | [20][max aggregation keys per attribution value] |
+| [Max aggregation keys per source registration][] | [20][max aggregation keys per source registration value] |
 | [Max pending sources per source origin][] | [1024][max pending sources per source origin value] |
 | [Navigation-source trigger data cardinality][] | [8][navigation-source trigger data cardinality value] |
 | [Event-source trigger data cardinality][] | [2][event-source trigger data cardinality value] |
@@ -32,7 +32,7 @@ Chromium's implementation assigns the following values:
 | [Max information gain for navigation sources][] | [11.46 bits][max information gain for navigations value] |
 | [Max information gain for event sources][] | [6.5 bits][max information gain for events value] |
 
-[Max aggregation keys per attribution]: https://wicg.github.io/attribution-reporting-api/#max-aggregation-keys-per-attribution
+[Max aggregation keys per source registration]: https://wicg.github.io/attribution-reporting-api/#max-aggregation-keys-per-source-registration
 [max aggregation keys per attribution value]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/attribution_reporting/constants.h;l=19;drc=b646f894a92491033bde5d1e75aba6f44c524f0e
 [Max pending sources per source origin]: https://wicg.github.io/attribution-reporting-api/#max-pending-sources-per-source-origin
 [max pending sources per source origin value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=122;drc=3733a639d724a4353463a872605119d11a1e4d37

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -315,7 +315,7 @@ const testCases: TestCase[] = [
         "b": "0x2"
       }
     }`,
-    vsv: { maxAggregationKeysPerAttribution: 1 },
+    vsv: { maxAggregationKeysPerSource: 1 },
     expectedErrors: [
       {
         path: ['aggregation_keys'],

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -345,17 +345,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       },
     ],
   },
-  {
-    name: 'aggregatable-values-too-many',
-    json: `{"aggregatable_values": {"a": 1, "b": 2}}`,
-    vsv: { maxAggregationKeysPerAttribution: 1 },
-    expectedErrors: [
-      {
-        path: ['aggregatable_values'],
-        msg: 'exceeds the maximum number of keys (1)',
-      },
-    ],
-  },
 
   {
     name: 'debug-reporting-wrong-type',
@@ -705,22 +694,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_trigger_data', 0, 'source_keys', 2],
         msg: 'duplicate value a',
-      },
-    ],
-  },
-  {
-    name: 'source-keys-too-many',
-    json: `{"aggregatable_trigger_data": [
-      {
-        "key_piece": "0x1",
-        "source_keys": ["a", "b"]
-      }
-    ]}`,
-    vsv: { maxAggregationKeysPerAttribution: 1 },
-    expectedErrors: [
-      {
-        path: ['aggregatable_trigger_data', 0, 'source_keys'],
-        msg: 'length must be in the range [0, 1]',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -662,7 +662,7 @@ function aggregationKeys(ctx: Context, j: Json): Maybe<Map<string, bigint>> {
     ctx,
     j,
     aggregationKey,
-    ctx.vsv.maxAggregationKeysPerAttribution
+    ctx.vsv.maxAggregationKeysPerSource
   )
 }
 
@@ -848,9 +848,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
 }
 
 function sourceKeys(ctx: Context, j: Json): Maybe<Set<string>> {
-  return set(ctx, j, string, {
-    maxLength: ctx.vsv.maxAggregationKeysPerAttribution,
-  })
+  return set(ctx, j, string)
 }
 
 export type AggregatableTriggerDatum = FilterPair & {
@@ -885,8 +883,7 @@ function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {
   return keyValues(
     ctx,
     j,
-    aggregatableKeyValue,
-    ctx.vsv.maxAggregationKeysPerAttribution
+    aggregatableKeyValue
   )
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -658,12 +658,7 @@ function aggregationKey(ctx: Context, [key, j]: [string, Json]): Maybe<bigint> {
 }
 
 function aggregationKeys(ctx: Context, j: Json): Maybe<Map<string, bigint>> {
-  return keyValues(
-    ctx,
-    j,
-    aggregationKey,
-    ctx.vsv.maxAggregationKeysPerSource
-  )
+  return keyValues(ctx, j, aggregationKey, ctx.vsv.maxAggregationKeysPerSource)
 }
 
 function clamp<N extends bigint | number>(
@@ -880,11 +875,7 @@ function aggregatableKeyValue(
 }
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {
-  return keyValues(
-    ctx,
-    j,
-    aggregatableKeyValue
-  )
+  return keyValues(ctx, j, aggregatableKeyValue)
 }
 
 export type EventTriggerDatum = FilterPair &

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -2,7 +2,7 @@ import { SourceType } from './source-type'
 
 export type VendorSpecificValues = {
   defaultEventLevelAttributionsPerSource: Record<SourceType, number>
-  maxAggregationKeysPerAttribution: number
+  maxAggregationKeysPerSource: number
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   randomizedResponseEpsilon: number
   triggerDataCardinality: Record<SourceType, bigint>
@@ -13,7 +13,7 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.event]: 1,
     [SourceType.navigation]: 3,
   },
-  maxAggregationKeysPerAttribution: 20,
+  maxAggregationKeysPerSource: 20,
   maxEventLevelChannelCapacityPerSource: {
     [SourceType.event]: 6.5,
     [SourceType.navigation]: 11.46173,


### PR DESCRIPTION
This limit is non-privacy related, therefore we can just rely on the limit on total header size.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/988.html" title="Last updated on Sep 15, 2023, 8:14 PM UTC (3c3f927)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/988/35aa3dc...linnan-github:3c3f927.html" title="Last updated on Sep 15, 2023, 8:14 PM UTC (3c3f927)">Diff</a>