### PR TITLE
Move vendor-specific values to separate file

### DIFF
--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -1,10 +1,10 @@
 import { SourceType } from '../source-type'
 import { Issue, PathComponent } from './context'
 import {
+  Chromium as ChromiumVsv,
   VendorSpecificValues,
-  validateSource,
-  validateTrigger,
-} from './validate-json'
+} from '../vendor-specific-values'
+import { validateSource, validateTrigger } from './validate-json'
 import { validateEligible } from './validate-eligible'
 import { validateOsRegistration } from './validate-os'
 
@@ -60,22 +60,9 @@ function sourceType(): SourceType {
   throw new TypeError()
 }
 
-const ChromiumVsv: VendorSpecificValues = {
-  defaultEventLevelAttributionsPerSource: {
-    [SourceType.event]: 1,
-    [SourceType.navigation]: 3,
-  },
-  maxAggregationKeysPerAttribution: 20,
-  triggerDataCardinality: {
-    [SourceType.event]: 2n,
-    [SourceType.navigation]: 8n,
-  },
-}
-
 function validate(): void {
-  const vsv: Partial<VendorSpecificValues> = useChromiumVsvCheckbox.checked
-    ? ChromiumVsv
-    : {}
+  const vsv: Readonly<Partial<VendorSpecificValues>> =
+    useChromiumVsvCheckbox.checked ? ChromiumVsv : {}
 
   sourceTypeFieldset.disabled = true
 

--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -2,12 +2,12 @@ import { strict as assert } from 'assert'
 import * as context from './context'
 import { Maybe } from './maybe'
 import * as testutil from './util.test'
-import * as json from './validate-json'
+import * as vsv from '../vendor-specific-values'
 
 export type TestCase<T> = testutil.TestCase & {
   name: string
   json: string
-  vsv?: Partial<json.VendorSpecificValues>
+  vsv?: Readonly<Partial<vsv.VendorSpecificValues>>
   expected?: Maybe<T>
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1,5 +1,6 @@
 import * as psl from 'psl'
 import { SourceType } from '../source-type'
+import { VendorSpecificValues } from '../vendor-specific-values'
 import * as context from './context'
 import { Maybe, Maybeable } from './maybe'
 
@@ -23,15 +24,9 @@ const limits = {
   sourceExpiryRange: [1 * SECONDS_PER_DAY, 30 * SECONDS_PER_DAY],
 }
 
-export type VendorSpecificValues = {
-  defaultEventLevelAttributionsPerSource: Record<SourceType, number>
-  maxAggregationKeysPerAttribution: number
-  triggerDataCardinality: Record<SourceType, bigint>
-}
-
 class Context extends context.Context {
   constructor(
-    readonly vsv: Partial<VendorSpecificValues>,
+    readonly vsv: Readonly<Partial<VendorSpecificValues>>,
     readonly sourceType: SourceType
   ) {
     super()
@@ -939,7 +934,7 @@ function trigger(ctx: Context, j: Json): Maybe<Trigger> {
 function validateJSON<T>(
   json: string,
   f: CtxFunc<Json, Maybe<T>>,
-  vsv: Partial<VendorSpecificValues>,
+  vsv: Readonly<Partial<VendorSpecificValues>>,
   sourceType: SourceType // irrelevant for triggers
 ): [context.ValidationResult, Maybe<T>] {
   const ctx = new Context(vsv, sourceType)
@@ -958,7 +953,7 @@ function validateJSON<T>(
 
 export function validateSource(
   json: string,
-  vsv: Partial<VendorSpecificValues>,
+  vsv: Readonly<Partial<VendorSpecificValues>>,
   sourceType: SourceType
 ): [context.ValidationResult, Maybe<Source>] {
   return validateJSON(json, source, vsv, sourceType)
@@ -966,7 +961,7 @@ export function validateSource(
 
 export function validateTrigger(
   json: string,
-  vsv: Partial<VendorSpecificValues>
+  vsv: Readonly<Partial<VendorSpecificValues>>
 ): [context.ValidationResult, Maybe<Trigger>] {
   return validateJSON(json, trigger, vsv, SourceType.navigation)
 }

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -1,0 +1,19 @@
+import { SourceType } from './source-type'
+
+export type VendorSpecificValues = {
+  defaultEventLevelAttributionsPerSource: Record<SourceType, number>
+  maxAggregationKeysPerAttribution: number
+  triggerDataCardinality: Record<SourceType, bigint>
+}
+
+export const Chromium: Readonly<VendorSpecificValues> = {
+  defaultEventLevelAttributionsPerSource: {
+    [SourceType.event]: 1,
+    [SourceType.navigation]: 3,
+  },
+  maxAggregationKeysPerAttribution: 20,
+  triggerDataCardinality: {
+    [SourceType.event]: 2n,
+    [SourceType.navigation]: 8n,
+  },
+}


### PR DESCRIPTION
For reuse in the flexible-event directory.