### PR TITLE
Express "parse report windows" algorithm in terms of expiry

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1856,18 +1856,25 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-and a [=report window list=] |default|:
+a [=source type=] |sourceType|, and a [=duration=] |expiry|.
 
-1. If |map|["`event_report_windows`"] does not [=map/exist=], return |default|.
+1. If |map|["`event_report_window`"] [=map/exists=] and
+    |map|["`event_report_windows`"] [=map/exists=], return an error.
+1. If |map|["`event_report_window`"] [=map/exists=]:
+    1. Let |eventReportWindow| be the result of running [=parse a duration=]
+        with |map|, "`event_report_window`", and ([=min report window=], |expiry|).
+    1. If |eventReportWindow| is an error, return |eventReportWindow|.
+    1. Return the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
+1. If |map|["`event_report_windows`"] does not [=map/exist=]:
+    1. Return the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |expiry|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
-1. Let |defaultEndDuration| be the [=duration from=] |sourceTime| and the [=report window/end=] of the last element of |default|.
 1. Let |startDuration| be 0 seconds.
 1. If |map|["`start_time`"] [=map/exists=]:
     1. Let |start| be |map|["`start_time`"].
     1. If |start| is not a non-negative integer, return an error.
     1. Set |startDuration| to |start| seconds.
-    1. If |startDuration| is greater than |defaultEndDuration|, return an error.
+    1. If |startDuration| is greater than |expiry|, return an error.
 1. If |values|["`end_times`"] does not [=map/exist=] or is not a [=list=], return an error.
 1. Let |endDurations| be |values|["`end_times`"].
 1. If the [=list/size=] of |endDurations| is greater than [=max settable event-level report windows=], return an error.
@@ -1876,7 +1883,7 @@ and a [=report window list=] |default|:
 1. [=list/iterate|For each=] |end| of |endDurations|:
     1. If |end| is not a positive integer, return an error.
     1. Let |endDuration| be |end| seconds.
-    1. If |endDuration| is greater than |defaultEndDuration|, set |endDuration| to |defaultEndDuration|.
+    1. If |endDuration| is greater than |expiry|, set |endDuration| to |expiry|.
     1. If |endDuration| is less than [=min report window=], set |endDuration| to [=min report window=].
     1. If |endDuration| is less than or equal to |startDuration|, return an error.
     1. Let |window| be a new [=report window=] whose items are
@@ -1932,19 +1939,13 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
 1. Set |maxAttributionsPerSource| to |value|["`max_event_level_reports`"] if it [=map/exists=].
 1. If |maxAttributionsPerSource| is not a non-negative integer, or is greater than [=max settable event-level attributions per source=], return null.
-1. Let |eventReportWindow| be the result of running [=parse a duration=] with
-    |value|, "`event_report_window`", and ([=min report window=], |expiry|).
-1. If |eventReportWindow| is an error, return null.
 1. Let |aggregatableReportWindowEnd| be the result of running [=parse a duration=]
     with |value|, "`aggregatable_report_window`", and ([=min report window=], |expiry|).
 1. If |aggregatableReportWindowEnd| is an error, return null.
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to |value|["`debug_reporting`"].
-
-1. Let |eventReportWindows| be the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
-1. If both |value|["`event_report_window`"] and |value|["`event_report_windows`"] [=map/exist=], return null.
-1. Set |eventReportWindows| to the result of [=parsing report windows=] with |value|, |sourceTime|, and |eventReportWindows|.
+1. Let |eventReportWindows| be the result of [=parsing report windows=] with |value|, |sourceTime|, |sourceType|, and |expiry|.
 1. If |eventReportWindows| is an error, return null.
 1. Let |aggregatableReportWindow| be a new [=report window=] with the following items:
 

--- a/index.bs
+++ b/index.bs
@@ -1865,8 +1865,9 @@ a [=source type=] |sourceType|, and a [=duration=] |expiry|.
         with |map|, "`event_report_window`", and ([=min report window=], |expiry|).
     1. If |eventReportWindow| is an error, return |eventReportWindow|.
     1. Return the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |eventReportWindow|.
-1. If |map|["`event_report_windows`"] does not [=map/exist=]:
-    1. Return the result of [=obtaining default effective windows=] given |sourceType|, |sourceTime|, and |expiry|.
+1. If |map|["`event_report_windows`"] does not [=map/exist=], return the result
+    of [=obtaining default effective windows=] given |sourceType|, |sourceTime|,
+    and |expiry|.
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
 1. Let |startDuration| be 0 seconds.

--- a/index.bs
+++ b/index.bs
@@ -1856,7 +1856,7 @@ a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
 1. Return |windows|.
 
 To <dfn>parse report windows</dfn> given a [=map=] |map|, a [=moment=] |sourceTime|,
-a [=source type=] |sourceType|, and a [=duration=] |expiry|.
+a [=source type=] |sourceType|, and a [=duration=] |expiry|:
 
 1. If |map|["`event_report_window`"] [=map/exists=] and
     |map|["`event_report_windows`"] [=map/exists=], return an error.


### PR DESCRIPTION
It feels a bit circular to define it in terms of the last value of the default windows, when the default windows are only used when the `event_report_windows` field is absent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1057.html" title="Last updated on Oct 2, 2023, 7:48 PM UTC (e29316e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1057/e1dc946...apasel422:e29316e.html" title="Last updated on Oct 2, 2023, 7:48 PM UTC (e29316e)">Diff</a>