### PR TITLE
Fix unary-channel calculations and warn about inconsistent registrations

### DIFF
--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -76,6 +76,11 @@ const infoGainTests = [
     epsilon: 14,
     expected: 1.584926511508231,
   },
+  {
+    numStates: 1,
+    epsilon: 14,
+    expected: 0,
+  },
 ]
 
 test('maxInformationGain', async (t) => {

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1665,6 +1665,37 @@ const testCases: TestCase[] = [
     }`,
     parseFullFlex: true,
   },
+
+  {
+    name: 'no-reports-but-specs',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_level_reports": 0,
+      "trigger_specs": [{"trigger_data": [1]}]
+    }`,
+    parseFullFlex: true,
+    expectedWarnings: [
+      {
+        path: [],
+        msg: 'trigger_specs non-empty but event-level attribution will always fail because max_event_level_reports = 0',
+      },
+    ],
+  },
+  {
+    name: 'reports-but-no-specs',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_level_reports": 1,
+      "trigger_specs": []
+    }`,
+    parseFullFlex: true,
+    expectedWarnings: [
+      {
+        path: [],
+        msg: 'max_event_level_reports > 0 but event-level attribution will always fail because trigger_specs is empty',
+      },
+    ],
+  },
 ]
 
 testCases.forEach((tc) =>

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1026,6 +1026,24 @@ function triggerDataMatching(
   })
 }
 
+function warnInconsistentMaxEventLevelReportsAndTriggerSpecs(
+  ctx: Context,
+  s: Source
+): void {
+  const allowsReports = s.maxEventLevelReports > 0
+  const hasSpecs = s.triggerSpecs.length > 0
+
+  if (allowsReports && !hasSpecs) {
+    ctx.warning(
+      'max_event_level_reports > 0 but event-level attribution will always fail because trigger_specs is empty'
+    )
+  } else if (hasSpecs && !allowsReports) {
+    ctx.warning(
+      'trigger_specs non-empty but event-level attribution will always fail because max_event_level_reports = 0'
+    )
+  }
+}
+
 export type Source = CommonDebug &
   Priority & {
     aggregatableReportWindow: number
@@ -1112,6 +1130,7 @@ function source(ctx: Context, j: Json): Maybe<Source> {
       })
     })
     .peek((s) => channelCapacity(ctx, s))
+    .peek((s) => warnInconsistentMaxEventLevelReportsAndTriggerSpecs(ctx, s))
 }
 
 function sourceKeys(ctx: Context, j: Json): Maybe<Set<string>> {


### PR DESCRIPTION
The warning part is related to #907.

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1115.html" title="Last updated on Nov 21, 2023, 3:53 PM UTC (f53e28e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1115/ed340d6...apasel422:f53e28e.html" title="Last updated on Nov 21, 2023, 3:53 PM UTC (f53e28e)">Diff</a>