### PR TITLE
Remove redundant SourceType enum

### DIFF
--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { SourceType } from '../source-type'
 import {
   flipProbabilityDp,
   maxInformationGain,
   binaryEntropy,
   DefaultConfig,
-  SourceType,
 } from './privacy'
 
 const flipProbabilityTests = [
@@ -107,9 +107,9 @@ test('binaryEntropy', async (t) => {
 test('computeConfigData', async (t) => {
   await t.test('navigation', () => {
     assert.deepStrictEqual(
-      DefaultConfig[SourceType.Navigation].computeConfigData(
+      DefaultConfig[SourceType.navigation].computeConfigData(
         14,
-        SourceType.Navigation
+        SourceType.navigation
       ),
       {
         numStates: 2925,
@@ -122,7 +122,7 @@ test('computeConfigData', async (t) => {
 
   await t.test('event', () => {
     assert.deepStrictEqual(
-      DefaultConfig[SourceType.Event].computeConfigData(14, SourceType.Event),
+      DefaultConfig[SourceType.event].computeConfigData(14, SourceType.event),
       {
         numStates: 3,
         infoGain: 1.584926511508231,

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -1,9 +1,5 @@
 const memoize = require('memoizee')
-
-export enum SourceType {
-  Event = 'event',
-  Navigation = 'navigation',
-}
+import { SourceType } from '../source-type'
 
 export type ExcessiveInfoGainData = {
   infoGainDefault: number
@@ -120,13 +116,13 @@ export class Config {
 }
 
 export const DefaultConfig: Readonly<Record<SourceType, Config>> = {
-  [SourceType.Navigation]: new Config(
+  [SourceType.navigation]: new Config(
     /*maxEventLevelReports=*/ 3,
     new Array(8).fill(
       new PerTriggerDataConfig(/*numWindows=*/ 3, /*numSummaryBuckets=*/ 3)
     )
   ),
-  [SourceType.Event]: new Config(
+  [SourceType.event]: new Config(
     /*maxEventLevelReports=*/ 1,
     new Array(2).fill(
       new PerTriggerDataConfig(/*numWindows=*/ 1, /*numSummaryBuckets=*/ 1)


### PR DESCRIPTION
This was an oversight in #1010.