### PR TITLE
Add version to the aggregation coordinator public key endpoint

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -308,7 +308,7 @@ shared.
 The encryption will use public keys specified by the aggregation service. The
 browser will encrypt payloads just before the report is sent by fetching the
 public key endpoint (the aggregation service coordinator origin at the path
- `/.well-known/aggregation-service/public-keys`) with an un-credentialed request. The processing origin will
+ `/.well-known/aggregation-service/v1/public-keys`) with an un-credentialed request. The processing origin will
 respond with a set of keys which will be stored according to standard HTTP
 caching rules, i.e. using Cache-Control headers to dictate how long to store the
 keys for (e.g. following the [freshness
@@ -328,6 +328,8 @@ encoded public keys is as follows:
   ]
 }
 ```
+
+Note: The version in the `.well-known` path may change.
 
 To limit the impact of a single compromised key, multiple keys (up to a small
 limit) can be provided. The browser should independently pick a key uniformly at

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -329,7 +329,9 @@ encoded public keys is as follows:
 }
 ```
 
-Note: The version in the `.well-known` path may change.
+Note: The version in the `.well-known` path may be updated in the future
+versions of the spec if the public key serving details change, especially in a
+backwards incompatible way.
 
 To limit the impact of a single compromised key, multiple keys (up to a small
 limit) can be provided. The browser should independently pick a key uniformly at

--- a/index.bs
+++ b/index.bs
@@ -3280,7 +3280,7 @@ To <dfn>obtain the public key for encryption</dfn> given an [=aggregation coordi
 1. Set |url|'s [=url/scheme=] to |aggregationCoordinator|'s [=origin/scheme=].
 1. Set |url|'s [=url/host=] to |aggregationCoordinator|'s [=origin/host=].
 1. Set |url|'s [=url/port=] to |aggregationCoordinator|'s [=origin/port=].
-1. Set |url|'s [=url/path=]  to «"`.well-known`", "`aggregation-service`", "`public-keys`"».
+1. Set |url|'s [=url/path=]  to «"`.well-known`", "`aggregation-service`", "`v1`", "`public-keys`"».
 1. Return a user-agent-determined public key from |url| or an error in the event that the user
     agent failed to obtain the public key from |url|. This step may be asynchronous.
 


### PR DESCRIPTION
Add version to the .well-known path, this allows future changes to public keys. This changes the endpoint for the client (e.g Chrome) to fetch public keys, and the ad-techs are not impacted.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1053.html" title="Last updated on Oct 16, 2023, 4:17 PM UTC (95377ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1053/74450a3...linnan-github:95377ba.html" title="Last updated on Oct 16, 2023, 4:17 PM UTC (95377ba)">Diff</a>