### PR TITLE
Allow sources to customize trigger data cardinality and values

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -405,16 +405,17 @@ all, or potentially reporting multiple fake reports for the event.
 Note that this scheme is an instantiation of k-randomized response, see
 [Differential privacy](#differential-privacy).
 
-Strawman: we can set `p` such that each source is protected with randomized
-response that satisfies an epsilon value of 14. This would entail:
+`p` is set such that each source is protected with randomized response that
+satisfies an epsilon value of 14. This would entail (for default configured
+sources):
 * `p = .24%` for `navigation` sources
 * `p = .00025%` for `event` sources
 
 Note that correcting for this noise addition is straightforward in most cases,
 please see <TODO link to de-biasing advice/code snippet here>. Reports will be
-updated to include `p` so that noise correction can work correctly in the event
-that `p` changes over time, or if different browsers apply different
-probabilities:
+updated to include `p` so that noise correction can work correctly for
+configurations that have different values of `p`, or if different browsers apply
+different probabilities:
 
 ```jsonc
 {

--- a/EVENT.md
+++ b/EVENT.md
@@ -284,8 +284,8 @@ about how to treat the trigger:
 ```
 
 - `trigger_data`: Optional. Coarse-grained data to identify the trigger.
-  The value will be limited [depending on the
-  attributed source type](#data-limits-and-noise). Defaults to 0.
+  The value will be used [according to the attributed source's allowed trigger
+  data and matching mode](#data-limits-and-noise). Defaults to 0.
 - `priority`: Optional. A signed 64-bit integer representing the priority
 of this trigger compared to other triggers for the same source. Defaults to 0.
 - `deduplication_key`: Optional. An unsigned 64-bit integer that will be used to
@@ -335,9 +335,64 @@ The `source_event_id` is limited to 64 bits of information to enable
 uniquely identifying an ad click.
 
 The trigger-side data must therefore be limited quite strictly, by limiting
-the amount of data and by applying noise to the data. `navigation` sources will
-be limited to only 3 bits of `trigger_data`, while `event` sources will be
-limited to only 1 bit.
+the amount of data and by applying noise to the data. By default, `navigation`
+sources will be limited to only 3 bits of `trigger_data` (the values 0 through
+7), while `event` sources will be limited to only 1 bit (the values 0 through
+1).
+
+Sources can be configured to allow non-default `trigger_data` (values and/or
+cardinality):
+
+```jsonc
+{
+  // Specifies how the 64-bit unsigned trigger_data from the trigger is matched
+  // against the source's trigger_data, which is 32-bit. Defaults to "modulus".
+  //
+  // If "exact", the trigger_data must exactly match a value contained in the
+  // source's trigger_data; if there is no such match, no event-level
+  // attribution takes place.
+  //
+  // If "modulus", the source's trigger_data must form a contiguous sequence of
+  // integers starting at 0. The trigger's trigger_data is taken modulus the
+  // cardinality of this sequence and then matched against the trigger data.
+  // See below for an example. It is an error to use "modulus" if the trigger
+  // data does not form such a sequence.
+  "trigger_data_matching": <one of "exact" or "modulus">,
+
+  // Size must be in the range [0, 32], inclusive.
+  // If omitted, defaults to [0, 1, 2, 3, 4, 5, 6, 7] for navigation sources and
+  // [0, 1] for event sources.
+  "trigger_data": [<32-bit unsigned integer>, ...]
+}
+```
+
+For example, the following configuration can be used to *reduce* noise for a
+navigation source (by limiting the number of distinct trigger data values) or
+*increase* noise for an event source (by increasing the number):
+
+```jsonc
+{
+  ...,
+  // The effective cardinality is 5, so the trigger's trigger_data will be taken
+  // modulus 5. Likewise, noise will be applied using the effective cardinality
+  // of 5, instead of the default for the source type.
+  "trigger_data": [0, 1, 2, 3, 4]
+}
+```
+
+If `"trigger_data_matching": "exact"` is used, then the values themselves need
+not form a contiguous sequence beginning at zero, and any generated report will
+contain the exact value, e.g.
+
+```jsonc
+{
+  "trigger_data_matching": "exact",
+  // If this list does not contain the trigger's trigger_data value, attribution
+  // will fail and no report will be generated. Noise will be applied using an
+  // effective cardinality of 2.
+  "trigger_data": [123, 456]
+}
+```
 
 Noise will be applied to whether a source will be reported truthfully.
 When an attribution source is registered, the browser will perform one of the

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -104,26 +104,16 @@ In addition to the parameters that were added in Phase 1, we will add one additi
     // Next trigger_spec
   }, ...],
 
-  // Specifies how the 64-bit unsigned trigger_data from the trigger is matched
-  // against the source's trigger_specs trigger_data, which is 32-bit. Defaults
-  // to "modulus".
-  //
-  // If "exact", the trigger_data must exactly match a value contained in the
-  // source's trigger_specs; if there is no such match, no event-level
-  // attribution takes place.
-  //
-  // If "modulus", the set of all trigger_data values across all trigger_specs
-  // for the source must be a contiguous sequence of integers starting at 0.
-  // The trigger's trigger_data is taken modulus the cardinality of this
-  // sequence and then matched against the trigger specs. See below for an
-  // example. It is an error to use "modulus" if the trigger specs do not
-  // contain such a sequence.
+  // See description in
+  // https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#data-limits-and-noise
   "trigger_data_matching": <one of "exact" or "modulus">,
 
-  // See description in phase 1.
+  // See description in
+  // https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-varying-frequency-and-number-of-reports
   "max_event_level_reports": <int>,
 
-  // See description in phase 1.
+  // See description in
+  // https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-varying-frequency-and-number-of-reports
   "event_report_windows": {
     "start_time": <int>,
     "end_times": [<int>, ...]

--- a/index.bs
+++ b/index.bs
@@ -715,6 +715,26 @@ A <dfn>trigger spec</dfn> is a [=struct=] with the following items:
 A <dfn>trigger spec map</dfn> is a [=map=] whose keys are unsigned 32-bit
 integers and values are [=trigger specs=].
 
+To <dfn>find a matching trigger spec</dfn> given an [=attribution source=]
+|source| and an unsigned 64-bit integer |triggerData|:
+
+1. Let |specs| be |source|'s [=attribution source/trigger specs=].
+1. If |source|'s [=attribution source/trigger-data matching mode=] is:
+    <dl class="switch">
+    : "<code>[=trigger-data matching mode/exact=]</code>"
+    :: Run the following steps:
+        1. If |specs|[|triggerData|] [=map/exists=], return its [=map/entry=].
+        1. Return null.
+    : "<code>[=trigger-data matching mode/modulus=]</code>"
+    :: Run the following steps:
+        1. If |specs| [=map/is empty=], return null.
+        1. Let |keys| be |specs|'s [=map/get the keys|keys=].
+        1. Let |index| be the remainder when dividing |triggerData| by |keys|'s
+            [=set/size=].
+        1. Return the [=map/entry=] for |specs|[|keys|[|index|]].
+
+    </dl>
+
 <h3 dfn-type=dfn>Attribution source</h3>
 
 An attribution source is a [=struct=] with the following items:
@@ -734,8 +754,8 @@ An attribution source is a [=struct=] with the following items:
 :: A [=source type=].
 : <dfn>expiry</dfn>
 :: A [=duration=].
-: <dfn>event-level report windows</dfn>
-:: A [=report window list=].
+: <dfn>trigger specs</dfn>
+:: A [=trigger spec map=].
 : <dfn>aggregatable report window</dfn>
 :: A [=report window=].
 : <dfn>priority</dfn>
@@ -1151,7 +1171,7 @@ Its value is (1 day, 30 days).
 <dfn>Min report window</dfn> is a positive [=duration=] that controls the
 minimum [=duration from=] an [=attribution source's=] [=attribution source/source time=]
 and any [=report window/end=] in [=attribution source/aggregatable report window=] or
-[=attribution source/event-level report windows=].
+[=trigger spec/event-level report windows=].
 Its value is 1 hour.
 
 <dfn>Max entries per filter data</dfn> is a positive integer that controls the
@@ -1179,7 +1199,7 @@ controls the maximum value of [=attribution source/max number of event-level rep
 Its value is 20.
 
 <dfn>Max settable event-level report windows</dfn> is a positive integer that
-controls the maximum [=list/size=] of [=attribution source/event-level report windows=].
+controls the maximum [=list/size=] of [=trigger spec/event-level report windows=].
 Its value is 5.
 
 <dfn>Default event-level attributions per source</dfn> is a [=map=] that
@@ -1903,6 +1923,12 @@ To <dfn>parse report windows</dfn> given a |value|, a
     1. Set |startDuration| to |endDuration|.
 1. Return |windows|.
 
+The user-agent has an associated boolean
+<dfn>experimental Flexible Event support</dfn> (default false) that exposes
+non-normative behavior described in the
+<a href="https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md">Flexible event-level configurations</a>
+proposal.
+
 To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
 
 1. Let |value| be "<code>[=summary window operator/count=]</code>".
@@ -1939,48 +1965,71 @@ To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxEve
     1. Set |prev| to |item|.
 1. Return |summaryBuckets|.
 
-To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
-|sourceTime|, a [=duration=] |expiry|, a [=report window list=]
-|defaultReportWindows|, an unsigned 32-bit integer
-|defaultTriggerDataCardinality|, and a [=trigger-data matching mode=]
-|matchingMode|:
+To <dfn>parse trigger data into a trigger spec map</dfn> given a
+|triggerDataList|, a [=trigger spec=] |spec|, a [=trigger spec map=]
+|specs|, and a [=boolean=] |allowEmpty|:
 
-1. [=Assert=]: |defaultTriggerDataCardinality| is greater than 0 and less than
-    or equal to [=max distinct trigger data per source=].
-1. Let |specs| be a new [=map=].
-1. If |map|["`trigger_specs`"] does not [=map/exist=]:
+1. If |triggerDataList| is not a [=list=] or its [=list/size=] is greater than
+    [=max distinct trigger data per source=], return false.
+1. If |allowEmpty| is false and |triggerDataList| [=list/is empty=], return
+    false.
+1. [=list/iterate|For each=] |triggerData| of |triggerDataList|:
+    1. If |triggerData| is not an integer or cannot be represented by an
+        unsigned 32-bit integer, or |specs|[|triggerData|] [=map/exists=],
+        return false.
+    1. [=map/Set=] |specs|[|triggerData|] to |spec|.
+    1. If |specs|'s [=map/size=] is greater than
+        [=max distinct trigger data per source=], return false.
+1. Return true.
+
+To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
+|sourceTime|, a [=source type=] |sourceType|, a [=duration=] |expiry|, and a
+[=trigger-data matching mode=] |matchingMode|:
+
+1. Let |defaultReportWindows| be the result of
+    [=parsing top-level report windows=] with |map|, |sourceTime|, |sourceType|,
+    and |expiry|.
+1. If |defaultReportWindows| is an error, return an error.
+1. Let |specs| be a new [=trigger spec map=].
+1. If [=experimental Flexible Event support=] is true and
+    |map|["`trigger_specs`"] [=map/exists=]:
+    1. If |map|["`trigger_data`"] [=map/exists=], return an error.
+    1. If |map|["`trigger_specs`"] is not a [=list=] or its
+        [=list/size=] is greater than [=max distinct trigger data per source=],
+        return an error.
+    1. [=list/iterate|For each=] |item| of |map|["`trigger_specs`"]:
+        1. If |item| is not a [=map=], return an error.
+        1. Let |spec| be a new [=trigger spec=] with the following items:
+            : [=trigger spec/event-level report windows=]
+            :: |defaultReportWindows|
+        1. If |item|["`event_report_windows`"] [=map/exists=]:
+            1. Let |reportWindows| be the result of
+                [=parsing report windows=] with |item|["`event_report_windows`"],
+                |sourceTime|, and |expiry|.
+            1. If |reportWindows| is an error, return it.
+            1. Set |spec|'s [=trigger spec/event-level report windows=] to
+                |reportWindows|.
+        1. If |item|["`trigger_data`"] does not [=map/exist=], return an error.
+        1. Let |allowEmpty| be false.
+        1. If the result of running
+            [=parse trigger data into a trigger spec map=] with
+            |item|["`trigger_data`"], |spec|, |specs|, and |allowEmpty| is
+            false, return an error.
+1. Otherwise:
     1. Let |spec| be a new [=trigger spec=] with the following items:
         : [=trigger spec/event-level report windows=]
         :: |defaultReportWindows|
-    1. [=set/iterate|For each=] integer |triggerData| of [=the exclusive range|the range=] 0 to
-        |defaultTriggerDataCardinality|, exclusive:
-        1. [=map/Set=] |specs|[|triggerData|] to |spec|.
-    1. Return |specs|.
-1. If |map|["`trigger_specs`"] is not a [=list=] or its
-    [=list/size=] is greater than [=max distinct trigger data per source=],
-    return an error.
-1. [=list/iterate|For each=] |item| of |map|["`trigger_specs`"]:
-    1. If |item| is not a [=map=], return an error.
-    1. Let |spec| be a new [=trigger spec=] with the following items:
-        : [=trigger spec/event-level report windows=]
-        :: |defaultReportWindows|
-    1. If |item|["`event_report_windows`"] [=map/exists=]:
-        1. Let |reportWindows| be the result of
-            [=parsing report windows=] with |item|["`event_report_windows`"],
-            |sourceTime|, and |expiry|.
-        1. If |reportWindows| is an error, return it.
-        1. Set |spec|'s [=trigger spec/event-level report windows=] to
-            |reportWindows|.
-    1. If |item|["`trigger_data`"] does not [=map/exist=], is not a [=list=], or
-        [=list/is empty=], or its [=list/size=] is greater than
-        [=max distinct trigger data per source=], return an error.
-    1. [=list/iterate|For each=] |triggerData| of |item|["`trigger_data`"]:
-        1. If |triggerData| is not an integer or cannot be represented by an
-            unsigned 32-bit integer, or |specs|[|triggerData|] [=map/exists=],
+    1. If |map|["`trigger_data`"] [=map/exists=]:
+        1. Let |allowEmpty| be true.
+        1. If the result of running
+            [=parse trigger data into a trigger spec map=] with
+            |map|["`trigger_data`"], |spec|, |specs|, and |allowEmpty| is false,
             return an error.
-        1. [=map/Set=] |specs|[|triggerData|] to |spec|.
-        1. If |specs|'s [=map/size=] is greater than
-            [=max distinct trigger data per source=], return an error.
+    1. Otherwise:
+        1. [=set/iterate|For each=] integer |triggerData| of
+            [=the exclusive range|the range=] 0 to
+            [=default trigger data cardinality=][|sourceType|], exclusive:
+            1. [=map/Set=] |specs|[|triggerData|] to |spec|.
 1. If |matchingMode| is "<code>[=trigger-data matching mode/modulus=]</code>":
     1. Let |i| be 0.
     1. [=map/iterate|For each=] |triggerData| of |specs|'s [=map/get the keys|keys=]:
@@ -2032,7 +2081,6 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. If |debugCookieSet| is false, set |debugKey| to null.
 1. Let |aggregationKeys| be the result of running [=parse aggregation keys=] with |value|.
 1. If |aggregationKeys| is null, return null.
-1. Let |triggerDataCardinality| be [=default trigger data cardinality=][|sourceType|].
 1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
 1. Set |maxAttributionsPerSource| to |value|["`max_event_level_reports`"] if it [=map/exists=].
 1. If |maxAttributionsPerSource| is not a non-negative integer, or is greater than [=max settable event-level attributions per source=], return null.
@@ -2042,8 +2090,6 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |debugReportingEnabled| be false.
 1. If |value|["`debug_reporting`"] [=map/exists=] and is a [=boolean=], set
     |debugReportingEnabled| to |value|["`debug_reporting`"].
-1. Let |eventReportWindows| be the result of [=parsing top-level report windows=] with |value|, |sourceTime|, |sourceType|, and |expiry|.
-1. If |eventReportWindows| is an error, return null.
 1. Let |aggregatableReportWindow| be a new [=report window=] with the following items:
 
     : [=report window/start=]
@@ -2051,12 +2097,14 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     : [=report window/end=]
     :: |sourceTime| + |aggregatableReportWindowEnd|
 
-1. Let |triggerSpecs| be a new [=trigger spec map=].
-1. [=set/iterate|For each=] integer |triggerData| of [=the exclusive range|the range=] 0 to |triggerDataCardinality|, exclusive:
-    1. Let |spec| be a new [=trigger spec=] struct whose items are:
-        : [=trigger spec/event-level report windows=]
-        :: |eventReportWindows|
-    1. [=map/Set=] |triggerSpecs|[|triggerData|] to |spec|.
+1. Let |triggerDataMatchingMode| be "<code>[=trigger-data matching mode/modulus=]</code>".
+1. If |value|["`trigger_data_matching`"] [=map/exists=]:
+    1. If |value|["`trigger_data_matching`"] is not a [=string=], return null.
+    1. If |value|["`trigger_data_matching`"] is not a [=trigger-data matching mode=], return null.
+    1. Set |triggerDataMatchingMode| to |value|["`trigger_data_matching`"].
+1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
+    |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
+1. If |triggerSpecs| is an error, return null.
 1. Let |randomizedResponseConfig| be a new [=randomized response output configuration=] whose items are:
 
     : [=randomized response output configuration/max attributions per source=]
@@ -2070,11 +2118,6 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. If [=automation local testing mode=] is true, set |epsilon| to `∞`.
 1. If the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon| is greater than
     [=max event-level channel capacity per source=][|sourceType|], return null.
-1. Let |triggerDataMatchingMode| be "<code>[=trigger-data matching mode/modulus=]</code>".
-1. If |value|["`trigger_data_matching`"] [=map/exists=]:
-    1. If |value|["`trigger_data_matching`"] is not a [=string=], return null.
-    1. If |value|["`trigger_data_matching`"] is not a [=trigger-data matching mode=], return null.
-    1. Set |triggerDataMatchingMode| to |value|["`trigger_data_matching`"].
 1. Let |source| be a new [=attribution source=] struct whose items are:
 
     : [=attribution source/source identifier=]
@@ -2089,8 +2132,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |reportingOrigin|
     : [=attribution source/expiry=]
     :: |expiry|
-    : [=attribution source/event-level report windows=]
-    :: |eventReportWindows|
+    : [=attribution source/trigger specs=]
+    :: |triggerSpecs|
     : [=attribution source/aggregatable report window=]
     :: |aggregatableReportWindow|
     : [=attribution source/priority=]
@@ -2177,20 +2220,14 @@ To <dfn>check if an [=attribution source=] exceeds the unexpired destination lim
 To <dfn>obtain a fake report</dfn> given an [=attribution source=] |source| and
 a [=trigger state=] |triggerState|:
 
-1. Let |fakeConfig| be a new [=event-level trigger configuration=] with the items:
-    : [=event-level trigger configuration/trigger data=]
-    :: |triggerState|'s [=trigger state/trigger data=]
-    : [=event-level trigger configuration/dedup key=]
-    :: null
-    : [=event-level trigger configuration/priority=]
-    :: 0
-    : [=event-level trigger configuration/filters=]
-    :: «[ "`source_type`" → « |source|'s [=attribution source/source type=] » ]»
+1. Let |specEntry| be the [=map/entry=] for
+    |source|'s [=attribution source/trigger specs=][|triggerState|'s [=trigger state/trigger data=]].
 1. Let |triggerTime| be the greatest [=moment=] that is strictly less than
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
+1. Let |priority| be 0.
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |triggerTime|, [=obtain an event-level report/triggerDebugKey=] set to null,
-    |fakeConfig|, and |triggerState|'s [=trigger state/trigger data=].
+    |priority|, and |specEntry|.
 1. [=Assert=]: |fakeReport|'s [=event-level report/report time=] is equal to
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
@@ -2798,6 +2835,10 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 
+Issue: This algorithm is not compatible with the behavior proposed for
+[=experimental Flexible Event support=] with differing
+[=trigger spec/event-level report windows=] for a given source.
+
 To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger|, an
 [=attribution source=] |sourceToAttribute|, and an
 [=attribution rate-limit record=] |rateLimitRecord|, run the following steps:
@@ -2832,24 +2873,17 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
          with "<code>[=trigger debug data type/trigger-event-deduplicated=]</code>", |trigger|, |sourceToAttribute| and
          [=obtain debug data on trigger registration/report=] set to null.
      1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. Let |triggerData| be |matchedConfig|'s [=event-level trigger configuration/trigger data=].
-1. Let |triggerDataCardinality| be [=default trigger data cardinality=][|attributedSource|'s [=attribution source/source type=]].
-1. If |attributedSource|'s [=attribution source/trigger-data matching mode=] is:
-    <dl class="switch">
-    : "<code>[=trigger-data matching mode/exact=]</code>":
-    :: Do nothing.
-    : "<code>[=trigger-data matching mode/modulus=]</code>":
-    :: Set |triggerData| to the remainder when dividing |triggerData| by |triggerDataCardinality|.
-
-    </dl>
-1. If |triggerData| is greater than or equal to |triggerDataCardinality|:
+1. Let |specEntry| be the result of [=finding a matching trigger spec=] with
+    |sourceToAttribute| and |matchedConfig|'s
+    [=event-level trigger configuration/trigger data=].
+1. If |specEntry| is null:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with "<code>[=trigger debug data type/trigger-event-no-matching-trigger-data=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. Let |windowResult| be the result of [=check whether a moment falls within a window=]
     with |trigger|'s [=attribution trigger/trigger time=] and
-    |sourceToAttribute|'s [=attribution source/event-level report windows=]'s
+    |specEntry|'s [=map/value=]'s [=trigger spec/event-level report windows=]'s
     [=report window list/total window=].
 1. If |windowResult| is <strong>falls before</strong>:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -2874,7 +2908,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     return it.
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|,
     |trigger|'s [=attribution trigger/trigger time=], |trigger|'s [=attribution trigger/debug key=],
-    |matchedConfig|, and |triggerData|.
+    |matchedConfig|'s [=event-level trigger configuration/priority=], and |specEntry|.
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
     is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -3099,11 +3133,10 @@ a [=report window=] |window|:
     return <strong>falls after</strong>.
 1. Return <strong>falls within</strong>.
 
-To <dfn>obtain an event-level report delivery time</dfn> given an [=attribution source=]
-|source| and a [=moment=] |triggerTime|:
+To <dfn>obtain an event-level report delivery time</dfn> given a
+[=report window list=] |windows| and a [=moment=] |triggerTime|:
 
 1. If [=automation local testing mode=] is true, return |triggerTime|.
-1. Let |windows| be |source|'s [=attribution source/event-level report windows=].
 1. [=list/iterate|For each=] |window| of |windows|:
     1. If the result of [=check whether a moment falls within a window=] with
         |triggerTime| and |window| is <strong>falls within</strong>, return
@@ -3123,15 +3156,19 @@ To <dfn>obtain an aggregatable report delivery time</dfn> given an [=attribution
 To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |source|,
 a [=moment=] |triggerTime|, an optional non-negative 64-bit integer
 <dfn for="obtain an event-level report"><var>triggerDebugKey</var></dfn>,
-an [=event-level trigger configuration=] |config|, and a non-negative 64-bit integer |triggerData|:
+a 64-bit integer priority |priority|, and a [=trigger spec map=] [=map/entry=]
+|specEntry|:
 
-1. Let |reportTime| be the result of running [=obtain an event-level report delivery time=] with |source| and |triggerTime|.
+1. Let |reportTime| be the result of running
+    [=obtain an event-level report delivery time=] with |specEntry|'s
+    [=map/value=]'s [=trigger spec/event-level report windows=] and
+    |triggerTime|.
 1. Let |report| be a new [=event-level report=] struct whose items are:
 
     : [=event-level report/event ID=]
     :: |source|'s [=attribution source/event ID=].
     : [=event-level report/trigger data=]
-    :: |triggerData|
+    :: |specEntry|'s [=map/key=]
     : [=event-level report/randomized trigger rate=]
     :: |source|'s [=attribution source/randomized trigger rate=].
     : [=event-level report/reporting origin=]
@@ -3141,7 +3178,7 @@ an [=event-level trigger configuration=] |config|, and a non-negative 64-bit int
     : [=event-level report/report time=]
     :: |reportTime|
     : [=event-level report/trigger priority=]
-    :: |config|'s [=event-level trigger configuration/priority=].
+    :: |priority|.
     : [=event-level report/trigger time=]
     :: |triggerTime|.
     : [=event-level report/source identifier=]

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -76,11 +76,11 @@ const testCases: TestCase[] = [
     name: 'unknown-field',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": []
+      "x": []
     }`,
     expectedWarnings: [
       {
-        path: ['trigger_specs'],
+        path: ['x'],
         msg: 'unknown field',
       },
     ],
@@ -1326,7 +1326,7 @@ const testCases: TestCase[] = [
     ],
   },
 
-  // Full Flex
+  // Flex
   // TODO: compare returned trigger specs against expected values
 
   {
@@ -1374,6 +1374,36 @@ const testCases: TestCase[] = [
     ],
   },
   {
+    name: 'top-level-trigger-data-and-trigger-specs',
+    json: `{
+      "destination": "https://a.test",
+      "trigger_data": [],
+      "trigger_specs": []
+    }`,
+    parseFullFlex: true,
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'mutually exclusive fields: trigger_data, trigger_specs',
+      },
+    ],
+  },
+  {
+    name: 'top-level-trigger-data-and-trigger-specs-ignored',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_level_reports": 0,
+      "trigger_data": [],
+      "trigger_specs": []
+    }`,
+    expectedWarnings: [
+      {
+        path: ['trigger_specs'],
+        msg: 'unknown field',
+      },
+    ],
+  },
+  {
     name: 'trigger-data-missing',
     json: `{
       "destination": "https://a.test",
@@ -1391,12 +1421,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-wrong-type',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [{"trigger_data": 1}]
+      "trigger_data": 1
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data'],
+        path: ['trigger_data'],
         msg: 'must be a list',
       },
     ],
@@ -1405,12 +1434,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-value-wrong-type',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [{"trigger_data": ["1"]}]
+      "trigger_data": ["1"]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data', 0],
+        path: ['trigger_data', 0],
         msg: 'must be a number',
       },
     ],
@@ -1419,12 +1447,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-value-not-integer',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [{"trigger_data": [1.5]}]
+      "trigger_data": [1.5]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data', 0],
+        path: ['trigger_data', 0],
         msg: 'must be an integer',
       },
     ],
@@ -1433,12 +1460,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-value-negative',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [{"trigger_data": [-1]}]
+      "trigger_data": [-1]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data', 0],
+        path: ['trigger_data', 0],
         msg: 'must be in the range [0, 4294967295]',
       },
     ],
@@ -1447,12 +1473,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-value-exceeds-max',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [{"trigger_data": [4294967296]}]
+      "trigger_data": [4294967296]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data', 0],
+        path: ['trigger_data', 0],
         msg: 'must be in the range [0, 4294967295]',
       },
     ],
@@ -1461,14 +1486,11 @@ const testCases: TestCase[] = [
     name: 'trigger-data-duplicated-within',
     json: `{
       "destination": "https://a.test",
-      "trigger_specs": [
-        { "trigger_data": [1, 2, 1] }
-      ]
+      "trigger_data": [1, 2, 1]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'trigger_data', 2],
+        path: ['trigger_data', 2],
         msg: 'duplicate value 1',
       },
     ],
@@ -1491,17 +1513,11 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'trigger-data-too-many-within',
-    json: JSON.stringify({
-      destination: 'https://a.test',
-      trigger_specs: [
-        {
-          trigger_data: Array(33)
-            .fill(0)
-            .map((_, i) => i),
-        },
-      ],
-    }),
+    name: 'trigger-spec-trigger-data-empty',
+    json: `{
+      "destination": "https://a.test",
+      "trigger_specs": [{"trigger_data": []}]
+    }`,
     parseFullFlex: true,
     expectedErrors: [
       {
@@ -1749,7 +1765,6 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "trigger_data_matching": 3
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
         path: ['trigger_data_matching'],
@@ -1763,7 +1778,6 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "trigger_data_matching": "EXACT"
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
         path: ['trigger_data_matching'],
@@ -1776,9 +1790,8 @@ const testCases: TestCase[] = [
     json: `{
       "destination": "https://a.test",
       "trigger_data_matching": "modulus",
-      "trigger_specs": [{"trigger_data": [1]}]
+      "trigger_data": [1]
     }`,
-    parseFullFlex: true,
     expectedErrors: [
       {
         path: ['trigger_data_matching'],
@@ -1787,7 +1800,7 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'trigger-data-matching-modulus-trigger-data-not-contiguous',
+    name: 'trigger-data-matching-modulus-trigger-data-not-contiguous-across',
     json: `{
       "destination": "https://a.test",
       "trigger_data_matching": "modulus",
@@ -1805,7 +1818,21 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'trigger-data-matching-modulus-valid',
+    name: 'trigger-data-matching-modulus-trigger-data-not-contiguous-within',
+    json: `{
+      "destination": "https://a.test",
+      "trigger_data_matching": "modulus",
+      "trigger_data": [0, 1, 3]
+    }`,
+    expectedErrors: [
+      {
+        path: ['trigger_data_matching'],
+        msg: 'trigger_data must form a contiguous sequence of integers starting at 0 for modulus',
+      },
+    ],
+  },
+  {
+    name: 'trigger-data-matching-modulus-valid-across',
     json: `{
       "destination": "https://a.test",
       "trigger_data_matching": "modulus",
@@ -1817,15 +1844,22 @@ const testCases: TestCase[] = [
     }`,
     parseFullFlex: true,
   },
+  {
+    name: 'trigger-data-matching-modulus-valid-within',
+    json: `{
+      "destination": "https://a.test",
+      "trigger_data_matching": "modulus",
+      "trigger_data": [1, 0, 2, 3]
+    }`,
+  },
 
   {
     name: 'no-reports-but-specs',
     json: `{
       "destination": "https://a.test",
       "max_event_level_reports": 0,
-      "trigger_specs": [{"trigger_data": [1]}]
+      "trigger_data": [1]
     }`,
-    parseFullFlex: true,
     expectedWarnings: [
       {
         path: [],
@@ -1838,9 +1872,8 @@ const testCases: TestCase[] = [
     json: `{
       "destination": "https://a.test",
       "max_event_level_reports": 1,
-      "trigger_specs": []
+      "trigger_data": []
     }`,
-    parseFullFlex: true,
     expectedWarnings: [
       {
         path: [],


### PR DESCRIPTION
This implements a subset of the Full Flexible Event proposal, allowing custom trigger data (both values and cardinality) via a new top-level `"trigger_data": [...]` field and the Full Flex proposal's `"trigger_data_matching": "exact"`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 405 Method Not Allowed :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 2, 2024, 5:14 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fapasel422%2Fattribution-reporting-api%2Fca946c4be03d8c1b60996b08d786b2d039baaa15%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"><html lang='en'><head><meta content='text/html; charset=utf-8' http-equiv='Content-Type'><title>CSS Spec Preprocessor</title><link href='/bikeshed/img/favicon.png' rel='icon' type='image/png'><link href='/bikeshed/core/stylesheets/base.css' rel='stylesheet' type='text/css'><link href='/bikeshed/core/stylesheets/system.css' rel='stylesheet' type='text/css'><link href='/bikeshed/stylesheets/bikeshed.css' rel='stylesheet' type='text/css'><script nonce='XdQvsRGDKiohTtl8FIWm6cLNFmER2roRI7BFurZSFKM=' type='text/javascript'><!--
var gCookieDomain=".api.csswg.org";var gCookiePath="\/bikeshed\/";var gCookiePrefix="bikeshed_";var gUserId=false;if(!Array.indexOf){Array.prototype.indexOf=function(obj){for(var index=0;index<this.length;index++){if(this[index]==obj){return index;}}return-1;}}try{if(1!=Node.ELEMENT_NODE){throw true;}}catch(exc){var Node={ELEMENT_NODE:1,ATTRIBUTE_NODE:2,TEXT_NODE:3};}var system={mAPIXHR:null,mAPITimer:null,mAPIQueue:[],commonPrefix:function(string1,string2){var prefix='';var length=((string1.length<string2.length)?string1.length:string2.length);var index=-1;while((++index<length)&(string1[index]==string2[index])){prefix+=string1[index];}return prefix;},getCookie:function(name){var cookies=document.cookie.split(';');name+='=';var prefixedName=gCookiePrefix+name;for(var index=0;index<cookies.length;index++){cookie=cookies[index].trim();if(prefixedName==cookie.substring(0,prefixedName.length)){return unescape(cookie.substring(prefixedName.length));}if(name==cookie.substring(0,name.length)){return unescape(cookie.substring(name.length));}}return null;},setCookie:function(name,value){if(null==value){var expDate=new Date();expDate.setDate(expDate.getDate()-1);document.cookie=gCookiePrefix+name+'=; expires='+expDate.toGMTString()+'; '+'domain='+gCookieDomain+'; path='+gCookiePath;}else{document.cookie=gCookiePrefix+name+'='+escape(value)+'; expires=0; '+'domain='+gCookieDomain+'; path='+gCookiePath;}},hasClass:function(element,className){if(element&&('className'in element)){var classes=element.className.split(' ');if(-1<classes.indexOf(className)){return true;}}return false;},addClass:function(element,className){if(element){var classes=(('className'in element)?element.className.split(' '):new Array());if(-1==classes.indexOf(className)){classes.push(className);element.className=classes.join(' ');}}},removeClass:function(element,className){if(element){var classes=(('className'in element)?element.className.split(' '):new Array());var index;while(-1<(index=classes.indexOf(className))){classes.splice(index,1);}element.className=classes.join(' ');}},findChildWithClass:function(element,className){if(element){var children=element.children;if(children){for(var index=0;index<children.length;index++){var child=children[index];if((child.nodeType==Node.ELEMENT_NODE)&&this.hasClass(child,className)){return child;}}}}return null;},getFirstElementChild:function(element){if(element){var children=element.children;for(var index=0;index<children.length;index++){var child=children[index];if(child.nodeType==Node.ELEMENT_NODE){return child;}}}return null;},iterateElementChildren:function(element,callback){if(element){var children=Array();for(var index=0;index<element.children.length;index++){var child=element.children[index];if(child.nodeType==Node.ELEMENT_NODE){children.push(child);}}for(var index=0;index<children.length;index++){var child=children[index];var result=callback(child,index);if(result){return result;}}}return false;},isLoggedIn:function(){var login=document.getElementById('login');return(login&&this.hasClass(login,'loggedin'));},toggleLoginMenu:function(){var login=document.getElementById('login');if(login){if(this.hasClass(login,'open')){this.removeClass(login,'open');}else{this.addClass(login,'open');}}},updatePageURI:function(uri){var login=document.getElementById('login');if(login){var a=system.createElement('a',{'href':uri});uri=a.pathname;system.iterateElementChildren(login,function(div,index){system.iterateElementChildren(div,function(item,index){if(item.hasAttribute('href')){var href=item.getAttribute('href');var index=href.indexOf('/return/');if(0<=index){var prefix=system.commonPrefix(uri,item.pathname);item.setAttribute('href',href.substring(0,index)+'/return/'+uri.substring(prefix.length));}}});});}},createProgressIcon:function(){var progress=this.createElement('span',{'class':'progress p1'});progress.setAttribute('data-timer',setInterval(function(){var state=progress.className.slice(-1);state=(state-0+1)%8;progress.className='progress p'+state;},125));return progress;},removeProgressIcon:function(progress){if(progress){clearInterval(progress.getAttribute('data-timer')-0);if(progress.parentNode){progress.parentNode.removeChild(progress);}}},addLoadEvent:function(onLoad){try{var oldOnLoad=window.onload;if('function'!=typeof(window.onload)){window.onload=onLoad;}else{window.onload=function(){if(oldOnLoad){oldOnLoad();}onLoad();}}}catch(err){}},createElement:function(tagName,attrs,textContent){var element=document.createElement(tagName);if(attrs){for(attr in attrs){if(attrs.hasOwnProperty(attr)){if('id'==attr){element.id=attrs.id;}else if('className'==attr){element.className=attrs.className;}else if(attrs[attr]){element.setAttribute(attr,attrs[attr]);}}}}if(textContent){element.textContent=textContent;}return element;},emptyElement:function(element){if(element){while(element.lastChild){element.removeChild(element.lastChild);}}},addFormData:function(form,name,value){if(form){var hidden=this.createElement('input',{'type':'hidden','name':name,'value':value});form.appendChild(hidden);}},addUserHyperLink:function(parent,user){var userName=(user&&user.name ?((user.name.toLowerCase()==user.full_name.toLowerCase())?user.full_name:user.name):'Anonymous User');var title=(user&&user.full_name&&user.name&&(user.full_name.toLowerCase()!=user.name.toLowerCase())?user.full_name:'');var email=(user&&user.email&&user.display_email ?user.email:'');var uri=(user&&user.uri ?user.uri:'');if(email){parent.appendChild(this.createElement('a',{'href':'mailto:'+email,'title':title},userName));}else if(uri){parent.appendChild(this.createElement('a',{'href':uri,'title':title},userName));}else{parent.appendChild(this.createElement('span',{'title':title},userName));}},_processAPIQueue:function(){var call=this.mAPIQueue.shift();if(call){if(!this.mAPIXHR){this.mAPIXHR=new XMLHttpRequest();}this.mAPIXHR.onreadystatechange=function(){if(4==system.mAPIXHR.readyState){if(call.callback){var response=false;try{if('json'==call.type){response=JSON.parse(system.mAPIXHR.responseText);}else if('xml'==call.type){response=system.mAPIXHR.responseXML.documentElement}}catch(err){}try{call.callback(system.mAPIXHR.status,response);}catch(err){if(call.progress){system.removeProgressIcon(call.progress);}throw err;}}if(call.progress){system.removeProgressIcon(call.progress);}this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);}};try{this.mAPIXHR.open(call.method,call.uri,true);if(call.callback){this.mAPIXHR.setRequestHeader('Accept','application/json');}if('POST'==call.method){this.mAPIXHR.setRequestHeader('Content-type','application/x-www-form-urlencoded');this.mAPIXHR.setRequestHeader('Content-length',call.data.length);}if('xml'==call.type){this.mAPIXHR.responseType='document';}else{this.mAPIXHR.responseType='';}this.mAPIXHR.send(call.data);}catch(err){if(call.progress){system.removeProgressIcon(call.progress);}this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);throw err;}}else{this.mAPITimer=null;}},callAPI:function(method,uri,data,type,callback,progressTarget,priority){var progress=null;if(progressTarget){progress=this.createProgressIcon();progressTarget.parentNode.insertBefore(progress,progressTarget.nextSibling);}var call={method:method,uri:uri,type:type,data:data,callback:callback,progress:progress};if(priority){this.mAPIQueue.unshift(call);}else{this.mAPIQueue.push(call);}if(null===this.mAPITimer){this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);}},encodeParams:function(params,arrayName){var paramString='';for(param in params){if(params.hasOwnProperty(param)){if(paramString){paramString+='&';}var name=param;if(arrayName){name=arrayName+'['+param+']';}if(Array.isArray(params[param])){for(var index=0;index<params[param].length;index++){paramString+=name+'[]='+params[param][index];}}else if('object'==typeof(params[param])){paramString+=this.encodeParams(params[param],param);}else if('boolean'==typeof(params[param])){paramString+=name+'='+(params[param]+0);}else{paramString+=name+'='+encodeURIComponent(params[param]);}}}return paramString;},getXML:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var paramString=this.encodeParams(params);this.callAPI('GET',uri+'?'+paramString,null,'xml',callback,progressTarget,priority);},callAPIGet:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var loginKey=this.getCookie('loginkey');if(loginKey){params.loginkey=loginKey;}var paramString=this.encodeParams(params);this.callAPI('GET',uri+'?'+paramString,null,'json',callback,progressTarget,priority);},callAPIPost:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var loginKey=this.getCookie('loginkey');if(loginKey){params.loginkey=loginKey;}var data=this.encodeParams(params);this.callAPI('POST',uri,data,'json',callback,progressTarget,priority);},abortAPICall:function(){if(this.mAPIXHR){if((4!=this.mAPIXHR.readyState)&&(0!=this.mAPIXHR.readyState)){this.mAPIXHR.abort();}}},setMenuAlert:function(menuId,state){var menuLink=document.getElementById(menuId);if(menuLink){if(state){if(!this.hasClass(menuLink,'alert')){var icon=this.createElement('span',{'class':'icon alert','style':'top: -14px ! important'});menuLink.appendChild(icon);this.addClass(menuLink,'alert');setTimeout(function(){icon.setAttribute('style','top: '+(menuLink.offsetTop+3)+'px');},100);}}else{if(this.hasClass(menuLink,'alert')){var icon=menuLink.lastChild;icon.setAttribute('style','top: -14px ! important');this.removeClass(menuLink,'alert');setTimeout(function(){menuLink.removeChild(icon);},500);}}}}};
// --></script><script nonce='XdQvsRGDKiohTtl8FIWm6cLNFmER2roRI7BFurZSFKM=' type='text/javascript'><!--
function updateForceControl(){var outputHTMLControl=document.getElementById('output-error');var forceControl=document.getElementById('force');var dieOnControl=document.getElementById('die-on');forceControl.disabled=outputHTMLControl.checked;dieOnControl.disabled=(outputHTMLControl.checked||forceControl.checked);}system.addLoadEvent(updateForceControl)
// --></script></head><body><div class='header'><div class='logo'><a href='http://www.w3.org/' rel='home'><img alt='W3C' src='/bikeshed/core/img/logo-w3c-screen-sm.png'></a></div><div class='login' id='login'><div><a href='/bikeshed/login/return/'>Login</a></div></div><p class='nav'><a>Home</a></p><h1 id='title'>CSS Spec Preprocessor</h1></div><div class='body'><p class='error'>Must use POST to process URL</p><form accept-charset='utf-8' action='' enctype='multipart/form-data' method='post'><fieldset><legend>Specification Source</legend><table class='labels'><tr><th><label for='file'>Upload File:</label></th><td><input name='file' type='file' value=''></td></tr><tr><th><label for='url'>Load from URL:</label></th><td><input id='url' name='url' size='60' type='text' value='https://raw.githubusercontent.com/apasel422/attribution-reporting-api/ca946c4be03d8c1b60996b08d786b2d039baaa15/index.bs'></td></tr><tr><th><label for='text'>Enter Text:</label></th><td><textarea cols='80' id='text' name='text' rows='10'></textarea></td></tr></table></fieldset><fieldset><legend>Options</legend><table class='labels'><tr><th><label for='input'>Input Type:</label></th><td><select id='input' name='input'><option selected value='spec'>Specification</option><option value='issues'>Issues List</option></select></td></tr><tr><th>Output:</th><td><input id='output-error' name='output' type='radio' value='err'><label for='output-error'>Errors &amp; Warnings</label><br><input id='output-html' name='output' type='radio' value='html'><label for='output-html'>Generated HTML</label><br><input checked id='output-frame' name='output' type='radio' value='frame'><label for='output-frame'>Both (in Frames)</label></td></tr><tr><th style='vertical-align: baseline'>Error Handling:</th><td><input checked id='force' name='force' type='checkbox' value='1'><label for='force'>Force HTML Output (ignore fatal errors)</label></td></tr><tr><th>Die On:</th><td><select id='die-on' name='die-on'><option selected value='nothing'>Nothing</option><option value='fatal'>Fatal</option><option value='link-error'>Link Error</option><option value='warning'>Warning</option><option value='everything'>Everything</option></select></td></tr><tr><th><label for='time'>Default Time:</label></th><td><input id='time' name='time' size='40' type='text'> (yyyy-mm-dd hh:mm:ss +0000)</td></tr></table></fieldset><input name='action' type='submit' value='Process'></form><div class='instructions'>This tool may also be used from the command line, e.g.:<code><span>curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F force=1 &gt; Overview.html</span><span>curl http://api.csswg.org/bikeshed/ -F url=https://drafts.csswg.org/css-align-3/Overview.bs &gt; Overview.html</span><span>curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F output=err</span><span>curl http://api.csswg.org/bikeshed/ -F file=@Issues.txt -F input=issues &gt; Issues.html</span></code><p>Valid paramaters are:</p><dl><dt>file</dt><dd>file contents to process</dd><dt>url</dt><dd>url contents to process</dd><dt>input</dt><dd>input type: &#039;spec&#039; or &#039;issues&#039; (default = &#039;spec&#039;)</dd><dt>output</dt><dd>desired output: &#039;html&#039;, &#039;err&#039; (default to Accept: header value)</dd><dt>force</dt><dd>send HTML output even if fatal errors encountered, otherwise output determined by Accept: header</dd><dt>die-on</dt><dd>select category of error to stop on, options are: nothing, fatal, link-error, warning, everything (default = &#039;fatal&#039;)</dd><dt>time</dt><dd>default specification time (yyyy-mm-dd hh:mm:ss +0000)</dd><dt>md-&lt;key&gt;</dt><dd>override metadata (e.g.: md-status=CR)</dd></dl><p>Parameters may be submitted as query arguments or form fields. HTTP POST must be used.</p><p>Further information can be found in the <a href='https://speced.github.io/bikeshed/#curl'>Bikeshed documentation</a>.</p></div></div><div class='footer'><address>Please send comments, questions, and error reports to <a href='&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#98;&#105;&#107;&#101;&#115;&#104;&#101;&#100;&#64;&#99;&#115;&#115;&#119;&#103;&#46;&#111;&#114;&#103;?subject=CSS Spec Preprocessor'>the server administrator &#60;&#98;&#105;&#107;&#101;&#115;&#104;&#101;&#100;&#64;&#99;&#115;&#115;&#119;&#103;&#46;&#111;&#114;&#103;&#62;</a></address></div><script nonce='XdQvsRGDKiohTtl8FIWm6cLNFmER2roRI7BFurZSFKM=' type='text/javascript'><!--
document.getElementById('output-error').onchange=function(event){updateForceControl()};document.getElementById('output-html').onchange=function(event){updateForceControl()};document.getElementById('output-frame').onchange=function(event){updateForceControl()};document.getElementById('force').onchange=function(event){updateForceControl()};
// --></script></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/attribution-reporting-api%231129.)._
</details>
