### PR TITLE
Check expected values within subtest

### DIFF
--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -15,10 +15,11 @@ export function run<T>(
   tc: TestCase<T>,
   f: () => [context.ValidationResult, Maybe<T>]
 ): void {
-  const [validationResult, value] = f()
-  testutil.run(tc, tc.name, () => validationResult)
-
-  if (tc.expected !== undefined) {
-    assert.deepEqual(value, tc.expected, tc.name)
-  }
+  testutil.run(tc, tc.name, () => {
+    const [validationResult, value] = f()
+    if (tc.expected !== undefined) {
+      assert.deepEqual(value, tc.expected, tc.name)
+    }
+    return validationResult
+  })
 }

--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -18,7 +18,7 @@ export function run<T>(
   testutil.run(tc, tc.name, () => {
     const [validationResult, value] = f()
     if (tc.expected !== undefined) {
-      assert.deepEqual(value, tc.expected, tc.name)
+      assert.deepEqual(value, tc.expected)
     }
     return validationResult
   })


### PR DESCRIPTION
Previously, the value check was performed outside the scope of the test() call in util.test.ts, making failure output misleading.