### PR TITLE
Document that the `fetch` API needs to allow `credentials` to set the debug cookie

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -619,9 +619,9 @@ Note that in the context of proposals such as
 order to allow debug keys to be registered.
 
 Responses that register sources/triggers can also set the `ar_debug` cookie to
-ensure that registeration is eligible for debug reports. When using the `fetch`
+ensure that registration is eligible for debug reports. When using the `fetch`
 APIs to do this, it will require ensuring the request is allowed to include
-[`credentials`]([url](https://developer.mozilla.org/en-US/docs/Web/API/fetch)).
+[`credentials`](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
 
 #### Attribution-success debugging reports
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -618,6 +618,11 @@ Note that in the context of proposals such as
 [CHIPS](https://github.com/privacycg/CHIPS), the cookie must be unpartitioned in
 order to allow debug keys to be registered.
 
+Responses that register sources/triggers can also set the `ar_debug` cookie to
+ensure that registeration is eligible for debug reports. When using the `fetch`
+APIs to do this, it will require ensuring the request is allowed to include
+[`credentials`]([url](https://developer.mozilla.org/en-US/docs/Web/API/fetch)).
+
 #### Attribution-success debugging reports
 
 Source and trigger registrations will both accept a new field `debug_key`:


### PR DESCRIPTION
Addresses #1028