### PR TITLE
Specify max bytes per filter string and max bytes per aggregation key identifier as constants

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1197,6 +1197,11 @@ Its value is 50.
 controls the maximum [=set/size=] of each [=map/value=] of an
 [=attribution source=]'s [=attribution source/filter data=]. Its value is 50.
 
+<dfn>Max bytes per filter string</dfn> is a positive interger that controls the
+maximum [=string/length=] of an [=attribution source=]'s [=attribution source/filter data=]'s
+[=map/keys=] and its [=map/values=]'s [=set/items=].
+Its value is 25.
+
 <dfn>Attribution rate-limit window</dfn> is a positive [=duration=] that
 controls the rate-limiting window for attribution. Its value is 30 days.
 
@@ -1219,6 +1224,12 @@ Its value is «[ [=source type/navigation=] → 3, [=source type/event=] → 1 ]
 <dfn>Allowed aggregatable budget per source</dfn> is a positive integer that controls the total
 [=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
 an [=attribution source=]. Its value is 65536.
+
+<dfn>Max bytes per aggregation key identifier</dfn> is a positive integer that controls
+the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values=]'s [=map/keys=],
+and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
+Its value is 25.
 
 # Vendor-Specific Values # {#vendor-specific-values}
 
@@ -1410,12 +1421,14 @@ To <dfn>parse filter data</dfn> given a |value|:
 1. If |map|'s [=map/size=] is greater than the [=max entries per filter data=],
     return null.
 1. [=map/iterate|For each=] |filter| → |set| of |map|:
+    1. If |filter|'s [=string/length=] is greater than the [=max bytes per filter string=],
+        return null.
     1. If |set|'s [=set/size=] is greater than the
         [=max values per filter data entry=], return null.
+    1. [=set/iterate|For each=] |s| of |set|:
+        1. If |s|'s [=string/length=] is greater than the [=max bytes per filter string=],
+            return null.
 1. Return |map|.
-
-Issue: Determine whether to limit [=string/length=] or
-[=string/code point length=] for |filter| and |d| above.
 
 To <dfn>parse filter config</dfn> given a |value|:
 
