### PR TITLE
Fix variable-reference typo in "parse report windows"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1771,8 +1771,8 @@ a [=source type=] |sourceType|, and a [=duration=] |expiry|:
 1. Let |values| be |map|["`event_report_windows`"].
 1. If |values| is not a [=map=], return an error.
 1. Let |startDuration| be 0 seconds.
-1. If |map|["`start_time`"] [=map/exists=]:
-    1. Let |start| be |map|["`start_time`"].
+1. If |values|["`start_time`"] [=map/exists=]:
+    1. Let |start| be |values|["`start_time`"].
     1. If |start| is not a non-negative integer, return an error.
     1. Set |startDuration| to |start| seconds.
     1. If |startDuration| is greater than |expiry|, return an error.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1077.html" title="Last updated on Oct 18, 2023, 1:43 PM UTC (6d81385)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1077/c96f1fe...apasel422:6d81385.html" title="Last updated on Oct 18, 2023, 1:43 PM UTC (6d81385)">Diff</a>