### PR TITLE
Replace top-level event-report windows in source with trigger specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -699,8 +699,8 @@ An attribution source is a [=struct=] with the following items:
 :: A [=source type=].
 : <dfn>expiry</dfn>
 :: A [=duration=].
-: <dfn>event-level report windows</dfn>
-:: A [=report window list=].
+: <dfn>trigger specs</dfn>
+:: A [=trigger spec map=].
 : <dfn>aggregatable report window</dfn>
 :: A [=report window=].
 : <dfn>priority</dfn>
@@ -1114,7 +1114,7 @@ Its value is (1 day, 30 days).
 <dfn>Min report window</dfn> is a positive [=duration=] that controls the
 minimum [=duration from=] an [=attribution source's=] [=attribution source/source time=]
 and any [=report window/end=] in [=attribution source/aggregatable report window=] or
-[=attribution source/event-level report windows=].
+[=trigger spec/event-level report windows=].
 Its value is 1 hour.
 
 <dfn>Max entries per filter data</dfn> is a positive integer that controls the
@@ -1142,7 +1142,7 @@ controls the maximum value of [=attribution source/max number of event-level rep
 Its value is 20.
 
 <dfn>Max settable event-level report windows</dfn> is a positive integer that
-controls the maximum [=list/size=] of [=attribution source/event-level report windows=].
+controls the maximum [=list/size=] of [=trigger spec/event-level report windows=].
 Its value is 5.
 
 <dfn>Default event-level attributions per source</dfn> is a [=map=] that
@@ -1996,8 +1996,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |reportingOrigin|
     : [=attribution source/expiry=]
     :: |expiry|
-    : [=attribution source/event-level report windows=]
-    :: |eventReportWindows|
+    : [=attribution source/trigger specs=]
+    :: |triggerSpecs|
     : [=attribution source/aggregatable report window=]
     :: |aggregatableReportWindow|
     : [=attribution source/priority=]
@@ -2120,7 +2120,6 @@ a [=trigger state=] |triggerState|:
     :: "<code>[=aggregatable source registration time configuration/exclude=]</code>"
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
-1. [=Assert=]: |fakeReport| is not null.
 1. Set |fakeReport|'s [=event-level report/report time=] to
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
@@ -2731,21 +2730,6 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
         with "<code>[=trigger debug data type/trigger-event-noise=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. Let |windowResult| be the result of [=check whether a moment falls within a window=]
-    with |trigger|'s [=attribution trigger/trigger time=] and
-    |sourceToAttribute|'s [=attribution source/event-level report windows=]'s
-    [=report window list/total window=].
-1. If |windowResult| is <strong>falls before</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-event-report-window-not-started=]</code>",
-        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If |windowResult| is <strong>falls after</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-event-report-window-passed=]</code>",
-        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. [=Assert=]: |windowResult| is <strong>falls within</strong>.
 1. Let |matchedConfig| be null.
 1. [=set/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
     [=attribution trigger/event-level trigger configurations=]:
@@ -2767,6 +2751,43 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
          with "<code>[=trigger debug data type/trigger-event-deduplicated=]</code>", |trigger|, |sourceToAttribute| and
          [=obtain debug data on trigger registration/report=] set to null.
      1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. Let |spec| be null.
+1. If |sourceToAttribute|'s [=attribution source/trigger-data matching mode=] is:
+    <dl class="switch">
+    : "<code>[=trigger-data matching mode/exact=]</code>":
+    :: Run the following steps:
+        1. If |sourceToAttribute|'s
+            [=attribution source/trigger specs=][|config|'s [=event-level trigger configuration/trigger data=]] [=map/exists=],
+            set |spec| to its value.
+    : "<code>[=trigger-data matching mode/modulus=]</code>":
+    :: Run the following steps:
+        1. Set |config|'s [=event-level trigger configuration/trigger data=] to the
+            remainder when dividing |config|'s [=event-level trigger configuration/trigger data=] by |sourceToAttribute|'s
+            [=attribution source/trigger specs=]'s [=map/size=].
+        1. Set |spec| to |sourceToAttribute|'s
+            [=attribution source/trigger specs=][|config|'s [=event-level trigger configuration/trigger data=]].
+
+    </dl>
+1. If |spec| is null:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-event-no-matching-trigger-data=]</code>", |trigger|, |sourceToAttribute| and
+        [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. Let |windowResult| be the result of [=check whether a moment falls within a window=]
+    with |trigger|'s [=attribution trigger/trigger time=] and
+    |spec|'s [=trigger spec/event-level report windows=]'s
+    [=report window list/total window=].
+1. If |windowResult| is <strong>falls before</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-event-report-window-not-started=]</code>",
+        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. If |windowResult| is <strong>falls after</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-event-report-window-passed=]</code>",
+        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. [=Assert=]: |windowResult| is <strong>falls within</strong>.
 1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
     [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
 1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:
@@ -2779,11 +2800,6 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     return it.
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|, |trigger|,
     and |matchedConfig|.
-1. If |report| is null:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-event-no-matching-trigger-data=]</code>", |trigger|, |sourceToAttribute| and
-        [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
     is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -3008,12 +3024,11 @@ a [=report window=] |window|:
     return <strong>falls after</strong>.
 1. Return <strong>falls within</strong>.
 
-To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution source=]
-|source| and a [=moment=] |triggerTime|:
+To <dfn>obtain an event-level report delivery time</dfn> given a
+[=report window list=] |reportWindows| and a [=moment=] |triggerTime|:
 
 1. If [=automation local testing mode=] is true, return |triggerTime|.
-1. Let |windows| be |source|'s [=attribution source/event-level report windows=].
-1. [=list/iterate|For each=] |window| of |windows|:
+1. [=list/iterate|For each=] |window| of |reportWindows|:
     1. If the result of [=check whether a moment falls within a window=] with
         |triggerTime| and |window| is <strong>falls within</strong>, return
         |window|'s [=report window/end=].
@@ -3030,23 +3045,20 @@ To <dfn>obtain an aggregatable report delivery time</dfn> given a [=moment=]
 To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |source|, an [=attribution trigger=]
 |trigger|, and an [=event-level trigger configuration=] |config|:
 
-1. Let |triggerData| be |config|'s [=event-level trigger configuration/trigger data=].
-1. Let |triggerDataCardinality| be [=default trigger data cardinality=][|source|'s [=attribution source/source type=]].
-1. If |source|'s [=attribution source/trigger-data matching mode=] is:
-    <dl class="switch">
-    : "<code>[=trigger-data matching mode/exact=]</code>":
-    :: If |triggerData| is greater than or equal to |triggerDataCardinality|, return null.
-    : "<code>[=trigger-data matching mode/modulus=]</code>":
-    :: Set |triggerData| to the remainder when dividing |triggerData| by |triggerDataCardinality|.
-
-    </dl>
-1. Let |reportTime| be the result of running [=obtain an event-level report delivery time=] with |source| and |trigger|'s [=attribution trigger/trigger time=].
+1. [=Assert=]: |source|'s [=attribution source/trigger specs=][|config|'s
+    [=event-level trigger configuration/trigger data=]] [=map/exists=].
+1. Let |spec| be |source|'s [=attribution source/trigger specs=][|config|'s
+    [=event-level trigger configuration/trigger data=]].
+1. Let |reportTime| be the result of running
+    [=obtain an event-level report delivery time=] with |spec|'s
+    [=trigger spec/event-level report windows=] and |trigger|'s
+    [=attribution trigger/trigger time=].
 1. Let |report| be a new [=event-level report=] struct whose items are:
 
     : [=event-level report/event ID=]
     :: |source|'s [=attribution source/event ID=].
     : [=event-level report/trigger data=]
-    :: |triggerData|
+    :: |config|'s [=event-level trigger configuration/trigger data=].
     : [=event-level report/randomized trigger rate=]
     :: |source|'s [=attribution source/randomized trigger rate=].
     : [=event-level report/reporting origin=]


### PR DESCRIPTION
Note that the specs are still based on the default trigger data cardinality, but that the other algorithms are abstracted over specs instead of themselves assuming the default.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1083.html" title="Last updated on Oct 24, 2023, 7:00 PM UTC (dcb46db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1083/35a730e...apasel422:dcb46db.html" title="Last updated on Oct 24, 2023, 7:00 PM UTC (dcb46db)">Diff</a>