### PR TITLE
Increase max pending sources per source origin

### DIFF
--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -7,7 +7,7 @@ Chromium's implementation assigns the following values:
 
 | Name | Value |
 | ---- | ----- |
-| [Max pending sources per source origin][] | [1024][max pending sources per source origin value] |
+| [Max pending sources per source origin][] | [4096][max pending sources per source origin value] |
 | [Randomized response epsilon][] | [14][randomized response epsilon value] |
 | [Randomized null report rate excluding source registration time][] | [0.05][randomized null report rate excluding source registration time value] |
 | [Randomized null report rate including source registration time][] | [0.008][randomized null report rate including source registration time value] |

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -27,7 +27,7 @@ Chromium's implementation assigns the following values:
 | [Max information gain for event sources][] | [6.5 bits][max information gain for events value] |
 
 [Max pending sources per source origin]: https://wicg.github.io/attribution-reporting-api/#max-pending-sources-per-source-origin
-[max pending sources per source origin value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=122;drc=3733a639d724a4353463a872605119d11a1e4d37
+[max pending sources per source origin value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=151;drc=3be0e68c5ed56aba7c321cbaea22558eee61fc50
 [Randomized response epsilon]: https://wicg.github.io/attribution-reporting-api/#randomized-response-epsilon
 [randomized response epsilon value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=57;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Randomized null report rate excluding source registration time]: https://wicg.github.io/attribution-reporting-api/#randomized-null-report-rate-excluding-source-registration-time


### PR DESCRIPTION
From UMA metrics, we identified that a higher than expected number of sources were being dropped due to the limit of 1024 sources per source origin, specifically ~6% are being dropped due to it.

This was also reported in https://github.com/WICG/attribution-reporting-api/issues/1103

A first step toward mitigating this issue is to increase the limit from 1024 to 4096. Analyses were conducted to confirm that no problematic increase in storage usage is expected from this change.
