### PR TITLE
Make default event-level attributions per source a spec constant

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1245,6 +1245,10 @@ Its value is 20.
 controls the maximum [=list/size=] of [=attribution source/event-level report windows=].
 Its value is 5.
 
+<dfn>Default event-level attributions per source</dfn> is a [=map=] that
+controls how many times a single [=attribution source=] can create an [=event-level report=] by default.
+Its value is «[ [=source type/navigation=] → 3, [=source type/event=] → 1 ]».
+
 # Vendor-Specific Values # {#vendor-specific-values}
 
 <dfn>Max aggregation keys per source registration</dfn> is a positive integer that
@@ -1283,10 +1287,6 @@ controls how many [=event-level reports=] can be in the
 <dfn>Max aggregatable reports per attribution destination</dfn> is a positive integer that controls how
 many [=aggregatable reports=] can be in the [=aggregatable report cache=] per
 [=aggregatable report/effective attribution destination=].
-
-<dfn>Default event-level attributions per source</dfn> is a [=map=] that
-controls how many times a single [=attribution source=] can create an [=event-level report=] by default.
-The keys are «[=source type/navigation=], [=source type/event=]». The values are non-negative integers.
 
 <dfn>Max event-level channel capacity per source</dfn> is a [=map=] that
 controls how many bits of information can be exposed associated with a single [=attribution source=].

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -16,8 +16,6 @@ Chromium's implementation assigns the following values:
 | [Randomized null report rate including source registration time][] | [0.008][randomized null report rate including source registration time value] |
 | [Max event-level reports per attribution destination][] | [1024][max event-level reports per attribution destination value] |
 | [Max aggregatable reports per attribution destination][] | [1024][max aggregatable reports per attribution destination value] |
-| [Max attributions per navigation source][] | [3][max attributions per navigation source value] |
-| [Max attributions per event source][] | [1][max attributions per event source value] |
 | [Max aggregatable reports per source][] | [20][max aggregatable reports per source value] |
 | [Max destinations covered by unexpired sources][] | [100][max destinations covered by unexpired sources value] |
 | [Destination rate-limit window][] | [1 minute][destination rate-limit window value]
@@ -50,10 +48,6 @@ Chromium's implementation assigns the following values:
 [max event-level reports per attribution destination value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=61;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max aggregatable reports per attribution destination]: https://wicg.github.io/attribution-reporting-api/#max-aggregatable-reports-per-attribution-destination
 [max aggregatable reports per attribution destination value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=90;drc=3733a639d724a4353463a872605119d11a1e4d37
-[Max attributions per navigation source]: https://wicg.github.io/attribution-reporting-api/#max-attributions-per-navigation-source
-[max attributions per navigation source value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=64;drc=3733a639d724a4353463a872605119d11a1e4d37
-[Max attributions per event source]: https://wicg.github.io/attribution-reporting-api/#max-attributions-per-event-source
-[max attributions per event source value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=65;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max aggregatable reports per source]: https://wicg.github.io/attribution-reporting-api/#max-aggregatable-reports-per-source
 [max aggregatable reports per source value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=111;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max destinations covered by unexpired sources]: https://wicg.github.io/attribution-reporting-api/#max-destinations-covered-by-unexpired-sources

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -24,3 +24,10 @@ export const defaultEarlyEventLevelReportWindows: Readonly<
   [SourceType.event]: [],
   [SourceType.navigation]: [2 * SECONDS_PER_DAY, 7 * SECONDS_PER_DAY],
 }
+
+export const defaultEventLevelAttributionsPerSource: Readonly<
+  Record<SourceType, number>
+> = {
+  [SourceType.event]: 1,
+  [SourceType.navigation]: 3,
+}

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -1,6 +1,7 @@
 const commandLineArgs = require('command-line-args')
 const fs = require('fs')
 
+import * as constants from '../constants'
 import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, defaultConfig, PerTriggerDataConfig } from './privacy'
