### PR TITLE
Perform event-report-window check after deduplication instead of before

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2752,21 +2752,6 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
         with "<code>[=trigger debug data type/trigger-event-noise=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. Let |windowResult| be the result of [=check whether a moment falls within a window=]
-    with |trigger|'s [=attribution trigger/trigger time=] and
-    |sourceToAttribute|'s [=attribution source/event-level report windows=]'s
-    [=report window list/total window=].
-1. If |windowResult| is <strong>falls before</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-event-report-window-not-started=]</code>",
-        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If |windowResult| is <strong>falls after</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-event-report-window-passed=]</code>",
-        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. [=Assert=]: |windowResult| is <strong>falls within</strong>.
 1. Let |matchedConfig| be null.
 1. [=set/iterate|For each=] [=event-level trigger configuration=] |config| of |trigger|'s
     [=attribution trigger/event-level trigger configurations=]:
@@ -2788,6 +2773,21 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
          with "<code>[=trigger debug data type/trigger-event-deduplicated=]</code>", |trigger|, |sourceToAttribute| and
          [=obtain debug data on trigger registration/report=] set to null.
      1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. Let |windowResult| be the result of [=check whether a moment falls within a window=]
+    with |trigger|'s [=attribution trigger/trigger time=] and
+    |sourceToAttribute|'s [=attribution source/event-level report windows=]'s
+    [=report window list/total window=].
+1. If |windowResult| is <strong>falls before</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-event-report-window-not-started=]</code>",
+        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. If |windowResult| is <strong>falls after</strong>:
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with "<code>[=trigger debug data type/trigger-event-report-window-passed=]</code>",
+        |trigger|, |sourceToAttribute| and [=obtain debug data on trigger registration/report=] set to null.
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. [=Assert=]: |windowResult| is <strong>falls within</strong>.
 1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
     [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
 1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:


### PR DESCRIPTION
Event-level report deduplication is based only on whether a given deduplication key has previously been seen for a given source. As such, it makes more sense to perform deduplication as soon as both of these values are known, instead of after the event-report-window check, which is not special with respect to any of the existing checks that are already performed after deduplication.

This change affects backwards compatibility in a minor way, in that the "trigger-event-deduplicated" verbose debug report will now be sent preferentially over the "trigger-event-report-window-not-started" and "trigger-event-report-window-passed" verbose debug reports, but this only affects triggers that are allowed to send verbose debug reports at all and is only observable when both such failure conditions occur together.

This change makes the specification more readily compatible with the Full Flexible Event Level proposal, as with that proposal, the event-report-window check can only be performed after the trigger spec, if any, has been found for the trigger's trigger data. (In the language of the spec, there is no "total window" for the source as a whole, only a total window for each of its trigger specs.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1092.html" title="Last updated on Nov 3, 2023, 4:35 PM UTC (e7670ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1092/2ef5146...apasel422:e7670ae.html" title="Last updated on Nov 3, 2023, 4:35 PM UTC (e7670ae)">Diff</a>