### PR TITLE
Remove inaccurate mention of modulus on source_event_id field

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -460,7 +460,7 @@ following keys:
 
 ### Data Encoding
 
-The source event id and trigger data should be specified in a way that is
+The trigger data should be specified in a way that is
 amenable to the privacy assurances a browser wants to provide (i.e. the number
 of distinct data states supported).
 


### PR DESCRIPTION
Per the spec, source_event_id is parsed as a 64-bit unsigned integer and never adjusted.