### PR TITLE
Separate build/pack Node scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(OUT_DIR):
 
 ts/dist/header-validator/main.js: ts/package.json ts/tsconfig.json ts/webpack.config.js ts/src/*.ts
 	@ npm ci --prefix ./ts
-	@ npm run build --prefix ./ts
+	@ npm run deploy --prefix ./ts
 
 clean:
 	@ rm -rf $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(OUT_DIR):
 
 ts/dist/header-validator/main.js: ts/package.json ts/tsconfig.json ts/webpack.config.js ts/src/*.ts
 	@ npm ci --prefix ./ts
-	@ npm run deploy --prefix ./ts
+	@ npm run pack --prefix ./ts
 
 clean:
 	@ rm -rf $(OUT_DIR)

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "deploy": "webpack --mode production",
+    "pack": "webpack --mode production",
     "flexible-event": "node dist/flexible-event/main.js",
     "test": "node --test dist/",
     "lint": "prettier . --write",

--- a/ts/package.json
+++ b/ts/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "private": true,
   "scripts": {
-    "build": "webpack --mode production",
+    "build": "tsc",
+    "deploy": "webpack --mode production",
     "flexible-event": "node dist/flexible-event/main.js",
-    "test": "tsc && node --test dist/",
+    "test": "node --test dist/",
     "lint": "prettier . --write",
     "lint:check": "prettier . --check"
   },


### PR DESCRIPTION
This helps prevent redundant build operations, which can be slow.