### PR TITLE
Prevent duplicate values in "obtain default effective windows" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1874,7 +1874,7 @@ To <dfn>obtain default effective windows</dfn> given a [=source type=] |sourceTy
 a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 
 1. Let |deadlines| be «» if |sourceType| is "<code>[=source type/event=]</code>", else « 2 days, 7 days ».
-1. [=list/Remove=] all elements in |deadlines| that are greater than |eventReportWindow|.
+1. [=list/Remove=] all elements in |deadlines| that are greater than or equal to |eventReportWindow|.
 1. [=list/Append=] |eventReportWindow| to |deadlines|.
 1. Let |lastEnd| be |sourceTime|.
 1. Let |windows| be «».


### PR DESCRIPTION
By removing only elements that were greater than eventReportWindow, this algorithm would have erroneously placed duplicate values in the deadlines list if the eventReportWindow was exactly 2 days or 7 days. In turn, this would have caused the returned windows list to contain 1 extra window.

This seems to have been an oversight in #742.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/992.html" title="Last updated on Sep 6, 2023, 1:05 PM UTC (fa35d8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/992/2b4773a...apasel422:fa35d8c.html" title="Last updated on Sep 6, 2023, 1:05 PM UTC (fa35d8c)">Diff</a>