### PR TITLE
Validate source registrations using a specific source type

### DIFF
--- a/header-validator/index.html
+++ b/header-validator/index.html
@@ -63,7 +63,12 @@ textarea {
   <div id="right">
     <fieldset id=header>
       <legend>Header</legend>
-      <p><label><input type=radio name=header value=source><code>Attribution-Reporting-Register-Source</code></label>
+      <p><label><input type=radio name=header value=source checked><code>Attribution-Reporting-Register-Source</code></label>
+      <fieldset id=source-type>
+        <legend>Source Type</legend>
+        <p><label><input type=radio name=source-type value=event checked>event</label>
+        <p><label><input type=radio name=source-type value=navigation>navigation</label>
+      </fieldset>
       <p><label><input type=radio name=header value=trigger><code>Attribution-Reporting-Register-Trigger</code></label>
       <p><label><input type=radio name=header value=os-source><code>Attribution-Reporting-Register-OS-Source</code></label>
       <p><label><input type=radio name=header value=os-trigger><code>Attribution-Reporting-Register-OS-Trigger</code></label>

--- a/header-validator/src/index.ts
+++ b/header-validator/src/index.ts
@@ -13,6 +13,10 @@ const input = form.querySelector('textarea')! as HTMLTextAreaElement
 const useChromiumVsvCheckbox = document.querySelector(
   '#chromium-vsv'
 )! as HTMLInputElement
+const headerRadios = form.elements.namedItem('header')! as RadioNodeList
+const sourceTypeRadios = form.elements.namedItem(
+  'source-type'
+)! as RadioNodeList
 const errorList = document.querySelector('#errors')!
 const warningList = document.querySelector('#warnings')!
 const successDiv = document.querySelector('#success')!
@@ -48,15 +52,10 @@ function makeLi({ path, msg }: Issue): HTMLElement {
   return li
 }
 
-function header(): string {
-  const el = form.elements.namedItem('header')! as RadioNodeList
-  return el.value
-}
-
 function sourceType(): SourceType {
-  const el = form.elements.namedItem('source-type')! as RadioNodeList
-  if (el.value in SourceType) {
-    return el.value as SourceType
+  const v = sourceTypeRadios.value
+  if (v in SourceType) {
+    return v as SourceType
   }
   throw new TypeError()
 }
@@ -77,7 +76,7 @@ function validate(): void {
   sourceTypeFieldset.disabled = true
 
   let result
-  switch (header()) {
+  switch (headerRadios.value) {
     case 'source':
       sourceTypeFieldset.disabled = false
       result = validateSource(input.value, vsv, sourceType())
@@ -116,7 +115,7 @@ form.addEventListener('input', validate)
 document.querySelector('#linkify')!.addEventListener('click', async () => {
   const url = new URL(location.toString())
   url.search = ''
-  url.searchParams.set('header', header())
+  url.searchParams.set('header', headerRadios.value)
   url.searchParams.set('json', input.value)
 
   if (useChromiumVsvCheckbox.checked) {
@@ -157,7 +156,7 @@ let selection = params.get('header')
 if (selection === null || !allowedValues.has(selection)) {
   selection = 'source'
 }
-;(form.querySelector(`input[value=${selection}]`) as HTMLInputElement).click()
+headerRadios.value = selection
 
 let st = params.get('source-type')
 if (st !== null && st in SourceType) {
@@ -165,6 +164,6 @@ if (st !== null && st in SourceType) {
 } else {
   st = SourceType.event
 }
-;(form.querySelector(`input[value=${st}]`) as HTMLInputElement).click()
+sourceTypeRadios.value = st
 
 validate()

--- a/header-validator/src/source.test.ts
+++ b/header-validator/src/source.test.ts
@@ -1,7 +1,12 @@
-import { validateSource } from './validate-json'
-import { runAll } from './validate-json.test'
+import * as testutil from './util.test'
+import { SourceType, validateSource } from './validate-json'
+import * as jsontest from './validate-json.test'
 
-runAll(validateSource, [
+type TestCase = jsontest.TestCase & {
+  sourceType?: SourceType
+}
+
+const testCases: TestCase[] = [
   // no errors or warnings
   {
     name: 'required-fields-only',
@@ -688,10 +693,11 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": "129599"
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (86400) if source type is event',
+        msg: 'will be rounded to nearest day (86400) as source type is event',
       },
     ],
   },
@@ -701,10 +707,11 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": "129600"
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (172800) if source type is event',
+        msg: 'will be rounded to nearest day (172800) as source type is event',
       },
     ],
   },
@@ -714,10 +721,11 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": "129601"
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (172800) if source type is event',
+        msg: 'will be rounded to nearest day (172800) as source type is event',
       },
     ],
   },
@@ -727,10 +735,11 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": 129599
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (86400) if source type is event',
+        msg: 'will be rounded to nearest day (86400) as source type is event',
       },
     ],
   },
@@ -740,10 +749,11 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": 129600
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (172800) if source type is event',
+        msg: 'will be rounded to nearest day (172800) as source type is event',
       },
     ],
   },