@@ -39,7 +40,7 @@ function getConfig(json: any, sourceType: SourceType): Config {
   }
 
   const defaultMaxReports =
-    vsv.Chromium.defaultEventLevelAttributionsPerSource[sourceType]
+    constants.defaultEventLevelAttributionsPerSource[sourceType]
   const defaultWindows = defaultMaxReports
 
   let maxEventLevelReports = json['max_event_level_reports']

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -114,7 +114,7 @@ export function defaultConfig(
   vsv: VendorSpecificValues
 ): Config {
   const defaultMaxReports =
-    vsv.defaultEventLevelAttributionsPerSource[sourceType]
+    constants.defaultEventLevelAttributionsPerSource[sourceType]
   return new Config(
     /*maxEventLevelReports=*/ defaultMaxReports,
     new Array(Number(vsv.triggerDataCardinality[sourceType])).fill(

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1089,10 +1089,6 @@ const testCases: TestCase[] = [
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.event,
     vsv: {
-      defaultEventLevelAttributionsPerSource: {
-        [SourceType.event]: 1,
-        [SourceType.navigation]: 3,
-      },
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: 0,
         [SourceType.navigation]: Infinity,
@@ -1115,10 +1111,6 @@ const testCases: TestCase[] = [
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.navigation,
     vsv: {
-      defaultEventLevelAttributionsPerSource: {
-        [SourceType.event]: 1,
-        [SourceType.navigation]: 3,
-      },
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: Infinity,
         [SourceType.navigation]: 0,

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -749,8 +749,7 @@ function channelCapacity(ctx: Context, s: Source): void {
   if (
     ctx.vsv.maxEventLevelChannelCapacityPerSource === undefined ||
     ctx.vsv.randomizedResponseEpsilon === undefined ||
-    ctx.vsv.triggerDataCardinality === undefined ||
-    s.maxEventLevelReports === null
+    ctx.vsv.triggerDataCardinality === undefined
   ) {
     // TODO: consider warning when this cannot be checked
     return
@@ -794,7 +793,7 @@ export type Source = CommonDebug &
     eventReportWindows: EventReportWindows
     expiry: number
     filterData: FilterData
-    maxEventLevelReports: number | null
+    maxEventLevelReports: number
     sourceEventId: bigint
   }
 
@@ -820,8 +819,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
         maxEventLevelReports: field(
           'max_event_level_reports',
           maxEventLevelReports,
-          ctx.vsv.defaultEventLevelAttributionsPerSource?.[ctx.sourceType] ??
-            null
+          constants.defaultEventLevelAttributionsPerSource[ctx.sourceType]
         ),
         sourceEventId: field('source_event_id', uint64, 0n),
 

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -1,7 +1,6 @@
 import { SourceType } from './source-type'
 
 export type VendorSpecificValues = {
-  defaultEventLevelAttributionsPerSource: Record<SourceType, number>
   maxAggregationKeysPerSource: number
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   randomizedResponseEpsilon: number
@@ -9,10 +8,6 @@ export type VendorSpecificValues = {
 }
 
 export const Chromium: Readonly<VendorSpecificValues> = {
-  defaultEventLevelAttributionsPerSource: {
-    [SourceType.event]: 1,
-    [SourceType.navigation]: 3,
-  },
   maxAggregationKeysPerSource: 20,
   maxEventLevelChannelCapacityPerSource: {
     [SourceType.event]: 6.5,


### PR DESCRIPTION
Now that max_event_level_reports is configurable per source registration and that implementations can impose constraints via https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source, there seems to be little benefit for different implementations to have different defaults here. Making this a constant ensures interoperability between specs, simplifies logic for reporting origins and implementers, and eliminates the only remaining source-parsing behavior that the spec allows to vary in this way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1022.html" title="Last updated on Sep 19, 2023, 6:43 PM UTC (ebacff1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1022/ec0778c...apasel422:ebacff1.html" title="Last updated on Sep 19, 2023, 6:43 PM UTC (ebacff1)">Diff</a>