### PR TITLE
Spec: Pad the payload with null contributions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3328,7 +3328,7 @@ is the result of running the following steps:
 
 1. Let |payloadData| be a new [=list/is empty|empty=] [=list=].
 1. Let |contributions| be |report|'s [=aggregatable report/contributions=].
-1. [=iteration/While=] |contributions|' [=list/size=] is less than [=maximum
+1. [=iteration/While=] |contributions|' [=list/size=] is less than [=max
     aggregation keys per source registration=]:
     1. Let |nullContribution| be a new [=aggregatable contribution=] with the
         items:

--- a/index.bs
+++ b/index.bs
@@ -3132,12 +3132,6 @@ To <dfn>obtain a null report</dfn> given an [=attribution trigger=] |trigger| an
 
 1. Let |reportTime| be the result of running [=obtain an aggregatable report delivery time=] with |trigger|'s
     [=attribution trigger/trigger time=].
-1. Let |contribution| be a new [=aggregatable contribution=] with the items:
-
-    : [=aggregatable contribution/key=]
-    :: 0
-    : [=aggregatable contribution/value=]
-    :: 0
 1. Let |report| be a new [=aggregatable report=] struct whose items are:
 
     : [=aggregatable report/reporting origin=]
@@ -3157,7 +3151,7 @@ To <dfn>obtain a null report</dfn> given an [=attribution trigger=] |trigger| an
     : [=aggregatable report/trigger debug key=]
     :: |trigger|'s [=attribution trigger/debug key=]
     : [=aggregatable report/contributions=]
-    :: « |contribution| »
+    :: «»
     : [=aggregatable report/serialized private state token=]
     :: null
     : [=aggregatable report/aggregation coordinator=]
@@ -3333,7 +3327,19 @@ An [=aggregatable report=] |report|'s <dfn for="aggregatable report">plaintext p
 is the result of running the following steps:
 
 1. Let |payloadData| be a new [=list/is empty|empty=] [=list=].
-1. [=list/iterate|For each=] |contribution| of |report|'s [=aggregatable report/contributions=]:
+1. Let |contributions| be |report|'s [=aggregatable report/contributions=].
+1. [=iteration/While=] |contributions|' [=list/size=] is less than [=maximum
+    aggregation keys per source registration=]:
+    1. Let |nullContribution| be a new [=aggregatable contribution=] with the
+        items:
+
+        : [=aggregatable contribution/key=]
+        :: 0
+        : [=aggregatable contribution/value=]
+        :: 0
+
+    1. [=list/Append=] |nullContribution| to |contributions|.
+1. [=list/iterate|For each=] |contribution| of |contributions|:
     1. Let |contributionData| be a [=map=] of the following key/value pairs:
 
         : "`bucket`"


### PR DESCRIPTION
Resolves #352.

See also the related spec change for the Private Aggregation API: https://github.com/patcg-individual-drafts/private-aggregation-api/pull/98. See also the corresponding ARA explainer change: #1031.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1030.html" title="Last updated on Sep 26, 2023, 9:20 PM UTC (11f2e08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1030/ec0778c...11f2e08.html" title="Last updated on Sep 26, 2023, 9:20 PM UTC (11f2e08)">Diff</a>