### PR TITLE
Rename Source.eventReportWindow to eventReportWindows

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -39,7 +39,7 @@ const testCases: TestCase[] = [
       debugKey: 1n,
       debugReporting: true,
       destination: new Set(['https://a.test']),
-      eventReportWindow: {
+      eventReportWindows: {
         startTime: 0,
         endTimes: [3601],
       },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -757,7 +757,7 @@ export type Source = CommonDebug &
     aggregatableReportWindow: number
     aggregationKeys: Map<string, bigint>
     destination: Set<string>
-    eventReportWindow: EventReportWindows
+    eventReportWindows: EventReportWindows
     expiry: number
     filterData: FilterData
     maxEventLevelReports: number | null
@@ -789,7 +789,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
       ),
       sourceEventId: field('source_event_id', uint64, 0n),
 
-      eventReportWindow: exclusive(
+      eventReportWindows: exclusive(
         {
           event_report_window: (ctx, j) => eventReportWindow(ctx, j, expiryVal),
           event_report_windows: (ctx, j) =>


### PR DESCRIPTION
Since there may be more than one.