### PR TITLE
Make default trigger data cardinality a constant

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1148,6 +1148,10 @@ the maximum [=string/length=] of an [=attribution source=]'s [=attribution sourc
 and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
 Its value is 25.
 
+<dfn>Default trigger data cardinality</dfn> is a [=map=] that
+controls the valid range of [=event-level trigger configuration/trigger data=].
+Its value is «[=source type/navigation=] → 8, [=source type/event=] → 2».
+
 # Vendor-Specific Values # {#vendor-specific-values}
 
 <dfn>Max aggregation keys per source registration</dfn> is a positive integer that
@@ -1157,10 +1161,6 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 <dfn>Max pending sources per source origin</dfn> is a positive integer that
 controls how many [=attribution sources=] can be in the
 [=attribution source cache=] per [=attribution source/source origin=].
-
-<dfn>Default trigger data cardinality</dfn> is a [=map=] that
-controls the valid range of [=event-level trigger configuration/trigger data=].
-The keys are «[=source type/navigation=], [=source type/event=]». The values are positive integers.
 
 <dfn>Randomized response epsilon</dfn> is a non-negative double that controls
 the randomized response probability of an [=attribution source=]. If [=automation local testing mode=] is true,
@@ -1871,7 +1871,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     |reportingOrigin| is <strong>blocked</strong>, set |debugKey| to null.
 1. Let |aggregationKeys| be the result of running [=parse aggregation keys=] with |value|.
 1. If |aggregationKeys| is null, return null.
-1. Let |triggerDataCardinality| be the user agent's [=default trigger data cardinality=][|sourceType|].
+1. Let |triggerDataCardinality| be [=default trigger data cardinality=][|sourceType|].
 1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
 1. Set |maxAttributionsPerSource| to |value|["`max_event_level_reports`"] if it [=map/exists=].
 1. If |maxAttributionsPerSource| is not a non-negative integer, or is greater than [=max settable event-level attributions per source=], return null.
@@ -2955,7 +2955,7 @@ To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |sour
 |trigger|, and an [=event-level trigger configuration=] |config|:
 
 1. Let |triggerData| be |config|'s [=event-level trigger configuration/trigger data=].
