### PR TITLE
Scope event-level report prioritization using original report time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2143,6 +2143,8 @@ a [=trigger state=] |triggerState|:
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
 
+Issue: Set |fakeReport|'s [=event-level report/original report time=] properly.
+
 To <dfn>check if debug reporting is allowed</dfn> given a [=source debug data type=] |dataType|
 and a [=boolean=] |debugCookieSet|:
 1. If |dataType| is:
@@ -2724,7 +2726,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
     |sourceToAttribute|'s [=attribution source/max number of event-level reports=].
 1. If |sourceToAttribute|'s [=attribution source/number of event-level reports=] is less than
     |sourceToAttribute|'s [=attribution source/max number of event-level reports=], return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
-1. Let |matchingReports| be a new [=list=] whose elements are all the elements in the [=event-level report cache=] whose [=event-level report/report time=] and [=event-level report/source identifier=] are equal to |report|'s, [=list/sorted in ascending order=] using [=event-level report/is lower-priority than=].
+1. Let |matchingReports| be a new [=list=] whose elements are all the elements in the [=event-level report cache=] whose [=event-level report/original report time=] and [=event-level report/source identifier=] are equal to |report|'s, [=list/sorted in ascending order=] using [=event-level report/is lower-priority than=].
 1. If |matchingReports| [=list/is empty=]:
     1. Set |sourceToAttribute|'s [=attribution source/event-level attributable=] value to false.
     1. Return "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>".


### PR DESCRIPTION
Otherwise, if the report time is adjusted, either due to retries or the browser being offline, the wrong report time will be used, which can cause later reports to erroneously replace earlier ones that haven't been successfully sent yet.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1098.html" title="Last updated on Nov 8, 2023, 1:37 PM UTC (8ccdb52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1098/5fd28d6...apasel422:8ccdb52.html" title="Last updated on Nov 8, 2023, 1:37 PM UTC (8ccdb52)">Diff</a>