### PR TITLE
Summary buckets and window operator parsing algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -709,10 +709,6 @@ A <dfn>trigger spec</dfn> is a [=struct=] with the following items:
 <dl dfn-for="trigger spec">
 : <dfn>event-level report windows</dfn>
 :: A [=report window list=].
-: <dfn>summary window operator</dfn>
-:: A [=summary window operator=].
-: <dfn>summary buckets</dfn>
-:: A [=summary bucket list=].
 
 </dl>
 
@@ -1903,6 +1899,7 @@ To <dfn>parse report windows</dfn> given a |value|, a
 1. Return |windows|.
 
 To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
+
 1. Let |values| be [=the inclusive range|the range=] 1 to
     <code>MAX_UINT32</code>, inclusive.
 1. If |map|["`summary_buckets`"] [=map/exists=]:
@@ -1957,20 +1954,6 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |reportWindows| is an error, return it.
         1. Set |spec|'s [=trigger spec/event-level report windows=] to
             |reportWindows|.
-    1. Set |spec|'s [=trigger spec/summary window operator=] to
-        "<code>[=summary window operator/count=]</code>".
-    1. If |item|["`summary_window_operator`"] [=map/exists=]:
-        1. If |item|["`summary_window_operator`"] is not a [=string=], return an
-            error.
-        1. If |item|["`summary_window_operator`"] is not a 
-            [=summary window operator=], return an error.
-        1. Set |spec|'s [=trigger spec/summary window operator=] to
-            |item|["`summary_window_operator`"].
-    1. Let |summaryBuckets| be the result of
-        [=parsing summary buckets=] with |item|["`summary_buckets`"],
-        |sourceTime|, and |expiry|.
-    1. If |summaryBuckets| is an error, return it.
-    1. Set |spec|'s [=trigger spec/summary buckets=] to |summaryBuckets|.
     1. If |item|["`trigger_data`"] does not [=map/exist=], is not a [=list=], or
         [=list/is empty=], or its [=list/size=] is greater than
         [=max distinct trigger data per source=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -1909,10 +1909,10 @@ To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
     1. Set |value| to |map|["`summary_window_operator`"].
 1. Return |value|.
 
-To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
+To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxAttributionsPerSource|:
 
 1. Let |values| be [=the inclusive range|the range=] 1 to
-    <code>MAX_UINT32</code>, inclusive.
+    |maxAttributionsPerSource|, inclusive.
 1. If |map|["`summary_buckets`"] [=map/exists=]:
     1. If |map|["`summary_buckets`"] is not a [=list=] or [=list/is empty=],
         return an error.

--- a/index.bs
+++ b/index.bs
@@ -655,6 +655,21 @@ Note: The [=report window list/total window=] is conceptually a union of
 [=report windows=], because there are no gaps in time between any of the
 [=report windows|windows=].
 
+<h3 id="summary-windows-operator-header">Summary windows operator</h3>
+
+A <dfn>summary windows operator</dfn> summarizes the triggers within a
+[=report window=]. Its value is one of the following:
+
+<dl dfn-for="summary windows operator">
+: "<dfn><code>count</code></dfn>"
+:: Number of triggers attributed.
+: "<dfn><code>value_sum</code></dfn>"
+:: Sum of the value of triggers.
+
+<h3 dfn-type=dfn>Summary buckets</h3>
+
+A list of strictly increasing unsigned 32-bit integers.
+
 <h3 id="trigger-data-matching-mode-header">Trigger-data matching mode</h3>
 
 A <dfn>trigger-data matching mode</dfn> is one of the following:
@@ -677,6 +692,8 @@ A <dfn>trigger spec</dfn> is a [=struct=] with the following items:
 <dl dfn-for="trigger spec">
 : <dfn>event-level report windows</dfn>
 :: A [=report window list=].
+: <dfn>summary window operator</dfn>
+: <dfn>summary buckets</dfn>
 
 </dl>
 
@@ -1866,6 +1883,20 @@ To <dfn>parse report windows</dfn> given a |value|, a
     1. Set |startDuration| to |endDuration|.
 1. Return |windows|.
 
+To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
+1. If |map|["`summary_buckets`"] does not [=map/exist=], return
+    the trivial mapping «[ 1, 2, ..., MAX_UINT32 ]».
+1. Let |values| be |map|["`summary_buckets`"].
+1. If |values| is not a [=list=] or [=list/is empty=], return an error.
+1. Let |prev| be 0.
+1. Let |summaryBuckets| be an [=list/is empty|empty=] [=list-]. 
+1. [=list/iterate|For each=] |item| of |values|:
+    1. If |item| is not an integer or cannot be represented by an unsigned
+        32-bit integer, or is less than or equal to |prev|, return an error.
+    1. [=list/Append] |item| to |summaryBuckets|.
+    1. Set |prev| to |item|.
+1. return |summaryBuckets|.
+
 To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
 |sourceTime|, a [=duration=] |expiry|, a [=report window list=]
 |defaultReportWindows|, an unsigned 32-bit integer
@@ -1898,6 +1929,20 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |reportWindows| is an error, return it.
         1. Set |spec|'s [=trigger spec/event-level report windows=] to
             |reportWindows|.
+    1. Let |summaryWindowOperator| be "<code>[=summary windows operator/count=]</code>".
+    1. If |map|["`summary_window_operator`"] [=map/exists=]:
+        1. If |map|["`summary_window_operator`"] is not a [=string=], return an
+            error.
+        1. If |value|["`summary_window_operator`"] is not a 
+            [=summary window operator=], return an error.
+        1. Set |summaryWindowOperator| to |map|["`summary_window_operator`"].
+    1. Let |summaryBuckets| be the result of
+        [=parsing summary buckets=] with |item|["`summary_buckets`"],
+        |sourceTime|, and |expiry|.
+    1. Set |spec|'s [=trigger spec/summary window operator=] to
+        |summaryWindowOperator|.
+    1. If |summaryBuckets| is an error, return it.
+    1. Set |spec|'s [=trigger spec/summary buckets=] to |summaryBuckets|.
     1. If |item|["`trigger_data`"] does not [=map/exist=], is not a [=list=], or
         [=list/is empty=], or its [=list/size=] is greater than
         [=max distinct trigger data per source=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -1903,7 +1903,8 @@ To <dfn>parse report windows</dfn> given a |value|, a
 1. Return |windows|.
 
 To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
-1. Let |values| be the trivial mapping «[ 1, 2, ..., MAX_UINT32 ]».
+1. Let |values| be [=the inclusive range|the range=] 1 to
+    <code>MAX_UINT32</code>, inclusive.
 1. If |map|["`summary_buckets`"] [=map/exists=]:
     1. If |map|["`summary_buckets`"] is not a [=list=] or [=list/is empty=],
         return an error.
@@ -1956,15 +1957,15 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |reportWindows| is an error, return it.
         1. Set |spec|'s [=trigger spec/event-level report windows=] to
             |reportWindows|.
-    1. Let |summaryWindowOperator| be "<code>[=summary window operator/count=]</code>".
+    1. Set |spec|'s [=trigger spec/summary window operator=] to
+        "<code>[=summary window operator/count=]</code>".
     1. If |item|["`summary_window_operator`"] [=map/exists=]:
         1. If |item|["`summary_window_operator`"] is not a [=string=], return an
             error.
         1. If |item|["`summary_window_operator`"] is not a 
             [=summary window operator=], return an error.
-        1. Set |summaryWindowOperator| to |map|["`summary_window_operator`"].
-    1. Set |spec|'s [=trigger spec/summary window operator=] to
-        |summaryWindowOperator|.
+        1. Set |spec|'s [=trigger spec/summary window operator=] to
+            |item|["`summary_window_operator`"].
     1. Let |summaryBuckets| be the result of
         [=parsing summary buckets=] with |item|["`summary_buckets`"],
         |sourceTime|, and |expiry|.

--- a/index.bs
+++ b/index.bs
@@ -655,20 +655,37 @@ Note: The [=report window list/total window=] is conceptually a union of
 [=report windows=], because there are no gaps in time between any of the
 [=report windows|windows=].
 
-<h3 id="summary-windows-operator-header">Summary windows operator</h3>
+<h3 id="summary-windows-operator-header">Summary window operator</h3>
 
-A <dfn>summary windows operator</dfn> summarizes the triggers within a
+A <dfn>summary window operator</dfn> summarizes the triggers within a
 [=report window=]. Its value is one of the following:
 
-<dl dfn-for="summary windows operator">
+<dl dfn-for="summary window operator">
 : "<dfn><code>count</code></dfn>"
 :: Number of triggers attributed.
 : "<dfn><code>value_sum</code></dfn>"
 :: Sum of the value of triggers.
 
-<h3 dfn-type=dfn>Summary buckets</h3>
+</dl>
 
-A list of strictly increasing unsigned 32-bit integers.
+<h3 id="summary-bucket-header">Summary bucket</h3>
+
+A <dfn>summary bucket</dfn> is a [=struct=] with the following items:
+
+<dl dfn-for="summary bucket">
+: <dfn>start</dfn>
+:: An unsigned 32-bit integer.
+: <dfn>end</dfn>
+:: An unsigned 32-bit integer.
+
+</dl>
+
+A <dfn>summary bucket list</dfn> is a [=list=] of [=summary buckets=].
+It has the following constraints:
+
+* Elements are strictly in ascending order based on their [=summary bucket/start=].
+* Every element's [=summary bucket/end=] is equal to the next element's [=summary bucket/start=] - 1, if it exists.
+* There is at least one element in the list.
 
 <h3 id="trigger-data-matching-mode-header">Trigger-data matching mode</h3>
 
@@ -692,8 +709,10 @@ A <dfn>trigger spec</dfn> is a [=struct=] with the following items:
 <dl dfn-for="trigger spec">
 : <dfn>event-level report windows</dfn>
 :: A [=report window list=].
-: <dfn>summary window operator</dfn>
+: A <dfn>summary window operator</dfn>
+::
 : <dfn>summary buckets</dfn>
+:: A [=summary bucket list=].
 
 </dl>
 
@@ -1884,16 +1903,24 @@ To <dfn>parse report windows</dfn> given a |value|, a
 1. Return |windows|.
 
 To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
-1. If |map|["`summary_buckets`"] does not [=map/exist=], return
-    the trivial mapping «[ 1, 2, ..., MAX_UINT32 ]».
-1. Let |values| be |map|["`summary_buckets`"].
-1. If |values| is not a [=list=] or [=list/is empty=], return an error.
+1. Let |values| be the trivial mapping «[ 1, 2, ..., MAX_UINT32 ]».
+1. If |map|["`summary_buckets`"] [=map/exists=]:
+    1. If |map|["`summary_buckets`"] is not a [=list=] or [=list/is empty=],
+        return an error.
+    1. Set |values| to |map|["`summary_buckets`"].
 1. Let |prev| be 0.
-1. Let |summaryBuckets| be an [=list/is empty|empty=] [=list-]. 
+1. Let |summaryBuckets| be an [=list/is empty|empty=] [=list=]. 
 1. [=list/iterate|For each=] |item| of |values|:
     1. If |item| is not an integer or cannot be represented by an unsigned
         32-bit integer, or is less than or equal to |prev|, return an error.
-    1. [=list/Append] |item| to |summaryBuckets|.
+    1. Let |summaryBucket| be a new [=summary bucket=] whose items are
+
+        : [=summary bucket/start=]
+        :: |prev|
+        : [=summary bucket/end=]
+        :: |item| - 1
+
+    1. [=list/Append=] |summaryBucket| to |summaryBuckets|.
     1. Set |prev| to |item|.
 1. return |summaryBuckets|.
 
@@ -1929,18 +1956,18 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |reportWindows| is an error, return it.
         1. Set |spec|'s [=trigger spec/event-level report windows=] to
             |reportWindows|.
-    1. Let |summaryWindowOperator| be "<code>[=summary windows operator/count=]</code>".
+    1. Let |summaryWindowOperator| be "<code>[=summary window operator/count=]</code>".
     1. If |map|["`summary_window_operator`"] [=map/exists=]:
         1. If |map|["`summary_window_operator`"] is not a [=string=], return an
             error.
         1. If |value|["`summary_window_operator`"] is not a 
             [=summary window operator=], return an error.
         1. Set |summaryWindowOperator| to |map|["`summary_window_operator`"].
+    1. Set |spec|'s [=trigger spec/summary window operator=] to
+        |summaryWindowOperator|.
     1. Let |summaryBuckets| be the result of
         [=parsing summary buckets=] with |item|["`summary_buckets`"],
         |sourceTime|, and |expiry|.
-    1. Set |spec|'s [=trigger spec/summary window operator=] to
-        |summaryWindowOperator|.
     1. If |summaryBuckets| is an error, return it.
     1. Set |spec|'s [=trigger spec/summary buckets=] to |summaryBuckets|.
     1. If |item|["`trigger_data`"] does not [=map/exist=], is not a [=list=], or
@@ -1959,8 +1986,6 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |triggerData| does not equal |i|, return an error.
         1. Set |i| to |i| + 1.
 1. Return |specs|.
-
-Issue: Parse "`summary_window_operator`" and "`summary_buckets`" fields.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a

--- a/index.bs
+++ b/index.bs
@@ -1909,13 +1909,14 @@ To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
     1. Set |value| to |map|["`summary_window_operator`"].
 1. Return |value|.
 
-To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxAttributionsPerSource|:
+To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxEventLevelReports|:
 
 1. Let |values| be [=the inclusive range|the range=] 1 to
-    |maxAttributionsPerSource|, inclusive.
+    |maxEventLevelReports|, inclusive.
 1. If |map|["`summary_buckets`"] [=map/exists=]:
-    1. If |map|["`summary_buckets`"] is not a [=list=] or [=list/is empty=],
-        return an error.
+    1. If |map|["`summary_buckets`"] is not a [=list=], [=list/is empty=], or 
+        its [=list/size=] is greater than |maxEventLevelReports|, return an
+        error.
     1. Set |values| to |map|["`summary_buckets`"].
 1. Let |prev| be 0.
 1. Let |summaryBuckets| be an [=list/is empty|empty=] [=list=]. 

--- a/index.bs
+++ b/index.bs
@@ -1898,6 +1898,17 @@ To <dfn>parse report windows</dfn> given a |value|, a
     1. Set |startDuration| to |endDuration|.
 1. Return |windows|.
 
+To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
+
+1. Let |value| be "<code>[=summary window operator/count=]</code>".
+1. If |map|["`summary_window_operator`"] [=map/exists=]:
+    1. If |map|["`summary_window_operator`"] is not a [=string=], return an
+        error.
+    1. If |map|["`summary_window_operator`"] is not a 
+        [=summary window operator=], return an error.
+    1. Set |value| to |map|["`summary_window_operator`"].
+1. Return |value|.
+
 To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
 
 1. Let |values| be [=the inclusive range|the range=] 1 to
@@ -1970,6 +1981,9 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. If |triggerData| does not equal |i|, return an error.
         1. Set |i| to |i| + 1.
 1. Return |specs|.
+
+Issue: Invoke [=parse summary buckets=] and [=parse summary window operator=]
+from this algorithm.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a

--- a/index.bs
+++ b/index.bs
@@ -709,8 +709,8 @@ A <dfn>trigger spec</dfn> is a [=struct=] with the following items:
 <dl dfn-for="trigger spec">
 : <dfn>event-level report windows</dfn>
 :: A [=report window list=].
-: A <dfn>summary window operator</dfn>
-::
+: <dfn>summary window operator</dfn>
+:: A [=summary window operator=].
 : <dfn>summary buckets</dfn>
 :: A [=summary bucket list=].
 
@@ -1922,7 +1922,7 @@ To <dfn>parse summary buckets</dfn> given a [=map=] |map|:
 
     1. [=list/Append=] |summaryBucket| to |summaryBuckets|.
     1. Set |prev| to |item|.
-1. return |summaryBuckets|.
+1. Return |summaryBuckets|.
 
 To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
 |sourceTime|, a [=duration=] |expiry|, a [=report window list=]
@@ -1957,10 +1957,10 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. Set |spec|'s [=trigger spec/event-level report windows=] to
             |reportWindows|.
     1. Let |summaryWindowOperator| be "<code>[=summary window operator/count=]</code>".
-    1. If |map|["`summary_window_operator`"] [=map/exists=]:
-        1. If |map|["`summary_window_operator`"] is not a [=string=], return an
+    1. If |item|["`summary_window_operator`"] [=map/exists=]:
+        1. If |item|["`summary_window_operator`"] is not a [=string=], return an
             error.
-        1. If |value|["`summary_window_operator`"] is not a 
+        1. If |item|["`summary_window_operator`"] is not a 
             [=summary window operator=], return an error.
         1. Set |summaryWindowOperator| to |map|["`summary_window_operator`"].
     1. Set |spec|'s [=trigger spec/summary window operator=] to


### PR DESCRIPTION
Includes the definition for summary window operator and summary bucket structure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1111.html" title="Last updated on Dec 1, 2023, 9:36 PM UTC (7406c72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1111/b0aa8a3...7406c72.html" title="Last updated on Dec 1, 2023, 9:36 PM UTC (7406c72)">Diff</a>