### PR TITLE
attributionsrc eligible response handling should handle in parallel

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1653,6 +1653,10 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
     state is not immediately detectable. Attribution may also be blocked if the reporting origin is not
     <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
 
+1. [=Queue a task=] on the [=networking task source=] to proceed with the following steps.
+
+    Note: This algorithm can be invoked from while [=in parallel=].
+
 1. [=Assert=]: |eligibility| is
     "<code>[=eligibility/navigation-source=]</code>" or
     "<code>[=eligibility/event-source=]</code>" or


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1073.html" title="Last updated on Oct 16, 2023, 1:20 PM UTC (77ebc5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1073/11882e6...linnan-github:77ebc5b.html" title="Last updated on Oct 16, 2023, 1:20 PM UTC (77ebc5b)">Diff</a>