### PR TITLE
`Allowed aggregatable budget per source` should be a constant

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1216,6 +1216,10 @@ Its value is 5.
 controls how many times a single [=attribution source=] can create an [=event-level report=] by default.
 Its value is «[ [=source type/navigation=] → 3, [=source type/event=] → 1 ]».
 
+<dfn>Allowed aggregatable budget per source</dfn> is a positive integer that controls the total
+[=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
+an [=attribution source=]. Its value is 65536.
+
 # Vendor-Specific Values # {#vendor-specific-values}
 
 <dfn>Max aggregation keys per source registration</dfn> is a positive integer that
@@ -1307,10 +1311,6 @@ controls the maximum number of attributions for a
 [=attribution rate-limit record/attribution destination=],
 [=attribution rate-limit record/reporting origin=] [=site=]) per
 [=attribution rate-limit window=].
-
-<dfn>Allowed aggregatable budget per source</dfn> is a positive integer that controls the total
-[=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
-an [=attribution source=].
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive [=duration=] that controls the
 random delay to deliver an [=aggregatable report=]. If [=automation local testing mode=] is true,

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -25,7 +25,6 @@ Chromium's implementation assigns the following values:
 | [Origin rate-limit window][] | [1 day][origin rate-limit window value]
 | [Max attribution reporting origins per rate-limit window][] | [10][max attribution reporting origins per rate-limit window value] |
 | [Max attributions per rate-limit window][] | [100][max attributions per rate-limit window value] |
-| [Allowed aggregatable budget per source][] | [65536][allowed aggregatable budget per source value] |
 | [Randomized aggregatable report delay][] | [10 minutes][randomized aggregatable report delay value] |
 | [Max information gain for navigation sources][] | [11.46 bits][max information gain for navigations value] |
 | [Max information gain for event sources][] | [6.5 bits][max information gain for events value] |
@@ -67,8 +66,6 @@ Chromium's implementation assigns the following values:
 [max attribution reporting origins per rate-limit window value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=32;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max attributions per rate-limit window]: https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window
 [max attributions per rate-limit window value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=36;drc=3733a639d724a4353463a872605119d11a1e4d37
-[Allowed aggregatable budget per source]: https://wicg.github.io/attribution-reporting-api/#allowed-aggregatable-budget-per-source
-[allowed aggregatable budget per source value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=97;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Randomized aggregatable report delay]: https://wicg.github.io/attribution-reporting-api/#randomized-aggregatable-report-delay
 [randomized aggregatable report delay value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=106;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max information gain for navigation sources]: https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -34,4 +34,4 @@ export const defaultEventLevelAttributionsPerSource: Readonly<
 
 export const maxTriggerDataPerSource: number = 32
 
-export const allowedAggregatableBudgetPerSource = 65536;
+export const allowedAggregatableBudgetPerSource = 65536

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -34,4 +34,4 @@ export const defaultEventLevelAttributionsPerSource: Readonly<
 
 export const maxTriggerDataPerSource: number = 32
 
-export const allowedAggregatableBudgetPerSource = 65536
+export const allowedAggregatableBudgetPerSource: number = 65536

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -33,3 +33,5 @@ export const defaultEventLevelAttributionsPerSource: Readonly<
 }
 
 export const maxTriggerDataPerSource: number = 32
+
+export const allowedAggregatableBudgetPerSource = 65536;

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1105,7 +1105,9 @@ function aggregatableKeyValue(
 ): Maybe<number> {
   return number(ctx, j)
     .filter((n) => isInteger(ctx, n))
-    .filter((n) => isInRange(ctx, n, 1, constants.allowedAggregatableBudgetPerSource))
+    .filter((n) =>
+      isInRange(ctx, n, 1, constants.allowedAggregatableBudgetPerSource)
+    )
 }
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1105,7 +1105,7 @@ function aggregatableKeyValue(
 ): Maybe<number> {
   return number(ctx, j)
     .filter((n) => isInteger(ctx, n))
-    .filter((n) => isInRange(ctx, n, 1, 65536))
+    .filter((n) => isInRange(ctx, n, 1, constants.allowedAggregatableBudgetPerSource))
 }
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1065.html" title="Last updated on Oct 10, 2023, 2:34 PM UTC (612c67b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1065/7b8dc41...612c67b.html" title="Last updated on Oct 10, 2023, 2:34 PM UTC (612c67b)">Diff</a>