### PR TITLE
Clean up fake report generation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2188,37 +2188,9 @@ a [=trigger state=] |triggerState|:
     :: «[ "`source_type`" → « |source|'s [=attribution source/source type=] » ]»
 1. Let |triggerTime| be the greatest [=moment=] that is strictly less than
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
-1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
-    : [=attribution trigger/attribution destination=]
-    :: |source|'s [=attribution source/source site=]
-    : [=attribution trigger/trigger time=]
-    :: |triggerTime|
-    : [=attribution trigger/reporting origin=]
-    :: |source|'s [=attribution source/reporting origin=]
-    : [=attribution trigger/filters=]
-    :: «[]»
-    : [=attribution trigger/debug key=]
-    :: null
-    : [=attribution trigger/event-level trigger configurations=]
-    :: « |fakeConfig| »
-    : [=attribution trigger/aggregatable trigger data=]
-    :: «»
-    : [=attribution trigger/aggregatable values=]
-    :: «[]»
-    : [=attribution trigger/aggregatable dedup key=]
-    :: «»
-    : [=attribution trigger/debug reporting enabled=]
-    :: false
-    : [=attribution trigger/aggregation coordinator=]
-    :: [=default aggregation coordinator=]
-    : [=attribution trigger/verifications=]
-    :: «»
-    : [=attribution trigger/aggregatable source registration time configuration=]
-    :: "<code>[=aggregatable source registration time configuration/exclude=]</code>"
-    : [=attribution trigger/trigger context ID=]
-    :: null
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
-    |fakeTrigger|, and |fakeConfig|.
+    |triggerTime|, [=obtain an event-level report/triggerDebugKey=] set to null,
+    |fakeConfig|, and |triggerState|'s [=trigger state/trigger data=].
 1. [=Assert=]: |fakeReport|'s [=event-level report/report time=] is equal to
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
@@ -2900,7 +2872,8 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. If the result of running [=should attribution be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
     return it.
-1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|, |trigger|,
+1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|,
+    |trigger|'s [=attribution trigger/trigger time=], |trigger|'s [=attribution trigger/debug key=],
     |matchedConfig|, and |triggerData|.
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
     is false:
@@ -3147,11 +3120,12 @@ To <dfn>obtain an aggregatable report delivery time</dfn> given an [=attribution
 
 <h3 algorithm id="obtaining-an-event-level-report">Obtaining an event-level report</h3>
 
-To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |source|, an [=attribution trigger=]
-|trigger|, an [=event-level trigger configuration=] |config|, and a non-negative
-64-bit integer |triggerData|:
+To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |source|,
+a [=moment=] |triggerTime|, an optional non-negative 64-bit integer
+<dfn for="obtain an event-level report"><var>triggerDebugKey</var></dfn>,
+an [=event-level trigger configuration=] |config|, and a non-negative 64-bit integer |triggerData|:
 
-1. Let |reportTime| be the result of running [=obtain an event-level report delivery time=] with |source| and |trigger|'s [=attribution trigger/trigger time=].
+1. Let |reportTime| be the result of running [=obtain an event-level report delivery time=] with |source| and |triggerTime|.
 1. Let |report| be a new [=event-level report=] struct whose items are:
 
     : [=event-level report/event ID=]
@@ -3169,7 +3143,7 @@ To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |sour
     : [=event-level report/trigger priority=]
     :: |config|'s [=event-level trigger configuration/priority=].
     : [=event-level report/trigger time=]
-    :: |trigger|'s [=attribution trigger/trigger time=].
+    :: |triggerTime|.
     : [=event-level report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
     : [=event-level report/report id=]
@@ -3177,7 +3151,7 @@ To <dfn>obtain an event-level report</dfn> given an [=attribution source=] |sour
     : [=event-level report/source debug key=]
     :: |source|'s [=attribution source/debug key=].
     : [=event-level report/trigger debug key=]
-    :: |trigger|'s [=attribution trigger/debug key=].
+    :: |triggerDebugKey|.
 1. Return |report|.
 
 <h3 id="obtaining-required-aggregatable-budget">Obtaining an aggregatable report's required budget</h3>

--- a/index.bs
+++ b/index.bs
@@ -2190,7 +2190,7 @@ a [=trigger state=] |triggerState|:
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
     : [=attribution trigger/attribution destinations=]
-    :: |source|'s [=attribution source/souce site=]
+    :: |source|'s [=attribution source/source site=]
     : [=attribution trigger/trigger time=]
     :: |triggerTime|
     : [=attribution trigger/reporting origin=]

--- a/index.bs
+++ b/index.bs
@@ -2190,7 +2190,7 @@ a [=trigger state=] |triggerState|:
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
     : [=attribution trigger/attribution destinations=]
-    :: |source|'s [=attribution source/attribution destinations=]
+    :: |source|'s [=attribution source/souce site=]
     : [=attribution trigger/trigger time=]
     :: |triggerTime|
     : [=attribution trigger/reporting origin=]

--- a/index.bs
+++ b/index.bs
@@ -2189,7 +2189,7 @@ a [=trigger state=] |triggerState|:
 1. Let |triggerTime| be the greatest [=moment=] that is strictly less than
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
-    : [=attribution trigger/attribution destinations=]
+    : [=attribution trigger/attribution destination=]
     :: |source|'s [=attribution source/source site=]
     : [=attribution trigger/trigger time=]
     :: |triggerTime|


### PR DESCRIPTION
Many fields in the trigger is irrelevant of event-level report generation. Removed fakeTrigger and passed the corresponding fields into the algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1135.html" title="Last updated on Jan 4, 2024, 7:07 PM UTC (936a053)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1135/be4d34b...linnan-github:936a053.html" title="Last updated on Jan 4, 2024, 7:07 PM UTC (936a053)">Diff</a>