-1. Let |triggerDataCardinality| be the user agent's [=default trigger data cardinality=][|source|'s [=attribution source/source type=]].
+1. Let |triggerDataCardinality| be [=default trigger data cardinality=][|source|'s [=attribution source/source type=]].
 1. If |source|'s [=attribution source/trigger-data matching mode=] is:
     <dl class="switch">
     : "<code>[=trigger-data matching mode/exact=]</code>":

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -9,8 +9,6 @@ Chromium's implementation assigns the following values:
 | ---- | ----- |
 | [Max aggregation keys per source registration][] | [20][max aggregation keys per source registration value] |
 | [Max pending sources per source origin][] | [1024][max pending sources per source origin value] |
-| [Navigation-source trigger data cardinality][] | [8][navigation-source trigger data cardinality value] |
-| [Event-source trigger data cardinality][] | [2][event-source trigger data cardinality value] |
 | [Randomized response epsilon][] | [14][randomized response epsilon value] |
 | [Randomized null report rate excluding source registration time][] | [0.05][randomized null report rate excluding source registration time value] |
 | [Randomized null report rate including source registration time][] | [0.008][randomized null report rate including source registration time value] |
@@ -33,10 +31,6 @@ Chromium's implementation assigns the following values:
 [max aggregation keys per source registration value]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:components/attribution_reporting/constants.h;l=19;drc=b646f894a92491033bde5d1e75aba6f44c524f0e
 [Max pending sources per source origin]: https://wicg.github.io/attribution-reporting-api/#max-pending-sources-per-source-origin
 [max pending sources per source origin value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=122;drc=3733a639d724a4353463a872605119d11a1e4d37
-[Navigation-source trigger data cardinality]: https://wicg.github.io/attribution-reporting-api/#navigation-source-trigger-data-cardinality
-[navigation-source trigger data cardinality value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=48;drc=3733a639d724a4353463a872605119d11a1e4d37
-[Event-source trigger data cardinality]: https://wicg.github.io/attribution-reporting-api/#event-source-trigger-data-cardinality
-[event-source trigger data cardinality value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=49;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Randomized response epsilon]: https://wicg.github.io/attribution-reporting-api/#randomized-response-epsilon
 [randomized response epsilon value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=57;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Randomized null report rate excluding source registration time]: https://wicg.github.io/attribution-reporting-api/#randomized-null-report-rate-excluding-source-registration-time

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -39,3 +39,10 @@ export const defaultEventLevelAttributionsPerSource: Readonly<
 export const maxTriggerDataPerSource: number = 32
 
 export const allowedAggregatableBudgetPerSource: number = 65536
+
+export const defaultTriggerDataCardinality: Readonly<
+  Record<SourceType, bigint>
+> = {
+  [SourceType.event]: 2n,
+  [SourceType.navigation]: 8n,
+}

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -107,15 +107,12 @@ test('binaryEntropy', async (t) => {
   )
 })
 
-function defaultConfig(
-  sourceType: SourceType,
-  vsv: vsv.VendorSpecificValues
-): Config {
+function defaultConfig(sourceType: SourceType): Config {
   const defaultMaxReports =
     constants.defaultEventLevelAttributionsPerSource[sourceType]
   return new Config(
     /*maxEventLevelReports=*/ defaultMaxReports,
-    new Array(Number(vsv.triggerDataCardinality[sourceType])).fill(
+    new Array(Number(constants.defaultTriggerDataCardinality[sourceType])).fill(
       new PerTriggerDataConfig(
         /*numWindows=*/
         constants.defaultEarlyEventLevelReportWindows[sourceType].length + 1,
@@ -128,7 +125,7 @@ function defaultConfig(
 test('computeConfigData', async (t) => {
   await t.test('navigation', () => {
     assert.deepStrictEqual(
-      defaultConfig(SourceType.navigation, vsv.Chromium).computeConfigData(
+      defaultConfig(SourceType.navigation).computeConfigData(
         14,
         vsv.Chromium.maxEventLevelChannelCapacityPerSource[
           SourceType.navigation
@@ -144,7 +141,7 @@ test('computeConfigData', async (t) => {
 
   await t.test('event', () => {
     assert.deepStrictEqual(
-      defaultConfig(SourceType.event, vsv.Chromium).computeConfigData(
+      defaultConfig(SourceType.event).computeConfigData(
         14,
         vsv.Chromium.maxEventLevelChannelCapacityPerSource[SourceType.event]
       ),

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1168,10 +1168,6 @@ const testCases: TestCase[] = [
         [SourceType.navigation]: Infinity,
       },
       randomizedResponseEpsilon: 14,
-      triggerDataCardinality: {
-        [SourceType.event]: 2n,
-        [SourceType.navigation]: 8n,
-      },
     },
     expectedErrors: [
       {
@@ -1190,10 +1186,6 @@ const testCases: TestCase[] = [
         [SourceType.navigation]: 0,
       },
       randomizedResponseEpsilon: 14,
-      triggerDataCardinality: {
-        [SourceType.event]: 2n,
-        [SourceType.navigation]: 8n,
-      },
     },
     expectedErrors: [
       {

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1,4 +1,3 @@
-import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
 import {
@@ -603,12 +602,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   {
     name: 'trigger-data-sanitized',
     json: `{"event_trigger_data": [{"trigger_data": "10"}]}`,
-    vsv: {
-      triggerDataCardinality: {
-        [SourceType.event]: 2n,
-        [SourceType.navigation]: 8n,
-      },
-    },
     expectedWarnings: [
       {
         path: ['event_trigger_data', 0, 'trigger_data'],

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -241,15 +241,17 @@ function uint64(ctx: Context, j: Json): Maybe<bigint> {
 
 function triggerData(ctx: Context, j: Json): Maybe<bigint> {
   return uint64(ctx, j).peek((n) => {
-    Object.entries(ctx.vsv.triggerDataCardinality).forEach(([t, c]) => {
-      if (n >= c) {
-        ctx.warning(
-          `will be sanitized to ${
-            n % c
-          } if trigger is attributed to ${t} source`
-        )
+    Object.entries(constants.defaultTriggerDataCardinality).forEach(
+      ([t, c]) => {
+        if (n >= c) {
+          ctx.warning(
+            `will be sanitized to ${
+              n % c
+            } if trigger is attributed to ${t} source`
+          )
+        }
       }
-    })
+    )
   })
 }
 
@@ -971,7 +973,11 @@ function defaultTriggerSpecs(
         summaryWindowOperator: SummaryWindowOperator.count,
         triggerData: new Set(
           Array.from(
-            { length: Number(ctx.vsv.triggerDataCardinality[ctx.sourceType]) },
+            {
+              length: Number(
+                constants.defaultTriggerDataCardinality[ctx.sourceType]
+              ),
+            },
             (_, i) => i
           )
         ),

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -4,7 +4,6 @@ export type VendorSpecificValues = {
   maxAggregationKeysPerSource: number
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   randomizedResponseEpsilon: number
-  triggerDataCardinality: Record<SourceType, bigint>
 }
 
 export const Chromium: Readonly<VendorSpecificValues> = {
@@ -14,8 +13,4 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.navigation]: 11.46173,
   },
   randomizedResponseEpsilon: 14,
-  triggerDataCardinality: {
-    [SourceType.event]: 2n,
-    [SourceType.navigation]: 8n,
-  },
 }


### PR DESCRIPTION
Similar to #1022 and the preexisting [default event-level report windows](https://wicg.github.io/attribution-reporting-api/#obtain-default-effective-windows), there is significant benefit in making these constants instead of vendor-specific values:

1. Users of the API can reliably depend on them without having to either maintain a map of them per user agent or interpret a browser-advertised configuration (e.g. a request header, which does not exist today.) Users of the API that are today assuming only Chromium's specific values without using one of those approaches are subject to unintended behavior with other implementations.
2. Implementations of the API can be simplified knowing that these values are fixed, making it easier, e.g., to maintain an interoperability-test runner.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1076.html" title="Last updated on Oct 20, 2023, 3:43 PM UTC (33bcc8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1076/71c9752...apasel422:33bcc8c.html" title="Last updated on Oct 20, 2023, 3:43 PM UTC (33bcc8c)">Diff</a>