### PR TITLE
Use realistic trigger time for fake reports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2109,11 +2109,13 @@ a [=trigger state=] |triggerState|:
     :: 0
     : [=event-level trigger configuration/filters=]
     :: «[ "`source_type`" → « |source|'s [=attribution source/source type=] » ]»
+1. Let |triggerTime| be the greatest [=moment=] that is strictly less than
+    |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
     : [=attribution trigger/attribution destinations=]
     :: |source|'s [=attribution source/attribution destinations=]
     : [=attribution trigger/trigger time=]
-    :: |source|'s [=attribution source/source time=]
+    :: |triggerTime|
     : [=attribution trigger/reporting origin=]
     :: |source|'s [=attribution source/reporting origin=]
     : [=attribution trigger/filters=]
@@ -2139,11 +2141,10 @@ a [=trigger state=] |triggerState|:
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |fakeTrigger|, and |fakeConfig|.
 1. [=Assert=]: |fakeReport| is not null.
-1. Set |fakeReport|'s [=event-level report/report time=] to
+1. [=Assert=]: |fakeReport|'s [=event-level report/original report time=] and
+    |fakeReport|'s [=event-level report/report time=] are both equal to
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
-
-Issue: Set |fakeReport|'s [=event-level report/original report time=] properly.
 
 To <dfn>check if debug reporting is allowed</dfn> given a [=source debug data type=] |dataType|
 and a [=boolean=] |debugCookieSet|:


### PR DESCRIPTION
This also fixes an inconsistency in which the fake report's report time was overridden but not its original report time, and matches [what Chromium's implementation is already doing](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_storage_sql.cc;l=685;drc=7fa0c25da15ae39bbd2fd720832ec4df4fee705a).

Fixes #727


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1099.html" title="Last updated on Nov 9, 2023, 4:28 PM UTC (9bd36ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1099/9259427...apasel422:9bd36ad.html" title="Last updated on Nov 9, 2023, 4:28 PM UTC (9bd36ad)">Diff</a>