### PR TITLE
Add speculative parsing for Full Flexible Event-Level source registrations

### DIFF
--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -31,3 +31,5 @@ export const defaultEventLevelAttributionsPerSource: Readonly<
   [SourceType.event]: 1,
   [SourceType.navigation]: 3,
 }
+
+export const maxTriggerDataPerSource: number = 32

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -1,7 +1,9 @@
 const commandLineArgs = require('command-line-args')
 import { readFileSync } from 'fs'
 
-import * as constants from '../constants'
+import { Issue } from '../header-validator/context'
+import { Maybe } from '../header-validator/maybe'
+import { validateSource } from '../header-validator/validate-json'
 import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, PerTriggerDataConfig } from './privacy'
@@ -15,88 +17,6 @@ function parseSourceType(str: string): SourceType {
     throw 'unknown source type'
   }
   return str as SourceType
-}
-
-function getNumWindowsFromJson(defaultVal: number, windows: any): number {
-  if (windows === undefined) {
-    return defaultVal
-  }
-
-  if (typeof windows !== 'object') {
-    throw 'event_report_windows must be an object'
-  }
-
-  const endTimes = windows['end_times']
-  if (!Array.isArray(endTimes)) {
-    throw 'end_times must be an array'
-  }
-
-  return endTimes.length
-}
-
-function getConfig(json: any, sourceType: SourceType): Config {
-  if (typeof json !== 'object') {
-    throw 'root JSON must be an object'
-  }
-
-  const defaultMaxReports =
-    constants.defaultEventLevelAttributionsPerSource[sourceType]
-  const defaultWindows = defaultMaxReports
-
-  let maxEventLevelReports = json['max_event_level_reports']
-  if (maxEventLevelReports === undefined) {
-    maxEventLevelReports = defaultMaxReports
-  } else if (typeof maxEventLevelReports !== 'number') {
-    throw 'max_event_level_reports must be a number'
-  }
-
-  const topLevelNumWindows = getNumWindowsFromJson(
-    defaultWindows,
-    json['event_report_windows']
-  )
-
-  const triggerSpecs = json['trigger_specs']
-  if (!Array.isArray(triggerSpecs)) {
-    throw 'trigger_specs must be an array'
-  }
-
-  const perTriggerDataConfigs: PerTriggerDataConfig[] = []
-  triggerSpecs.forEach((spec: any) => {
-    if (typeof spec !== 'object') {
-      throw 'trigger_specs item must be an object'
-    }
-
-    const triggerData = spec['trigger_data']
-    if (!Array.isArray(triggerData)) {
-      throw 'trigger_data must be an array'
-    }
-
-    const numDataTypes = triggerData.length
-
-    const numWindows = getNumWindowsFromJson(
-      topLevelNumWindows,
-      spec['event_report_windows']
-    )
-
-    // Technically this can be larger, but we will always be constrained
-    // by `max_event_level_reports`.
-    let numBuckets = maxEventLevelReports
-    const summaryBuckets = spec['summary_buckets']
-    if (summaryBuckets !== undefined) {
-      if (!Array.isArray(summaryBuckets)) {
-        throw 'summary_buckets must be an array'
-      }
-      numBuckets = summaryBuckets.length
-    }
-
-    for (let i = 0; i < numDataTypes; i++) {
-      perTriggerDataConfigs.push(
-        new PerTriggerDataConfig(numWindows, numBuckets)
-      )
-    }
-  })
-
-  return new Config(maxEventLevelReports, perTriggerDataConfigs)
 }
 
 const optionDefs = [
@@ -135,41 +55,78 @@ const optionDefs = [
   },
 ]
 
+function logIssue(prefix: string, i: Issue): void {
+  console.log(
+    `${prefix}: ${i.path !== undefined ? i.path.join('/') : 'root'}: ${i.msg}`
+  )
+}
+
 const options = commandLineArgs(optionDefs)
 
