### PR TITLE
Make it clear the channel capacity of the unary channel is 0

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1770,6 +1770,7 @@ To <dfn>obtain a randomized source response</dfn> given a [=randomized response 
 To <dfn>compute the channel capacity of a source</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
 1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
 1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
+1. If |states| is 1, return 0.
 1. Let |p| be |pickRate| * (|states| - 1) / |states|.
 1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
 


### PR DESCRIPTION
See https://chromium-review.googlesource.com/c/chromium/src/+/4909556 for the chromium change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1060.html" title="Last updated on Oct 4, 2023, 2:43 PM UTC (c8a7a00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1060/90b576c...c8a7a00.html" title="Last updated on Oct 4, 2023, 2:43 PM UTC (c8a7a00)">Diff</a>