### PR TITLE
Queue a task to trigger attribution

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3240,7 +3240,7 @@ run the following steps [=in parallel=]:
 1. Let |sources| be all source registrations originating from background attributionsrc requests initiated by |navigation|.
 1. If |sources| is empty, return.
 1. Wait until all |sources| are [=process an attribution source|processed=].
-1. [=Trigger attribution=] with |trigger|.
+1. [=Queue a task=] on the [=networking task source=] to [=trigger attribution=] with |trigger|.
 
 Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigating-across-documents">Navigation</a>
 


### PR DESCRIPTION
The algorithm may run in parallel: https://wicg.github.io/attribution-reporting-api/#maybe-defer-and-then-complete-trigger-attribution


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1108.html" title="Last updated on Nov 13, 2023, 2:15 PM UTC (6b6551e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1108/23dca6b...linnan-github:6b6551e.html" title="Last updated on Nov 13, 2023, 2:15 PM UTC (6b6551e)">Diff</a>