### PR TITLE
Default and limit summary_buckets based on max_event_level_reports

### DIFF
--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -86,7 +86,8 @@ In addition to the parameters that were added in Phase 1, we will add one additi
     // Represents a bucketization of the integers from [0, MAX_UINT32], encoded as
     // a list of integers where new buckets begin (excluding 0 which is
     // implicitly included).
-    // It must consist of strictly increasing positive integers.
+    // It must consist of strictly increasing positive integers, and its length
+    // must be <= max_event_level_reports.
     //
     // e.g. [5, 10, 100] encodes the following ranges:
     // [[0, 4], [5, 9], [10, 99], [100, MAX_UINT32]]
@@ -96,7 +97,8 @@ In addition to the parameters that were added in Phase 1, we will add one additi
     // every new range boundary that is crossed. Reports will never be sent for
     // the range that includes 0, as every source is initialized in this range.
     //
-    // If omitted, then represents a trivial mapping [1, 2, ... , MAX_UINT32].
+    // If omitted, then represents a trivial mapping
+    // [1, 2, ... , max_event_level_reports].
     "summary_buckets": [<bucket start>, ...]
   }, {
     // Next trigger_spec

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1449,7 +1449,47 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['trigger_specs', 0, 'summary_buckets'],
-        msg: 'length must be in the range [1, Infinity]',
+        msg: 'length must be in the range [1, 3 (max_event_level_reports)]',
+      },
+    ],
+  },
+  {
+    name: 'summary-buckets-too-long',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_level_reports": 4,
+      "trigger_specs": [{
+        "trigger_data": [3],
+        "summary_buckets": [1, 2, 3, 4, 5]
+      }]
+    }`,
+    parseFullFlex: true,
+    expectedErrors: [
+      {
+        path: ['trigger_specs', 0, 'summary_buckets'],
+        msg: 'length must be in the range [1, 4 (max_event_level_reports)]',
+      },
+    ],
+  },
+  {
+    name: 'summary-buckets-cannot-validate-length',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_level_reports": null,
+      "trigger_specs": [{
+        "trigger_data": [3],
+        "summary_buckets": [1, 2, 3, 4, 5]
+      }]
+    }`,
+    parseFullFlex: true,
+    expectedErrors: [
+      {
+        path: ['max_event_level_reports'],
+        msg: 'must be a number',
+      },
+      {
+        path: ['trigger_specs', 0, 'summary_buckets'],
+        msg: 'cannot be fully validated without a valid max_event_level_reports',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -195,16 +195,23 @@ function keyValues<V>(
 type ListOpts = {
   minLength?: number
   maxLength?: number
+  maxLengthErrSuffix?: string
 }
 
 function list(
   ctx: Context,
   j: Json,
-  { minLength = 0, maxLength = Infinity }: ListOpts = {}
+  {
+    minLength = 0,
+    maxLength = Infinity,
+    maxLengthErrSuffix = '',
+  }: ListOpts = {}
 ): Maybe<Json[]> {
   return typeSwitch(ctx, j, { list: (_ctx, j) => some(j) }).filter((j) => {
     if (j.length > maxLength || j.length < minLength) {
-      ctx.error(`length must be in the range [${minLength}, ${maxLength}]`)
+      ctx.error(
+        `length must be in the range [${minLength}, ${maxLength}${maxLengthErrSuffix}]`
+      )
       return false
     }
     return true
@@ -839,6 +846,16 @@ function summaryBuckets(
   j: Json,
   maxEventLevelReports: Maybe<number>
 ): Maybe<number[]> {
+  let maxLength
+  if (maxEventLevelReports.value === undefined) {
+    ctx.error(
+      'cannot be fully validated without a valid max_event_level_reports'
+    )
+    maxLength = constants.maxSettableEventLevelAttributionsPerSource
+  } else {
+    maxLength = maxEventLevelReports.value
+  }
+
   let prev = 0
   let prevDesc = 'implicit minimum'
 
@@ -861,16 +878,10 @@ function summaryBuckets(
 
   return array(ctx, j, bucket, {
     minLength: 1,
+    maxLength,
+    maxLengthErrSuffix: ' (max_event_level_reports)',
     keepGoing: false, // suppress unhelpful cascaded errors
-  }).peek((buckets) =>
-    maxEventLevelReports.peek((n) => {
-      if (buckets.length > n) {
-        ctx.warning(
-          `will be truncated to first ${n} buckets (max event-level reports)`
-        )
-      }
-    })
-  )
+  })
 }
 
 function fullFlexTriggerDatum(ctx: Context, j: Json): Maybe<number> {


### PR DESCRIPTION
The max_event_level_reports value (whether explicit or defaulted based on source type) restricts the maximum number of reports that can be produced from a single source. Therefore, it is misleading to have more than that number of summary_buckets, since bucket increments will stop once reaching max_event_level_reports.

Rejecting sources with inconsistent values in these fields will help prevent developer errors, and both the rejection and defaulting based on max_event_level_reports bounds the storage space needed per trigger_spec for the summary_buckets field to 20, which is the max settable value for max_event_level_reports.

This is a revival of #1021, which has more discussion.