@@ -1827,13 +1840,13 @@ To <dfn>parse aggregation keys</dfn> given an [=ordered map=] |map|:
 1. If |values|'s [=map/size=] is greater than the user agent's
     [=max aggregation keys per source registration=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
+    1. If |key|'s [=string/length=] is greater than the [=max bytes per aggregation key identifier=],
+        return null.
     1. If |value| is not a [=string=], return null.
     1. Let |keyPiece| be the result of running [=parse an aggregation key piece=] with |value|.
     1. If |keyPiece| is an error, return null.
     1. [=map/Set=] |aggregationKeys|[|key|] to |keyPiece|.
 1. Return |aggregationKeys|.
-
-Issue: Determine whether to limit [=string/length=] or [=string/code point length=] for |key| above.
 
 To <dfn>obtain default effective windows</dfn> given a [=source type=] |sourceType|,
 a [=moment=] |sourceTime|, and a [=duration=] |eventReportWindow|:
@@ -2294,6 +2307,8 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
         1. If |value|["`source_keys`"] is not a [=list=], return null.
         1. [=list/iterate|For each=] |sourceKey| of |value|["`source_keys`"]:
             1. If |sourceKey| is not a [=string=], return null.
+            1. If |sourceKey|'s [=string/length=] is greater than the
+                [=max bytes per aggregation key identifier=], return null.
             1. [=set/Append=] |sourceKey| to |sourceKeys|.
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
         |value|.
@@ -2310,20 +2325,18 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
     1. [=list/Append=] |aggregatableTrigger| to |aggregatableTriggerData|.
 1. Return |aggregatableTriggerData|.
 
-Issue: Determine whether to limit [=string/length=] or [=string/code point length=] for |sourceKey| above.
-
 To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
+     1. If |key|'s [=string/length=] is greater than the [=max bytes per aggregation key identifier=],
+         return null.
      1. If |value| is not an integer, return null.
      1. If |value| is less than or equal to 0, return null.
      1. If |value| is greater than [=allowed aggregatable budget per source=], return null.
 1. Return |values|.
-
-Issue: Determine whether to limit [=string/length=] or [=string/code point length=] for |key| above.
 
 To <dfn>parse aggregatable dedup keys</dfn> given an [=ordered map=] |map|:
 

--- a/index.bs
+++ b/index.bs
@@ -1197,7 +1197,7 @@ Its value is 50.
 controls the maximum [=set/size=] of each [=map/value=] of an
 [=attribution source=]'s [=attribution source/filter data=]. Its value is 50.
 
-<dfn>Max bytes per filter string</dfn> is a positive interger that controls the
+<dfn>Max bytes per filter string</dfn> is a positive integer that controls the
 maximum [=string/length=] of an [=attribution source=]'s [=attribution source/filter data=]'s
 [=map/keys=] and its [=map/values=]'s [=set/items=].
 Its value is 25.

--- a/index.bs
+++ b/index.bs
@@ -1197,7 +1197,7 @@ Its value is 50.
 controls the maximum [=set/size=] of each [=map/value=] of an
 [=attribution source=]'s [=attribution source/filter data=]. Its value is 50.
 
-<dfn>Max bytes per filter string</dfn> is a positive integer that controls the
+<dfn>Max length per filter string</dfn> is a positive integer that controls the
 maximum [=string/length=] of an [=attribution source=]'s [=attribution source/filter data=]'s
 [=map/keys=] and its [=map/values=]'s [=set/items=].
 Its value is 25.
@@ -1225,7 +1225,7 @@ Its value is «[ [=source type/navigation=] → 3, [=source type/event=] → 1 ]
 [=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
 an [=attribution source=]. Its value is 65536.
 
-<dfn>Max bytes per aggregation key identifier</dfn> is a positive integer that controls
+<dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
 [=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values=]'s [=map/keys=],
 and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
@@ -1421,12 +1421,12 @@ To <dfn>parse filter data</dfn> given a |value|:
 1. If |map|'s [=map/size=] is greater than the [=max entries per filter data=],
     return null.
 1. [=map/iterate|For each=] |filter| → |set| of |map|:
-    1. If |filter|'s [=string/length=] is greater than the [=max bytes per filter string=],
+    1. If |filter|'s [=string/length=] is greater than the [=max length per filter string=],
         return null.
     1. If |set|'s [=set/size=] is greater than the
         [=max values per filter data entry=], return null.
     1. [=set/iterate|For each=] |s| of |set|:
-        1. If |s|'s [=string/length=] is greater than the [=max bytes per filter string=],
+        1. If |s|'s [=string/length=] is greater than the [=max length per filter string=],
             return null.
 1. Return |map|.
 
@@ -1840,7 +1840,7 @@ To <dfn>parse aggregation keys</dfn> given an [=ordered map=] |map|:
 1. If |values|'s [=map/size=] is greater than the user agent's
     [=max aggregation keys per source registration=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
-    1. If |key|'s [=string/length=] is greater than the [=max bytes per aggregation key identifier=],
+    1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
         return null.
     1. If |value| is not a [=string=], return null.
     1. Let |keyPiece| be the result of running [=parse an aggregation key piece=] with |value|.
@@ -2308,7 +2308,7 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
         1. [=list/iterate|For each=] |sourceKey| of |value|["`source_keys`"]:
             1. If |sourceKey| is not a [=string=], return null.
             1. If |sourceKey|'s [=string/length=] is greater than the
-                [=max bytes per aggregation key identifier=], return null.
+                [=max length per aggregation key identifier=], return null.
             1. [=set/Append=] |sourceKey| to |sourceKeys|.
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
         |value|.
@@ -2331,7 +2331,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
-     1. If |key|'s [=string/length=] is greater than the [=max bytes per aggregation key identifier=],
+     1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
          return null.
      1. If |value| is not an integer, return null.
      1. If |value| is less than or equal to 0, return null.

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -11,6 +11,10 @@ export const maxEntriesPerFilterData: number = 50
 
 export const maxValuesPerFilterDataEntry: number = 50
 
+export const maxBytesPerFilterString: number = 25
+
+export const maxBytesPerAggregationKeyIdentifier: number = 25
+
 export const minReportWindow: number = 1 * SECONDS_PER_HOUR
 
 export const validSourceExpiryRange: Readonly<[min: number, max: number]> = [

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -11,9 +11,9 @@ export const maxEntriesPerFilterData: number = 50
 
 export const maxValuesPerFilterDataEntry: number = 50
 
-export const maxBytesPerFilterString: number = 25
+export const maxLengthPerFilterString: number = 25
 
-export const maxBytesPerAggregationKeyIdentifier: number = 25
+export const maxLengthPerAggregationKeyIdentifier: number = 25
 
 export const minReportWindow: number = 1 * SECONDS_PER_HOUR
 

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -292,7 +292,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['filter_data', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max length per filter string (26 > 25)',
+        msg: 'key exceeds max length per filter string (26 > 25)',
       },
     ],
   },
@@ -378,7 +378,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregation_keys', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
+        msg: 'key exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },
@@ -393,7 +393,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregation_keys', 'aaaaaaaaaaaaaaaaaaaaaaaaa\u03A9'],
-        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
+        msg: 'key exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -292,7 +292,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['filter_data', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max bytes per filter string (26 > 25)',
+        msg: 'exceeds max length per filter string (26 > 25)',
       },
     ],
   },
