### PR TITLE
Check event-level channel capacity limit in header validator

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1083,6 +1083,59 @@ const testCases: TestCase[] = [
       },
     ],
   },
+
+  {
+    name: 'channel-capacity-default-event',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.event,
+    vsv: {
+      defaultEventLevelAttributionsPerSource: {
+        [SourceType.event]: 1,
+        [SourceType.navigation]: 3,
+      },
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: 0,
+        [SourceType.navigation]: Infinity,
+      },
+      randomizedResponseEpsilon: 14,
+      triggerDataCardinality: {
+        [SourceType.event]: 2n,
+        [SourceType.navigation]: 8n,
+      },
+    },
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'exceeds max event-level channel capacity per event source (1.58 > 0.00)',
+      },
+    ],
+  },
+  {
+    name: 'channel-capacity-default-navigation',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.navigation,
+    vsv: {
+      defaultEventLevelAttributionsPerSource: {
+        [SourceType.event]: 1,
+        [SourceType.navigation]: 3,
+      },
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: Infinity,
+        [SourceType.navigation]: 0,
+      },
+      randomizedResponseEpsilon: 14,
+      triggerDataCardinality: {
+        [SourceType.event]: 2n,
+        [SourceType.navigation]: 8n,
+      },
+    },
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'exceeds max event-level channel capacity per navigation source (11.46 > 0.00)',
+      },
+    ],
+  },
 ]
 
 testCases.forEach((tc) =>

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -3,6 +3,8 @@ import { SourceType } from './source-type'
 export type VendorSpecificValues = {
   defaultEventLevelAttributionsPerSource: Record<SourceType, number>
   maxAggregationKeysPerAttribution: number
+  maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
+  randomizedResponseEpsilon: number
   triggerDataCardinality: Record<SourceType, bigint>
 }
 
@@ -12,6 +14,11 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.navigation]: 3,
   },
   maxAggregationKeysPerAttribution: 20,
+  maxEventLevelChannelCapacityPerSource: {
+    [SourceType.event]: 6.5,
+    [SourceType.navigation]: 11.46173,
+  },
+  randomizedResponseEpsilon: 14,
   triggerDataCardinality: {
     [SourceType.event]: 2n,
     [SourceType.navigation]: 8n,


### PR DESCRIPTION
If vendor-specific values are enabled and the source is otherwise valid, an error will be omitted if the effective channel capacity of the source is greater than the limit for the selected source type.