### PR TITLE
Default max_event_level_reports in header validator

### DIFF
--- a/header-validator/src/index.ts
+++ b/header-validator/src/index.ts
@@ -61,6 +61,10 @@ function sourceType(): SourceType {
 }
 
 const ChromiumVsv: VendorSpecificValues = {
+  defaultEventLevelAttributionsPerSource: {
+    [SourceType.event]: 1,
+    [SourceType.navigation]: 3,
+  },
   maxAggregationKeysPerAttribution: 20,
   triggerDataCardinality: {
     [SourceType.event]: 2n,

--- a/header-validator/src/validate-json.ts
+++ b/header-validator/src/validate-json.ts
@@ -23,6 +23,7 @@ const limits = {
 }
 
 export type VendorSpecificValues = {
+  defaultEventLevelAttributionsPerSource: Record<SourceType, number>
   maxAggregationKeysPerAttribution: number
   triggerDataCardinality: Record<SourceType, bigint>
 }
@@ -788,7 +789,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
       maxEventLevelReports: field(
         'max_event_level_reports',
         maxEventLevelReports,
-        null
+        ctx.vsv.defaultEventLevelAttributionsPerSource?.[ctx.sourceType] ?? null
       ),
       sourceEventId: field('source_event_id', uint64, 0n),
 


### PR DESCRIPTION
Now that the validator is source-type-aware, this will allow us to show the effective value in the UI and use it for channel-capacity computations.