### PR TITLE
Remove redundant sorting step from "maybe replace event-level report"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2733,8 +2733,6 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
     1. Return "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>".
 1. [=Assert=]: |sourceToAttribute|'s [=attribution source/number of event-level reports=]
     is greater than or equal to |matchingReports|'s [=list/size=].
-1. Set |matchingReports| to the result of [=list/sort in ascending order|sorting=] |matchingReports|
-    in ascending order using [=event-level report/is lower-priority than=].
 1. Let |lowestPriorityReport| be |matchingReports|[0].
 1. If |report| [=event-level report/is lower-priority than=] |lowestPriorityReport|,
     return "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>".


### PR DESCRIPTION
The list is sorted two steps below.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1104.html" title="Last updated on Nov 9, 2023, 7:39 PM UTC (ee22a43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1104/b0aa8a3...apasel422:ee22a43.html" title="Last updated on Nov 9, 2023, 7:39 PM UTC (ee22a43)">Diff</a>