### PR TITLE
Fix erroneous field reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1671,7 +1671,7 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
 
 To <dfn>obtain a set of possible trigger states</dfn> given a [=randomized response output configuration=] |config|:
 1. Let |possibleTriggerStates| be a new [=list/is empty|empty=] [=set=].
-1. [=map/iterate|For each=] |triggerData| → |reportWindows| of |config|:
+1. [=map/iterate|For each=] |triggerData| → |reportWindows| of |config|'s [=randomized response output configuration/trigger data map=]:
     1. [=list/For each=] |reportWindow| of |reportWindows|:
         1. Let |state| be a new [=trigger state=] with the items:
             : [=trigger state/trigger data=]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1080.html" title="Last updated on Oct 20, 2023, 5:48 PM UTC (2dc5961)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1080/b90aab0...apasel422:2dc5961.html" title="Last updated on Oct 20, 2023, 5:48 PM UTC (2dc5961)">Diff</a>