@@ -753,12 +763,21 @@ runAll(validateSource, [
       "destination": "https://a.test",
       "expiry": 129601
     }`,
+    sourceType: SourceType.event,
     expectedWarnings: [
       {
         path: ['expiry'],
-        msg: 'will be rounded to nearest day (172800) if source type is event',
+        msg: 'will be rounded to nearest day (172800) as source type is event',
       },
     ],
+  },
+  {
+    name: 'expiry-integer-no-rounding-navigation-source',
+    json: `{
+      "destination": "https://a.test",
+      "expiry": 129601
+    }`,
+    sourceType: SourceType.navigation,
   },
 
   {
@@ -1044,4 +1063,14 @@ runAll(validateSource, [
       },
     ],
   },
-])
+]
+
+testCases.forEach((tc) =>
+  testutil.run(tc, tc.name, () =>
+    validateSource(
+      tc.json,
+      tc.vsv ?? {},
+      tc.sourceType ?? SourceType.navigation
+    )
+  )
+)

--- a/header-validator/src/trigger.test.ts
+++ b/header-validator/src/trigger.test.ts
@@ -1,7 +1,8 @@
+import * as testutil from './util.test'
 import { SourceType, validateTrigger } from './validate-json'
-import { runAll } from './validate-json.test'
+import * as jsontest from './validate-json.test'
 
-runAll(validateTrigger, [
+const testCases: jsontest.TestCase[] = [
   // no errors or warnings
   {
     name: 'required-fields-only',
@@ -845,4 +846,8 @@ runAll(validateTrigger, [
       },
     ],
   },
-])
+]
+
+testCases.forEach((tc) =>
+  testutil.run(tc, tc.name, () => validateTrigger(tc.json, tc.vsv ?? {}))
+)

--- a/header-validator/src/validate-json.test.ts
+++ b/header-validator/src/validate-json.test.ts
@@ -1,16 +1,8 @@
 import * as testutil from './util.test'
-import { ValueCheck, VendorSpecificValues, validateJSON } from './validate-json'
+import * as json from './validate-json'
 
 export type TestCase = testutil.TestCase & {
   name: string
   json: string
-  vsv?: Partial<VendorSpecificValues>
-}
-
-export function runAll(validate: ValueCheck, tcs: TestCase[]) {
-  tcs.forEach((tc) =>
-    testutil.run(tc, tc.name, () =>
-      validateJSON(tc.json, validate, tc.vsv ?? {})
-    )
-  )
+  vsv?: Partial<json.VendorSpecificValues>
 }


### PR DESCRIPTION
This is necessary to ensure that expiry and the fields that depend on it (event_report_window, event_report_windows, aggregatable_report_window) are fully validated.

We present a new radio button in the UI to allow the user to choose which type to validate against.