### PR TITLE
Make max aggregation keys per source constant

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1787,7 +1787,7 @@ To <dfn>parse aggregation keys</dfn> given an [=ordered map=] |map|:
 1. If |map|["`aggregation_keys`"] does not [=map/exist=], return |aggregationKeys|.
 1. Let |values| be |map|["`aggregation_keys`"].
 1. If |values| is not an [=ordered map=], return null.
-1. If |values|'s [=map/size=] is greater than the user agent's
+1. If |values|'s [=map/size=] is greater than the
     [=max aggregation keys per source registration=], return null.
 1. [=map/iterate|For each=] |key| → |value| of |values|:
     1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],

--- a/index.bs
+++ b/index.bs
@@ -1158,6 +1158,10 @@ Its value is «[ [=source type/navigation=] → 3, [=source type/event=] → 1 ]
 [=aggregatable report/required aggregatable budget=] of all [=aggregatable reports=] created for
 an [=attribution source=]. Its value is 65536.
 
+<dfn>Max aggregation keys per source registration</dfn> is a positive integer that
+controls the maximum [=map/size=] of an [=attribution source=]'s
+[=attribution source/aggregation keys=]. Its value is 20.
+
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
 [=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values=]'s [=map/keys=],
@@ -1173,10 +1177,6 @@ controls the maximum [=map/size=] of a [=trigger spec map=] for an
 [=attribution source=]. Its value is 32.
 
 # Vendor-Specific Values # {#vendor-specific-values}
-
-<dfn>Max aggregation keys per source registration</dfn> is a positive integer that
-controls the maximum [=map/size=] of an [=attribution source=]'s
-[=attribution source/aggregation keys=].
 
 <dfn>Max pending sources per source origin</dfn> is a positive integer that
 controls how many [=attribution sources=] can be in the

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -13,7 +13,7 @@ export const maxValuesPerFilterDataEntry: number = 50
 
 export const maxLengthPerFilterString: number = 25
 
-export const maxAggregationKeysPerSource: number = 25
+export const maxAggregationKeysPerSource: number = 20
 
 export const maxLengthPerAggregationKeyIdentifier: number = 25
 

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -13,6 +13,8 @@ export const maxValuesPerFilterDataEntry: number = 50
 
 export const maxLengthPerFilterString: number = 25
 
+export const maxAggregationKeysPerSource: number = 25
+
 export const maxLengthPerAggregationKeyIdentifier: number = 25
 
 export const minReportWindow: number = 1 * SECONDS_PER_HOUR

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -351,23 +351,6 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'aggregation-keys-too-many',
-    json: `{
-      "destination": "https://a.test",
-      "aggregation_keys": {
-        "a": "0x1",
-        "b": "0x2"
-      }
-    }`,
-    vsv: { maxAggregationKeysPerSource: 1 },
-    expectedErrors: [
-      {
-        path: ['aggregation_keys'],
-        msg: 'exceeds the maximum number of keys (1)',
-      },
-    ],
-  },
-  {
     name: 'aggregation-keys-key-too-long',
     json: `{
       "destination": "https://a.test",
@@ -397,6 +380,7 @@ const testCases: TestCase[] = [
       },
     ],
   },
+  // TODO: add tests for exceeding size limits
 
   {
     name: 'source-event-id-wrong-type',

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -351,6 +351,41 @@ const testCases: TestCase[] = [
     ],
   },
   {
+    name: 'aggregation-keys-too-many',
+    json: `{
+      "destination": "https://a.test",
+      "aggregation_keys": {
+        "1": "0x1",
+        "2": "0x1",
+        "3": "0x1",
+        "4": "0x1",
+        "5": "0x1",
+        "6": "0x1",
+        "7": "0x1",
+        "8": "0x1",
+        "9": "0x1",
+        "10": "0x1",
+        "11": "0x1",
+        "12": "0x1",
+        "13": "0x1",
+        "14": "0x1",
+        "15": "0x1",
+        "16": "0x1",
+        "17": "0x1",
+        "18": "0x1",
+        "19": "0x1",
+        "20": "0x1",
+        "21": "0x1"
+      }
+    }`,
+    expectedErrors: [
+      {
+        path: ['aggregation_keys'],
+        msg: 'exceeds the maximum number of keys (20)',
+      },
+    ],
+  },
+  {
     name: 'aggregation-keys-key-too-long',
     json: `{
       "destination": "https://a.test",

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -700,7 +700,12 @@ function aggregationKey(ctx: Context, [key, j]: [string, Json]): Maybe<bigint> {
 }
 
 function aggregationKeys(ctx: Context, j: Json): Maybe<Map<string, bigint>> {
-  return keyValues(ctx, j, aggregationKey, ctx.vsv.maxAggregationKeysPerSource)
+  return keyValues(
+    ctx,
+    j,
+    aggregationKey,
+    constants.maxAggregationKeysPerSource
+  )
 }
 
 function clamp<N extends bigint | number>(

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -1,13 +1,11 @@
 import { SourceType } from './source-type'
 
 export type VendorSpecificValues = {
-  maxAggregationKeysPerSource: number
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   randomizedResponseEpsilon: number
 }
 
 export const Chromium: Readonly<VendorSpecificValues> = {
-  maxAggregationKeysPerSource: 20,
   maxEventLevelChannelCapacityPerSource: {
     [SourceType.event]: 6.5,
     [SourceType.navigation]: 11.46173,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1096.html" title="Last updated on Nov 7, 2023, 3:30 PM UTC (647099d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1096/c47f837...linnan-github:647099d.html" title="Last updated on Nov 7, 2023, 3:30 PM UTC (647099d)">Diff</a>