### PR TITLE
Fix context origin definition in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1497,7 +1497,7 @@ would have to be further processed to check for the "`ar_debug`" cookie.
 <h3 algorithm id="obtaining-context-origin">Obtaining context origin</h3>
 
 To obtain the <dfn export for=node>context origin</dfn> of a [=node=] |node|, return |node|'s [=node navigable=]'s
-<a spec=fenced-frame for=navigable>unfenced container document</a>'s [=origin=].
+<a spec=fenced-frame for=navigable>top-level traversable</a>'s [=navigable/active document=]'s [=origin=].
 
 <h3 id="obtaining-randomized-response">Obtaining a randomized response</h3>
 


### PR DESCRIPTION
Discussed with @domfarolino, top-level traversal is the right way to get top-level document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1070.html" title="Last updated on Oct 12, 2023, 5:36 PM UTC (aa8c265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1070/6198a8c...linnan-github:aa8c265.html" title="Last updated on Oct 12, 2023, 5:36 PM UTC (aa8c265)">Diff</a>