@@ -305,7 +305,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['filter_data', 'a', 0],
-        msg: 'exceeds max bytes per filter string (26 > 25)',
+        msg: 'exceeds max length per filter string (26 > 25)',
       },
     ],
   },
@@ -378,7 +378,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregation_keys', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
+        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -382,6 +382,21 @@ const testCases: TestCase[] = [
       },
     ],
   },
+  {
+    name: 'aggregation-keys-key-too-long-non-ascii',
+    json: `{
+      "destination": "https://a.test",
+      "aggregation_keys": {
+        "aaaaaaaaaaaaaaaaaaaaaaaaa\u03A9": "0x1"
+      }
+    }`,
+    expectedErrors: [
+      {
+        path: ['aggregation_keys', 'aaaaaaaaaaaaaaaaaaaaaaaaa\u03A9'],
+        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
+      },
+    ],
+  },
 
   {
     name: 'source-event-id-wrong-type',

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -283,6 +283,32 @@ const testCases: TestCase[] = [
       },
     ],
   },
+  {
+    name: 'filter-data-key-too-long',
+    json: `{
+      "destination": "https://a.test",
+      "filter_data": {"aaaaaaaaaaaaaaaaaaaaaaaaaa": ["x"]}
+    }`,
+    expectedErrors: [
+      {
+        path: ['filter_data', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        msg: 'exceeds max bytes per filter string (26 > 25)',
+      },
+    ],
+  },
+  {
+    name: 'filter-data-value-too-long',
+    json: `{
+      "destination": "https://a.test",
+      "filter_data": {"a": ["xxxxxxxxxxxxxxxxxxxxxxxxxx"]}
+    }`,
+    expectedErrors: [
+      {
+        path: ['filter_data', 'a', 0],
+        msg: 'exceeds max bytes per filter string (26 > 25)',
+      },
+    ],
+  },
   // TODO: add tests for exceeding size limits
 
   {
@@ -338,6 +364,21 @@ const testCases: TestCase[] = [
       {
         path: ['aggregation_keys'],
         msg: 'exceeds the maximum number of keys (1)',
+      },
+    ],
+  },
+  {
+    name: 'aggregation-keys-key-too-long',
+    json: `{
+      "destination": "https://a.test",
+      "aggregation_keys": {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaa": "0x1"
+      }
+    }`,
+    expectedErrors: [
+      {
+        path: ['aggregation_keys', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -360,7 +360,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_values', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
+        msg: 'key exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -360,7 +360,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_values', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
+        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },
@@ -725,7 +725,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_trigger_data', 0, 'source_keys', 0],
-        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
+        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -354,6 +354,16 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       },
     ],
   },
+  {
+    name: 'aggregatable-values-key-too-long',
+    json: `{"aggregatable_values": {"aaaaaaaaaaaaaaaaaaaaaaaaaa": 1}}`,
+    expectedErrors: [
+      {
+        path: ['aggregatable_values', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
+      },
+    ],
+  },
 
   {
     name: 'debug-reporting-wrong-type',
@@ -703,6 +713,19 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_trigger_data', 0, 'source_keys', 2],
         msg: 'duplicate value a',
+      },
+    ],
+  },
+  {
+    name: 'source-keys-key-too-long',
+    json: `{"aggregatable_trigger_data": [{
+      "key_piece": "0x1",
+      "source_keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    }]}`,
+    expectedErrors: [
+      {
+        path: ['aggregatable_trigger_data', 0, 'source_keys', 0],
+        msg: 'exceeds max bytes per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1105,9 +1105,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
 
 function sourceKeys(ctx: Context, j: Json): Maybe<Set<string>> {
   return set(ctx, j, (ctx, j) =>
-    string(ctx, j).filter((s) =>
-      aggregationKeyIdentifierLength(ctx, s)
-    )
+    string(ctx, j).filter((s) => aggregationKeyIdentifierLength(ctx, s))
   )
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1105,9 +1105,9 @@ function source(ctx: Context, j: Json): Maybe<Source> {
 
 function sourceKeys(ctx: Context, j: Json): Maybe<Set<string>> {
   return set(ctx, j, (ctx, j) =>
-    string(ctx, j).filter((s) => {
-      return aggregationKeyIdentifierLength(ctx, s)
-    })
+    string(ctx, j).filter((s) =>
+      aggregationKeyIdentifierLength(ctx, s)
+    )
   )
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -561,17 +561,17 @@ function filterDataKeyValue(
     return None
   }
 
-  const filterStringLength = (s: string) => {
+  const filterStringLength = (s: string, errorPrefix: string = '') => {
     if (s.length > constants.maxLengthPerFilterString) {
       ctx.error(
-        `exceeds max length per filter string (${s.length} > ${constants.maxLengthPerFilterString})`
+        `${errorPrefix}exceeds max length per filter string (${s.length} > ${constants.maxLengthPerFilterString})`
       )
       return false
     }
     return true
   }
 
-  if (!filterStringLength(key)) {
+  if (!filterStringLength(key, 'key ')) {
     return None
   }
 
@@ -676,10 +676,14 @@ const priorityField: StructFields<Priority> = {
   priority: field('priority', int64, 0n),
 }
 
-function aggregationKeyIdentifierLength(ctx: Context, s: string): boolean {
+function aggregationKeyIdentifierLength(
+  ctx: Context,
+  s: string,
+  errPrefix: string = ''
+): boolean {
   if (s.length > constants.maxLengthPerAggregationKeyIdentifier) {
     ctx.error(
-      `exceeds max length per aggregation key identifier (${s.length} > ${constants.maxLengthPerAggregationKeyIdentifier})`
+      `${errPrefix}exceeds max length per aggregation key identifier (${s.length} > ${constants.maxLengthPerAggregationKeyIdentifier})`
     )
     return false
   }
@@ -687,7 +691,7 @@ function aggregationKeyIdentifierLength(ctx: Context, s: string): boolean {
 }
 
 function aggregationKey(ctx: Context, [key, j]: [string, Json]): Maybe<bigint> {
-  if (!aggregationKeyIdentifierLength(ctx, key)) {
+  if (!aggregationKeyIdentifierLength(ctx, key, 'key ')) {
     return None
   }
   return hex128(ctx, j)
@@ -1130,7 +1134,7 @@ function aggregatableKeyValue(
   ctx: Context,
   [key, j]: [string, Json]
 ): Maybe<number> {
-  if (!aggregationKeyIdentifierLength(ctx, key)) {
+  if (!aggregationKeyIdentifierLength(ctx, key, 'key ')) {
     return None
   }
   return number(ctx, j)

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -560,9 +560,9 @@ function filterDataKeyValue(
     ctx.error('is prohibited as keys starting with "_" are reserved')
     return None
   }
-  if (key.length > constants.maxBytesPerFilterString) {
+  if (key.length > constants.maxLengthPerFilterString) {
     ctx.error(
-      `exceeds max bytes per filter string (${key.length} > ${constants.maxBytesPerFilterString})`
+      `exceeds max length per filter string (${key.length} > ${constants.maxLengthPerFilterString})`
     )
     return None
   }
@@ -572,9 +572,9 @@ function filterDataKeyValue(
     j,
     (ctx, j) =>
       string(ctx, j).peek((s) => {
-        if (s.length > constants.maxBytesPerFilterString) {
+        if (s.length > constants.maxLengthPerFilterString) {
           ctx.error(
-            `exceeds max bytes per filter string (${s.length} > ${constants.maxBytesPerFilterString})`
+            `exceeds max length per filter string (${s.length} > ${constants.maxLengthPerFilterString})`
           )
         }
       }),
@@ -681,9 +681,9 @@ const priorityField: StructFields<Priority> = {
 }
 
 function aggregationKey(ctx: Context, [key, j]: [string, Json]): Maybe<bigint> {
-  if (key.length > constants.maxBytesPerAggregationKeyIdentifier) {
+  if (key.length > constants.maxLengthPerAggregationKeyIdentifier) {
     ctx.error(
-      `exceeds max bytes per aggregation key identifier (${key.length} > ${constants.maxBytesPerAggregationKeyIdentifier})`
+      `exceeds max length per aggregation key identifier (${key.length} > ${constants.maxLengthPerAggregationKeyIdentifier})`
     )
     return None
   }
@@ -1099,9 +1099,9 @@ function source(ctx: Context, j: Json): Maybe<Source> {
 function sourceKeys(ctx: Context, j: Json): Maybe<Set<string>> {
   return set(ctx, j, (ctx, j) =>
     string(ctx, j).peek((s) => {
-      if (s.length > constants.maxBytesPerAggregationKeyIdentifier) {
+      if (s.length > constants.maxLengthPerAggregationKeyIdentifier) {
         ctx.error(
-          `exceeds max bytes per aggregation key identifier (${s.length} > ${constants.maxBytesPerAggregationKeyIdentifier})`
+          `exceeds max length per aggregation key identifier (${s.length} > ${constants.maxLengthPerAggregationKeyIdentifier})`
         )
       }
     })
@@ -1131,9 +1131,9 @@ function aggregatableKeyValue(
   ctx: Context,
   [key, j]: [string, Json]
 ): Maybe<number> {
-  if (key.length > constants.maxBytesPerAggregationKeyIdentifier) {
+  if (key.length > constants.maxLengthPerAggregationKeyIdentifier) {
     ctx.error(
-      `exceeds max bytes per aggregation key identifier (${key.length} > ${constants.maxBytesPerAggregationKeyIdentifier})`
+      `exceeds max length per aggregation key identifier (${key.length} > ${constants.maxLengthPerAggregationKeyIdentifier})`
     )
     return None
   }


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1066.html" title="Last updated on Oct 16, 2023, 1:47 PM UTC (d4c010c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1066/6198a8c...linnan-github:d4c010c.html" title="Last updated on Oct 16, 2023, 1:47 PM UTC (d4c010c)">Diff</a>