### PR TITLE
Require vendor-specific values for source/trigger validation

### DIFF
--- a/ts/src/header-validator/index.html
+++ b/ts/src/header-validator/index.html
@@ -73,7 +73,7 @@ textarea {
       <p><label><input type=radio name=header value=os-source><code>Attribution-Reporting-Register-OS-Source</code></label>
       <p><label><input type=radio name=header value=os-trigger><code>Attribution-Reporting-Register-OS-Trigger</code></label>
       <p><label><input type=radio name=header value=eligible><code>Attribution-Reporting-Eligible</code></label>
-      <p><label><input type=checkbox id=chromium-vsv>Use Chromium's vendor-specific values</label> <a href="https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md" target=_blank>(details)</a>
+      <p><label><input type=checkbox checked disabled>Use Chromium's vendor-specific values</label> <a href="https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md" target=_blank>(details)</a>
     </fieldset>
     <fieldset id=output>
       <legend>Validation Result</legend>

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -1,18 +1,12 @@
 import { SourceType } from '../source-type'
 import { Issue, PathComponent } from './context'
-import {
-  Chromium as ChromiumVsv,
-  VendorSpecificValues,
-} from '../vendor-specific-values'
+import * as vsv from '../vendor-specific-values'
 import { validateSource, validateTrigger } from './validate-json'
 import { validateEligible } from './validate-eligible'
 import { validateOsRegistration } from './validate-os'
 
 const form = document.querySelector('form')! as HTMLFormElement
 const input = form.querySelector('textarea')! as HTMLTextAreaElement
-const useChromiumVsvCheckbox = document.querySelector(
-  '#chromium-vsv'
-)! as HTMLInputElement
 const headerRadios = form.elements.namedItem('header')! as RadioNodeList
 const sourceTypeRadios = form.elements.namedItem(
   'source-type'
@@ -61,19 +55,16 @@ function sourceType(): SourceType {
 }
 
 function validate(): void {
-  const vsv: Readonly<Partial<VendorSpecificValues>> =
-    useChromiumVsvCheckbox.checked ? ChromiumVsv : {}
-
   sourceTypeFieldset.disabled = true
 
   let result
   switch (headerRadios.value) {
     case 'source':
       sourceTypeFieldset.disabled = false
-      result = validateSource(input.value, vsv, sourceType())[0]
+      result = validateSource(input.value, vsv.Chromium, sourceType())[0]
       break
     case 'trigger':
-      result = validateTrigger(input.value, vsv)[0]
+      result = validateTrigger(input.value, vsv.Chromium)[0]
       break
     case 'os-source':
       result = validateOsRegistration(input.value)
@@ -100,7 +91,6 @@ function validate(): void {
   warningList.replaceChildren(...result.warnings.map(makeLi))
 }
 
-useChromiumVsvCheckbox.addEventListener('change', validate)
 form.addEventListener('input', validate)
 
 document.querySelector('#linkify')!.addEventListener('click', async () => {
@@ -108,10 +98,6 @@ document.querySelector('#linkify')!.addEventListener('click', async () => {
   url.search = ''
   url.searchParams.set('header', headerRadios.value)
   url.searchParams.set('json', input.value)
-
-  if (useChromiumVsvCheckbox.checked) {
-    url.searchParams.set('vsv', 'chromium')
-  }
 
   if (url.searchParams.get('header') === 'source') {
     url.searchParams.set('source-type', sourceType())
@@ -128,11 +114,6 @@ const params = new URLSearchParams(location.search)
 const json = params.get('json')
 if (json) {
   input.value = json
-}
-
-const vsv = params.get('vsv')
-if (vsv === 'chromium') {
-  useChromiumVsvCheckbox.checked = true
 }
 
 const allowedValues = new Set([

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1,4 +1,5 @@
 import { SourceType } from '../source-type'
+import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
 import { Source, validateSource } from './validate-json'
 import * as jsontest from './validate-json.test'
@@ -906,7 +907,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "event_report_windows": {
         "start_time": 10,
-        "end_times": [3611,3612,3613,3614]
+        "end_times": [3611,3612,3613]
       }
     }`,
   },
@@ -1134,7 +1135,7 @@ testCases.forEach((tc) =>
   jsontest.run(tc, () =>
     validateSource(
       tc.json,
-      tc.vsv ?? {},
+      { ...vsv.Chromium, ...tc.vsv },
       tc.sourceType ?? SourceType.navigation
     )
   )

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1,4 +1,5 @@
 import { SourceType } from '../source-type'
+import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
 import {
   AggregatableSourceRegistrationTime,
@@ -36,7 +37,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "filters": {"x": []},
         "not_filters": {"y": []},
         "priority": "-7",
-        "trigger_data": "6"
+        "trigger_data": "1"
       }],
       "filters": {"f": []},
       "not_filters": {"g": []}
@@ -87,7 +88,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         {
           dedupKey: 123n,
           priority: -7n,
-          triggerData: 6n,
+          triggerData: 1n,
           positive: [
             {
               lookbackWindow: null,
@@ -903,5 +904,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
 ]
 
 testCases.forEach((tc) =>
-  jsontest.run(tc, () => validateTrigger(tc.json, tc.vsv ?? {}))
+  jsontest.run(tc, () =>
+    validateTrigger(tc.json, { ...vsv.Chromium, ...tc.vsv })
+  )
 )

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -17,7 +17,7 @@ const hex128Regex = /^0[xX][0-9A-Fa-f]{1,32}$/
 
 class Context extends context.Context {
   constructor(
-    readonly vsv: Readonly<Partial<VendorSpecificValues>>,
+    readonly vsv: Readonly<VendorSpecificValues>,
     readonly sourceType: SourceType
   ) {
     super()
@@ -238,7 +238,7 @@ function uint64(ctx: Context, j: Json): Maybe<bigint> {
 
 function triggerData(ctx: Context, j: Json): Maybe<bigint> {
   return uint64(ctx, j).peek((n) => {
-    Object.entries(ctx.vsv.triggerDataCardinality ?? []).forEach(([t, c]) => {
+    Object.entries(ctx.vsv.triggerDataCardinality).forEach(([t, c]) => {
       if (n >= c) {
         ctx.warning(
           `will be sanitized to ${
@@ -752,15 +752,6 @@ function eventReportWindow(
 }
 
 function channelCapacity(ctx: Context, s: Source): void {
-  if (
-    ctx.vsv.maxEventLevelChannelCapacityPerSource === undefined ||
-    ctx.vsv.randomizedResponseEpsilon === undefined ||
-    ctx.vsv.triggerDataCardinality === undefined
-  ) {
-    // TODO: consider warning when this cannot be checked
-    return
-  }
-
   const perTriggerDataConfigs = []
   for (let i = 0n; i < ctx.vsv.triggerDataCardinality[ctx.sourceType]; i++) {
     perTriggerDataConfigs.push(
@@ -983,7 +974,7 @@ function trigger(ctx: Context, j: Json): Maybe<Trigger> {
 function validateJSON<T>(
   json: string,
   f: CtxFunc<Json, Maybe<T>>,
-  vsv: Readonly<Partial<VendorSpecificValues>>,
+  vsv: Readonly<VendorSpecificValues>,
   sourceType: SourceType // irrelevant for triggers
 ): [context.ValidationResult, Maybe<T>] {
   const ctx = new Context(vsv, sourceType)
@@ -1002,7 +993,7 @@ function validateJSON<T>(
 
 export function validateSource(
   json: string,
-  vsv: Readonly<Partial<VendorSpecificValues>>,
+  vsv: Readonly<VendorSpecificValues>,
   sourceType: SourceType
 ): [context.ValidationResult, Maybe<Source>] {
   return validateJSON(json, source, vsv, sourceType)
@@ -1010,7 +1001,7 @@ export function validateSource(
 
 export function validateTrigger(
   json: string,
-  vsv: Readonly<Partial<VendorSpecificValues>>
+  vsv: Readonly<VendorSpecificValues>
 ): [context.ValidationResult, Maybe<Trigger>] {
   return validateJSON(json, trigger, vsv, SourceType.navigation)
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -179,6 +179,7 @@ function keyValues<V>(
 
       if (entries.length > maxKeys) {
         ctx.error(`exceeds the maximum number of keys (${maxKeys})`)
+        return false
       }
 
       return isCollection(ctx, entries, (ctx, [key, j]) =>
@@ -198,10 +199,12 @@ function list(
   j: Json,
   { minLength = 0, maxLength = Infinity }: ListOpts = {}
 ): Maybe<Json[]> {
-  return typeSwitch(ctx, j, { list: (_ctx, j) => some(j) }).peek((j) => {
+  return typeSwitch(ctx, j, { list: (_ctx, j) => some(j) }).filter((j) => {
     if (j.length > maxLength || j.length < minLength) {
       ctx.error(`length must be in the range [${minLength}, ${maxLength}]`)
+      return false
     }
+    return true
   })
 }
 


### PR DESCRIPTION
Proper validation relies more and more on the presence of all
vendor-specific values, so requiring this here simplifies the code,
especially for the forthcoming Full Flexible Event-Level changes.

If there are alternative vendor-specific values in the future, we will
expose them in the interactive header validator using a dropdown menu.