-let config: Config
+let config: Maybe<Config> = Maybe.None
 if ('json_file' in options) {
-  const json = JSON.parse(readFileSync(options.json_file, { encoding: 'utf8' }))
-  config = getConfig(json, options.source_type)
+  const json = readFileSync(options.json_file, { encoding: 'utf8' })
+  const [{ errors, warnings }, source] = validateSource(
+    json,
+    vsv.Chromium,
+    options.source_type,
+    /*parseFullFlex=*/ true
+  )
+  warnings.forEach((i) => logIssue('W', i))
+  if (errors.length > 0) {
+    errors.forEach((i) => logIssue('E', i))
+    process.exit(1)
+  }
+
+  config = source.map(
+    (source) =>
+      new Config(
+        source.maxEventLevelReports!,
+        source.triggerSpecs.flatMap((spec) =>
+          new Array(spec.triggerData.size).fill(
+            new PerTriggerDataConfig(
+              spec.eventReportWindows.endTimes.length,
+              spec.summaryBuckets.length
+            )
+          )
+        )
+      )
+  )
 } else {
   if (options.windows.length !== options.buckets.length) {
     throw 'windows and buckets must have same length'
   }
-  config = new Config(
-    options.max_event_level_reports,
-    options.windows.map(
-      (w: number, i: number) => new PerTriggerDataConfig(w, options.buckets[i])
+  config = Maybe.some(
+    new Config(
+      options.max_event_level_reports,
+      options.windows.map(
+        (w: number, i: number) =>
+          new PerTriggerDataConfig(w, options.buckets[i])
+      )
     )
   )
 }
 
-const infoGainMax =
-  vsv.Chromium.maxEventLevelChannelCapacityPerSource[
-    options.source_type as SourceType
-  ]
-const out = config.computeConfigData(options.epsilon, infoGainMax)
+config.peek((config) => {
+  const infoGainMax =
+    vsv.Chromium.maxEventLevelChannelCapacityPerSource[
+      options.source_type as SourceType
+    ]
 
-console.log(`Number of possible different output states: ${out.numStates}`)
-console.log(`Information gain: ${out.infoGain.toFixed(2)} bits`)
-console.log(`Flip percent: ${(100 * out.flipProb).toFixed(5)}%`)
+  const out = config.computeConfigData(options.epsilon, infoGainMax)
 
-if (out.excessive) {
-  const e = out.excessive
-  console.log(
-    `WARNING: info gain > ${infoGainMax.toFixed(2)} for ${
-      options.source_type
-    } sources. Would require a ${(100 * e.newFlipProb).toFixed(
-      5
-    )}% flip chance (effective epsilon = ${e.newEps.toFixed(3)}) to resolve.`
-  )
-}
+  console.log(`Number of possible different output states: ${out.numStates}`)
+  console.log(`Information gain: ${out.infoGain.toFixed(2)} bits`)
+  console.log(`Flip percent: ${(100 * out.flipProb).toFixed(5)}%`)
+
+  if (out.excessive) {
+    const e = out.excessive
+    console.log(
+      `WARNING: info gain > ${infoGainMax.toFixed(2)} for ${
+        options.source_type
+      } sources. Would require a ${(100 * e.newFlipProb).toFixed(
+        5
+      )}% flip chance (effective epsilon = ${e.newEps.toFixed(3)}) to resolve.`
+    )
+  }
+})

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import * as constants from '../constants'
 import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import {
+  Config,
+  PerTriggerDataConfig,
+  binaryEntropy,
   flipProbabilityDp,
   maxInformationGain,
-  binaryEntropy,
-  defaultConfig,
 } from './privacy'
 
 const flipProbabilityTests = [
@@ -104,6 +106,24 @@ test('binaryEntropy', async (t) => {
     )
   )
 })
+
+function defaultConfig(
+  sourceType: SourceType,
+  vsv: vsv.VendorSpecificValues
+): Config {
+  const defaultMaxReports =
+    constants.defaultEventLevelAttributionsPerSource[sourceType]
+  return new Config(
+    /*maxEventLevelReports=*/ defaultMaxReports,
+    new Array(Number(vsv.triggerDataCardinality[sourceType])).fill(
+      new PerTriggerDataConfig(
+        /*numWindows=*/
+        constants.defaultEarlyEventLevelReportWindows[sourceType].length + 1,
+        /*numSummaryBuckets=*/ defaultMaxReports
+      )
+    )
+  )
+}
 
 test('computeConfigData', async (t) => {
   await t.test('navigation', () => {

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -1,7 +1,4 @@
 import memoize from 'memoizee'
-import * as constants from '../constants'
-import { SourceType } from '../source-type'
-import { VendorSpecificValues } from '../vendor-specific-values'
 
 export type ExcessiveInfoGainData = {
   newEps: number
@@ -106,24 +103,6 @@ export class Config {
 
     return data
   }
-}
-
-export function defaultConfig(
-  sourceType: SourceType,
-  vsv: VendorSpecificValues
-): Config {
-  const defaultMaxReports =
-    constants.defaultEventLevelAttributionsPerSource[sourceType]
-  return new Config(
-    /*maxEventLevelReports=*/ defaultMaxReports,
-    new Array(Number(vsv.triggerDataCardinality[sourceType])).fill(
-      new PerTriggerDataConfig(
-        /*numWindows=*/
-        constants.defaultEarlyEventLevelReportWindows[sourceType].length + 1,
-        /*numSummaryBuckets=*/ defaultMaxReports
-      )
-    )
-  )
 }
 
 // Evaluates the binary entropy function.

--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -8,6 +8,7 @@ export type TestCase<T> = testutil.TestCase & {
   name: string
   json: string
   vsv?: Readonly<Partial<vsv.VendorSpecificValues>>
+  parseFullFlex?: boolean
   expected?: Maybe<T>
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -760,7 +760,7 @@ function eventReportWindow(
 
 function channelCapacity(ctx: Context, s: Source): void {
   const perTriggerDataConfigs = s.triggerSpecs.flatMap((spec) =>
-    new Array(spec.triggerData.size).fill(
+    Array(spec.triggerData.size).fill(
       new privacy.PerTriggerDataConfig(
         spec.eventReportWindows.endTimes.length,
         spec.summaryBuckets.length
@@ -811,15 +811,15 @@ function summaryBuckets(
   const bucket = (ctx: Context, j: Json): Maybe<number> =>
     number(ctx, j)
       .filter((n) => isInteger(ctx, n))
-      .filter((n) => {
-        return isInRange(
+      .filter((n) =>
+        isInRange(
           ctx,
           n,
           prev + 1,
           UINT32_MAX,
           `must be > ${prevDesc} (${prev}) and <= uint32 max (${UINT32_MAX})`
         )
-      })
+      )
       .peek((n) => {
         prev = n
         prevDesc = 'previous value'
@@ -864,13 +864,9 @@ function triggerSpec(
   j: Json,
   deps: TriggerSpecDeps
 ): Maybe<TriggerSpec> {
-  const defaultSummaryBuckets = deps.maxEventLevelReports.map((n) => {
-    const buckets: number[] = []
-    for (let i = 1; i <= n; ++i) {
-      buckets.push(i)
-    }
-    return buckets
-  })
+  const defaultSummaryBuckets = deps.maxEventLevelReports.map((n) =>
+    Array.from({ length: n }, (_, i) => i + 1)
+  )
 
   return struct(ctx, j, {
     eventReportWindows: field(
@@ -941,14 +937,16 @@ function defaultTriggerSpecs(
     maxEventLevelReports.map((maxEventLevelReports) => [
       {
         eventReportWindows,
-        summaryBuckets: Array(maxEventLevelReports)
-          .fill(0)
-          .map((_, i) => i + 1),
+        summaryBuckets: Array.from(
+          { length: maxEventLevelReports },
+          (_, i) => i + 1
+        ),
         summaryWindowOperator: SummaryWindowOperator.count,
         triggerData: new Set(
-          Array(Number(ctx.vsv.triggerDataCardinality[ctx.sourceType]))
-            .fill(0)
-            .map((_, i) => i)
+          Array.from(
+            { length: Number(ctx.vsv.triggerDataCardinality[ctx.sourceType]) },
+            (_, i) => i
+          )
         ),
       },
     ])


### PR DESCRIPTION
This replaces the ad-hoc parsing and validation in the Flexible Event privacy scripts.

By default, parsing of these fields is disabled in the interactive header validator, since they are unspecified and subject to change.