### PR TITLE
Allow trigger side filtering on aggregation keys

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -188,12 +188,13 @@ to it just like for event-level reports.
 
 Note: The `aggregatable_values` field may also be specified as a list of dict,
 where each dict contains a dict of key-value pair as outlined above as well as
-an optional `filters` (and its corresponding `not_filters`) field, allowing
-trigger registrations to customize how values are contributed to keys depending
-on the context of the source.
+optional `filters` and `not_filters` fields, allowing trigger registrations to
+customize how values are contributed to keys depending on source event data. If
+multiple list entries have filters that match the source's filters, only the
+first entry and its corresponding values will be used.
 ```jsonc
 {
-  ...
+  ...,
   "aggregatable_values": [
     {
       "values": {

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -186,12 +186,15 @@ Note: The `filters` field will still apply to aggregatable reports, and each
 dict in `aggregatable_trigger_data` can still optionally have filters applied
 to it just like for event-level reports.
 
-Note: The `aggregatable_values` field may also be specified as a list of dict,
-where each dict contains a dict of key-value pair as outlined above as well as
-optional `filters` and `not_filters` fields, allowing trigger registrations to
-customize how values are contributed to keys depending on source event data. If
-multiple list entries have filters that match the source's filters, only the
-first entry and its corresponding values will be used.
+Note: The `aggregatable_values` field may also be specified as a list of
+dictionaries, where each dictionary contains a dictionary `values` of key-value
+pairs as outlined above as well as optional `filters` and `not_filters` fields,
+allowing trigger registrations to customize how values are contributed to keys
+depending on source filter data. If multiple list entries have filters that
+match the source's filters, only the first entry and its corresponding values
+will be used.
+
+For example:
 ```jsonc
 {
   ...,

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -172,9 +172,6 @@ The scheme above will generate the following abstract histogram contributions:
   value: 1664
 }]
 ```
-Note: The `filters` field will still apply to aggregatable reports, and each
-dict in `aggregatable_trigger_data` can still optionally have filters applied
-to it just like for event-level reports.
 
 Note: the above scheme was used to maximize the [contribution
 budget](#contribution-bounding-and-budgeting) and optimize utility in the face
@@ -183,6 +180,30 @@ of constant noise. To rescale, simply inverse the scaling factors used above:
 L1 = 1 << 16
 true_agg_campaign_counts = raw_agg_campaign_counts / (L1 / 2)
 true_agg_geo_value = 1024 * raw_agg_geo_value / (L1 / 2)
+```
+
+Note: The `filters` field will still apply to aggregatable reports, and each
+dict in `aggregatable_trigger_data` can still optionally have filters applied
+to it just like for event-level reports.
+
+Note: The `aggregatable_values` field may also be specified as a list of dict,
+where each dict contains a dict of key-value pair as outlined above as well as
+an optional `filters` (and its corresponding `not_filters`) field, allowing
+trigger registrations to customize how values are contributed to keys depending
+on the context of the source.
+```jsonc
+{
+  ...
+  "aggregatable_values": [
+    {
+      "values": {
+        "campaignCounts": 32768,
+        "geoValue": 1664
+      },
+      "filters": {"source_type": ["navigation"]}
+    }
+  ]
+}
 ```
 
 Trigger registration will accept an optional field

--- a/index.bs
+++ b/index.bs
@@ -2715,9 +2715,9 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
     1. If the result of running [=match an attribution source's filter data against filters and negated filters=] with
         |source|, |aggregatableValuesConfiguration|'s [=aggregatable values configuration/filters=],
         |aggregatableValuesConfiguration|'s [=aggregatable values configuration/negated filters=], and
-        |trigger|'s [=attribution trigger/trigger time=] is true: 
+        |trigger|'s [=attribution trigger/trigger time=] is true:
+        1. Let |aggregatableValues| be |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
         1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
-            1. Let |aggregatableValues| be |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
             1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
             1. Let |contribution| be a new [=aggregatable contribution=] with the items:
                 : [=aggregatable contribution/key=]
@@ -2725,7 +2725,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
                 : [=aggregatable contribution/value=]
                 :: |aggregatableValues|[|id|]
             1. [=list/Append=] |contribution| to |contributions|.
-        1. If |contributions| is not [=list/is empty|empty=], [=iteration/break=].
+        1. [=iteration/Break=].
 1. Return |contributions|.
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>

--- a/index.bs
+++ b/index.bs
@@ -1209,7 +1209,7 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s item's 
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=list/item=]'s 
 [=aggregatable values configuration/values=]'s [=map/keys=], and an [=aggregatable trigger data=]'s 
 [=aggregatable trigger data/source keys=]'s [=set/items=]. Its value is 25.
 
@@ -2427,7 +2427,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return a new [=list/is empty|empty=] [=list=].
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=] or a [=list=], return null.
-1. Let |aggregatableValuesConfigurations| be a [=list=] of [=aggregatable values configuration=], initially empty.
+1. Let |aggregatableValuesConfigurations| be a [=list=] of [=aggregatable values configurations=], initially empty.
 1. If |values| is an [=ordered map=]:
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |values|.
     1. If |aggregatableKeyValues| is null, return null.
@@ -2695,8 +2695,8 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
-To <dfn>match [=aggregatable contributions=] to [=attribution source/aggregation keys=]</dfn> given
- an [=ordered map=] |aggregationKeys| and an [=ordered map=] |aggregatableValues|,
+To <dfn>create [=aggregatable contributions=] from [=attribution source/aggregation keys=] and aggregatable values</dfn>
+ given an [=ordered map=] |aggregationKeys| and an [=ordered map=] |aggregatableValues|,
  run the following steps:
 
 1. Let |contributions| be an empty [=list=].
@@ -2730,7 +2730,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
         |source|, |aggregatableValuesConfiguration|'s [=aggregatable values configuration/filters=],
         |aggregatableValuesConfiguration|'s [=aggregatable values configuration/negated filters=], and
         |trigger|'s [=attribution trigger/trigger time=] is true:
-        1. Return the result of running [=match aggregatable contributions to aggregation keys=] with
+        1. Return the result of running [=create aggregatable contributions from aggregation keys and aggregatable values=] with
             |aggregationKeys| and |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
 1. Return a new [=list/is empty|empty=] [=list=].
 

--- a/index.bs
+++ b/index.bs
@@ -2696,7 +2696,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
 To <dfn>create [=aggregatable contributions=] from [=attribution source/aggregation keys=] and aggregatable [=aggregatable values configuration/values=]</dfn>
- given an [=ordered map=] |aggregationKeys| and a [=map=] |aggregatableValues|,
+ given a [=map=] |aggregationKeys| and a [=map=] |aggregatableValues|,
  run the following steps:
 
 1. Let |contributions| be an empty [=list=].

--- a/index.bs
+++ b/index.bs
@@ -797,6 +797,18 @@ An aggregatable trigger data is a [=struct=] with the following items:
 
 </dl>
 
+<h3 dfn-type=dfn>Aggregatable value</h3>
+
+An aggregatable value is a [=struct=] with the following items:
+
+<dl dfn-for="aggregatable value">
+: <dfn>values</dfn>
+:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are non-negative 32-bit integers.
+: <dfn>filters</dfn>
+:: A [=list=] of [=filter configs=].
+: <dfn>negated filters</dfn>
+:: A [=list=] of [=filter configs=].
+
 <h3 dfn-type=dfn>Aggregatable dedup key</h3>
 
 An aggregatable dedup key is a [=struct=] with the following items:
@@ -869,8 +881,7 @@ An attribution trigger is a [=struct=] with the following items:
 : <dfn>aggregatable trigger data</dfn>
 :: A [=list=] of [=aggregatable trigger data=].
 : <dfn>aggregatable values</dfn>
-:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose
-    [=map/value|values=] are non-negative 32-bit integers.
+:: A [=list=] of [=aggregatable value=].
 : <dfn>aggregatable dedup keys</dfn>
 :: A [=list=] of [=aggregatable dedup key=].
 : <dfn>verifications</dfn>
@@ -2399,18 +2410,50 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
     1. [=list/Append=] |aggregatableTrigger| to |aggregatableTriggerData|.
 1. Return |aggregatableTriggerData|.
 
+To <dfn>parse aggregatable key-values</dfn> given an [=ordered map=] |map|:
+
+1. [=map/iterate|For each=] |key| → |value| of |values|:
+    1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
+        return null.
+    1. If |value| is not an integer, return null.
+    1. If |value| is less than or equal to 0, return null.
+    1. If |value| is greater than [=allowed aggregatable budget per source=], return null.
+1. Return |values|.
+
 To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
 1. Let |values| be |map|["`aggregatable_values`"].
-1. If |values| is not an [=ordered map=], return null.
-1. [=map/iterate|For each=] |key| → |value| of |values|:
-     1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
-         return null.
-     1. If |value| is not an integer, return null.
-     1. If |value| is less than or equal to 0, return null.
-     1. If |value| is greater than [=allowed aggregatable budget per source=], return null.
-1. Return |values|.
+1. If |values| is not a [=ordered map=] or a [=list=], return null.
+1. Let |aggregatableValues| be a [=list=] of [=aggregatable value=], initially empty.
+1. If |values| is an [=ordered map=]:
+    1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |values|.
+    1. Let |aggregatableValue| be a new [=aggregatable value=] with the items:
+        : [=aggregatable value/values=]
+        :: |aggregatableKeyValues|
+        : [=aggregatable value/filters=]
+        :: «[]»
+        : [=aggregatable value/negated filters=]
+        :: «[]»
+    1. [=list/Append=] |aggregatableValue| to |aggregatableValues|.
+    1. Return |aggregatableValues|
+1. [=list/iterate|For each=] |value| of |values|:
+    1. If |value| is not an [=ordered map=], return null.
+    1. If |value|["`values`"] does not [=map/exist=], return null.
+    1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |value|["`values`"].
+    1. If |aggregatableKeyValues| is null, return null.
+    1. Let |filterPair| be the result of running [=parse a filter pair=] with
+        |aggregatableKeyValues|.
+    1. If |filterPair| is null, return null.
+    1. Let |aggregatableValue| be a new [=aggregatable value=] with the items:
+        : [=aggregatable value/values=]
+        :: |aggregatableKeyValues|
+        : [=aggregatable value/filters=]
+        :: |filterPair|[0]
+        : [=aggregatable value/negated filters=]
+        :: |filterPair|[1]
+    1. [=list/Append=] |aggregatableValue| to |aggregatableValues|.
+1. Return |aggregatableValues|.
 
 To <dfn>parse aggregatable dedup keys</dfn> given an [=ordered map=] |map|:
 
@@ -2665,14 +2708,21 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
             [=aggregatable trigger data/key piece=].
 1. Let |aggregatableValues| be |trigger|'s [=attribution trigger/aggregatable values=].
 1. Let |contributions| be a new empty [=list=].
-1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
-    1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
-    1. Let |contribution| be a new [=aggregatable contribution=] with the items:
-        : [=aggregatable contribution/key=]
-        :: |key|
-        : [=aggregatable contribution/value=]
-        :: |aggregatableValues|[|id|]
-    1. [=list/Append=] |contribution| to |contributions|.
+1. [=list/iterate|For each=] |aggregatableValue| of |aggregatableValues|:
+    1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
+        1. If |aggregatableValue|'s [=aggregatable value/values=][|id|] does not [=map/exist=] or if
+            the result of running [=match an attribution source's filter data against filters and negated filters=] with
+            |source|, |aggregatableValue|'s [=aggregatable value/filters=],
+            |triggerData|'s [=aggregatable value/negated filters=], and
+            |trigger|'s [=attribution trigger/trigger time=]
+            is false, [=iteration/continue=]:.
+        1. Let |contribution| be a new [=aggregatable contribution=] with the items:
+            : [=aggregatable contribution/key=]
+            :: |key|
+            : [=aggregatable contribution/value=]
+            :: |aggregatableValues|[|id|]
+        1. [=list/Append=] |contribution| to |contributions|.
+    1. If |contributions| is not [=list/is empty|empty=], [=iteration/Break=].
 1. Return |contributions|.
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>

--- a/index.bs
+++ b/index.bs
@@ -1209,7 +1209,7 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=aggregatable values configuration/values=]'s [=map/keys=],
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s item's [=aggregatable values configuration/values=]'s [=map/keys=],
 and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
 Its value is 25.
 

--- a/index.bs
+++ b/index.bs
@@ -2695,6 +2695,21 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
+To <dfn>match [=aggregatable contributions=] to [=attribution source/aggregation keys=]</dfn> given
+ an [=ordered map=] |aggregationKeys| and an [=ordered map=] |aggregatableValues|,
+ run the following steps:
+
+1. Let |contributions| be an empty list.
+1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
+    1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
+    1. Let |contribution| be a new [=aggregatable contribution=] with the items:
+        : [=aggregatable contribution/key=]
+        :: |key|
+        : [=aggregatable contribution/value=]
+        :: |aggregatableValues|[|id|]
+    1. [=list/Append=] |contribution| to |contributions|.
+1. Return |contributions|.
+
 To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution source=] |source| and an
  [=attribution trigger=] |trigger|, run the following steps:
 
@@ -2710,23 +2725,14 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
         1. [=map/Set=] |aggregationKeys|[|sourceKey|] to |aggregationKeys|[|sourceKey|] bitwise-OR |triggerData|'s
             [=aggregatable trigger data/key piece=].
 1. Let |aggregatableValuesConfigurations| be |trigger|'s [=attribution trigger/aggregatable values configurations=].
-1. Let |contributions| be a new empty [=list=].
 1. [=list/iterate|For each=] |aggregatableValuesConfiguration| of |aggregatableValuesConfigurations|:
     1. If the result of running [=match an attribution source's filter data against filters and negated filters=] with
         |source|, |aggregatableValuesConfiguration|'s [=aggregatable values configuration/filters=],
         |aggregatableValuesConfiguration|'s [=aggregatable values configuration/negated filters=], and
         |trigger|'s [=attribution trigger/trigger time=] is true:
-        1. Let |aggregatableValues| be |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
-        1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
-            1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
-            1. Let |contribution| be a new [=aggregatable contribution=] with the items:
-                : [=aggregatable contribution/key=]
-                :: |key|
-                : [=aggregatable contribution/value=]
-                :: |aggregatableValues|[|id|]
-            1. [=list/Append=] |contribution| to |contributions|.
-        1. [=iteration/Break=].
-1. Return |contributions|.
+        1. Return the result of running [=match aggregatable contributions to aggregation keys=] with
+            |aggregationKeys| and |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
+1. Return «[]».
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -1209,9 +1209,9 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s item's [=aggregatable values configuration/values=]'s [=map/keys=],
-and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
-Its value is 25.
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s item's 
+[=aggregatable values configuration/values=]'s [=map/keys=], and an [=aggregatable trigger data=]'s 
+[=aggregatable trigger data/source keys=]'s [=set/items=]. Its value is 25.
 
 <dfn>Default trigger data cardinality</dfn> is a [=map=] that
 controls the valid range of [=event-level trigger configuration/trigger data=].

--- a/index.bs
+++ b/index.bs
@@ -2695,7 +2695,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
-To <dfn>create [=aggregatable contributions=] from [=attribution source/aggregation keys=] and aggregatable values</dfn>
+To <dfn>create [=aggregatable contributions=] from [=attribution source/aggregation keys=] and aggregatable [=aggregatable values configuration/values=]</dfn>
  given an [=ordered map=] |aggregationKeys| and a [=map=] |aggregatableValues|,
  run the following steps:
 

--- a/index.bs
+++ b/index.bs
@@ -2699,7 +2699,7 @@ To <dfn>match [=aggregatable contributions=] to [=attribution source/aggregation
  an [=ordered map=] |aggregationKeys| and an [=ordered map=] |aggregatableValues|,
  run the following steps:
 
-1. Let |contributions| be an empty list.
+1. Let |contributions| be an empty [=list=].
 1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
     1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
     1. Let |contribution| be a new [=aggregatable contribution=] with the items:
@@ -3078,7 +3078,7 @@ To <dfn>check if an [=attribution trigger=] contains aggregatable data</dfn> giv
 run the following steps:
 
 1. If |trigger|'s [=attribution trigger/aggregatable trigger data=] is not [=list/is empty|empty=], return true.
-1. If |trigger|'s [=attribution trigger/aggregatable values configurations=] is not [=map/is empty|empty=], return true.
+1. If |trigger|'s [=attribution trigger/aggregatable values configurations=] is not [=list/is empty|empty=], return true.
 1. Return false.
 
 To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -1209,7 +1209,7 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=map/keys=],
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=aggregatable values configuration/values=]'s [=map/keys=],
 and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
 Its value is 25.
 

--- a/index.bs
+++ b/index.bs
@@ -803,7 +803,7 @@ An aggregatable values configuration is a [=struct=] with the following items:
 
 <dl dfn-for="aggregatable values configuration">
 : <dfn>values</dfn>
-:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are non-negative 32-bit integers.
+:: A [=map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are non-negative 32-bit integers.
 : <dfn>filters</dfn>
 :: A [=list=] of [=filter configs=].
 : <dfn>negated filters</dfn>
@@ -2412,7 +2412,7 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
     1. [=list/Append=] |aggregatableTrigger| to |aggregatableTriggerData|.
 1. Return |aggregatableTriggerData|.
 
-To <dfn>parse aggregatable key-values</dfn> given an [=ordered map=] |map|:
+To <dfn>parse aggregatable key-values</dfn> given a [=map=] |map|:
 
 1. [=map/iterate|For each=] |key| → |value| of |map|:
     1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
@@ -2428,7 +2428,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=] or a [=list=], return null.
 1. Let |aggregatableValuesConfigurations| be a [=list=] of [=aggregatable values configurations=], initially empty.
-1. If |values| is an [=ordered map=]:
+1. If |values| is a [=map=]:
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |values|.
     1. If |aggregatableKeyValues| is null, return null.
     1. Let |aggregatableValuesConfiguration| be a new [=aggregatable values configuration=] with the items:
@@ -2441,7 +2441,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
     1. [=list/Append=] |aggregatableValuesConfiguration| to |aggregatableValuesConfigurations|.
     1. Return |aggregatableValuesConfigurations|.
 1. [=list/iterate|For each=] |value| of |values|:
-    1. If |value| is not an [=ordered map=], return null.
+    1. If |value| is not a [=map=], return null.
     1. If |value|["`values`"] does not [=map/exist=], return null.
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |value|["`values`"].
     1. If |aggregatableKeyValues| is null, return null.
@@ -2696,7 +2696,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 <h3 algorithm id="creating-aggregatable-contributions">Creating aggregatable contributions</h3>
 
 To <dfn>create [=aggregatable contributions=] from [=attribution source/aggregation keys=] and aggregatable values</dfn>
- given an [=ordered map=] |aggregationKeys| and an [=ordered map=] |aggregatableValues|,
+ given an [=ordered map=] |aggregationKeys| and a [=map=] |aggregatableValues|,
  run the following steps:
 
 1. Let |contributions| be an empty [=list=].

--- a/index.bs
+++ b/index.bs
@@ -3078,7 +3078,7 @@ To <dfn>check if an [=attribution trigger=] contains aggregatable data</dfn> giv
 run the following steps:
 
 1. If |trigger|'s [=attribution trigger/aggregatable trigger data=] is not [=list/is empty|empty=], return true.
-1. If |trigger|'s [=attribution trigger/aggregatable values configurations=] is not [=list/is empty|empty=], return true.
+1. If any of |trigger|'s [=attribution trigger/aggregatable values configurations=]'s [=aggregatable values configuration/values=] is not [=list/is empty|empty=], return true.
 1. Return false.
 
 To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -2726,7 +2726,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
             [=aggregatable trigger data/key piece=].
 1. Let |aggregatableValuesConfigurations| be |trigger|'s [=attribution trigger/aggregatable values configurations=].
 1. [=list/iterate|For each=] |aggregatableValuesConfiguration| of |aggregatableValuesConfigurations|:
-    1. If the result of running [=match an attribution source's filter data against filters and negated filters=] with
+    1. If the result of running [=match an attribution source against filters and negated filters=] with
         |source|, |aggregatableValuesConfiguration|'s [=aggregatable values configuration/filters=],
         |aggregatableValuesConfiguration|'s [=aggregatable values configuration/negated filters=], and
         |trigger|'s [=attribution trigger/trigger time=] is true:

--- a/index.bs
+++ b/index.bs
@@ -2725,7 +2725,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
                 : [=aggregatable contribution/value=]
                 :: |aggregatableValues|[|id|]
             1. [=list/Append=] |contribution| to |contributions|.
-        1. If |contributions| is not [=list/is empty|empty=], [=iteration/Break=].
+        1. If |contributions| is not [=list/is empty|empty=], [=iteration/break=].
 1. Return |contributions|.
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>

--- a/index.bs
+++ b/index.bs
@@ -809,6 +809,8 @@ An aggregatable value is a [=struct=] with the following items:
 : <dfn>negated filters</dfn>
 :: A [=list=] of [=filter configs=].
 
+</dl>
+
 <h3 dfn-type=dfn>Aggregatable dedup key</h3>
 
 An aggregatable dedup key is a [=struct=] with the following items:
@@ -2424,7 +2426,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
 1. Let |values| be |map|["`aggregatable_values`"].
-1. If |values| is not a [=ordered map=] or a [=list=], return null.
+1. If |values| is not an [=ordered map=] or a [=list=], return null.
 1. Let |aggregatableValues| be a [=list=] of [=aggregatable value=], initially empty.
 1. If |values| is an [=ordered map=]:
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |values|.
@@ -2713,9 +2715,9 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
         1. If |aggregatableValue|'s [=aggregatable value/values=][|id|] does not [=map/exist=] or if
             the result of running [=match an attribution source's filter data against filters and negated filters=] with
             |source|, |aggregatableValue|'s [=aggregatable value/filters=],
-            |triggerData|'s [=aggregatable value/negated filters=], and
+            |aggregatableValue|'s [=aggregatable value/negated filters=], and
             |trigger|'s [=attribution trigger/trigger time=]
-            is false, [=iteration/continue=]:.
+            is false, [=iteration/continue=].
         1. Let |contribution| be a new [=aggregatable contribution=] with the items:
             : [=aggregatable contribution/key=]
             :: |key|

--- a/index.bs
+++ b/index.bs
@@ -797,11 +797,11 @@ An aggregatable trigger data is a [=struct=] with the following items:
 
 </dl>
 
-<h3 dfn-type=dfn>Aggregatable value</h3>
+<h3 dfn-type=dfn>Aggregatable values configuration</h3>
 
-An aggregatable value is a [=struct=] with the following items:
+An aggregatable values configuration is a [=struct=] with the following items:
 
-<dl dfn-for="aggregatable value">
+<dl dfn-for="aggregatable values configuration">
 : <dfn>values</dfn>
 :: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are non-negative 32-bit integers.
 : <dfn>filters</dfn>
@@ -882,8 +882,8 @@ An attribution trigger is a [=struct=] with the following items:
 :: A [=set=] of [=event-level trigger configuration=].
 : <dfn>aggregatable trigger data</dfn>
 :: A [=list=] of [=aggregatable trigger data=].
-: <dfn>aggregatable values</dfn>
-:: A [=list=] of [=aggregatable value=].
+: <dfn>aggregatable values configurations</dfn>
+:: A [=list=] of [=aggregatable values configuration=].
 : <dfn>aggregatable dedup keys</dfn>
 :: A [=list=] of [=aggregatable dedup key=].
 : <dfn>verifications</dfn>
@@ -1209,7 +1209,7 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values=]'s [=map/keys=],
+[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=map/keys=],
 and an [=aggregatable trigger data=]'s [=aggregatable trigger data/source keys=]'s [=set/items=].
 Its value is 25.
 
@@ -2414,31 +2414,32 @@ To <dfn>parse aggregatable trigger data</dfn> given an [=ordered map=] |map|:
 
 To <dfn>parse aggregatable key-values</dfn> given an [=ordered map=] |map|:
 
-1. [=map/iterate|For each=] |key| → |value| of |values|:
+1. [=map/iterate|For each=] |key| → |value| of |map|:
     1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
         return null.
     1. If |value| is not an integer, return null.
     1. If |value| is less than or equal to 0, return null.
     1. If |value| is greater than [=allowed aggregatable budget per source=], return null.
-1. Return |values|.
+1. Return |map|.
 
 To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 
 1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=] or a [=list=], return null.
-1. Let |aggregatableValues| be a [=list=] of [=aggregatable value=], initially empty.
+1. Let |aggregatableValuesConfigurations| be a [=list=] of [=aggregatable values configuration=], initially empty.
 1. If |values| is an [=ordered map=]:
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |values|.
-    1. Let |aggregatableValue| be a new [=aggregatable value=] with the items:
-        : [=aggregatable value/values=]
+    1. If |aggregatableKeyValues| is null, return null.
+    1. Let |aggregatableValuesConfiguration| be a new [=aggregatable values configuration=] with the items:
+        : [=aggregatable values configuration/values=]
         :: |aggregatableKeyValues|
-        : [=aggregatable value/filters=]
+        : [=aggregatable values configuration/filters=]
         :: «[]»
-        : [=aggregatable value/negated filters=]
+        : [=aggregatable values configuration/negated filters=]
         :: «[]»
-    1. [=list/Append=] |aggregatableValue| to |aggregatableValues|.
-    1. Return |aggregatableValues|
+    1. [=list/Append=] |aggregatableValuesConfiguration| to |aggregatableValuesConfigurations|.
+    1. Return |aggregatableValuesConfigurations|.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not an [=ordered map=], return null.
     1. If |value|["`values`"] does not [=map/exist=], return null.
@@ -2447,15 +2448,15 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
         |aggregatableKeyValues|.
     1. If |filterPair| is null, return null.
-    1. Let |aggregatableValue| be a new [=aggregatable value=] with the items:
-        : [=aggregatable value/values=]
+    1. Let |aggregatableValuesConfiguration| be a new [=aggregatable values configuration=] with the items:
+        : [=aggregatable values configuration/values=]
         :: |aggregatableKeyValues|
-        : [=aggregatable value/filters=]
+        : [=aggregatable values configuration/filters=]
         :: |filterPair|[0]
-        : [=aggregatable value/negated filters=]
+        : [=aggregatable values configuration/negated filters=]
         :: |filterPair|[1]
-    1. [=list/Append=] |aggregatableValue| to |aggregatableValues|.
-1. Return |aggregatableValues|.
+    1. [=list/Append=] |aggregatableValuesConfiguration| to |aggregatableValuesConfigurations|.
+1. Return |aggregatableValuesConfigurations|.
 
 To <dfn>parse aggregatable dedup keys</dfn> given an [=ordered map=] |map|:
 
@@ -2495,8 +2496,8 @@ and a [=moment=] |triggerTime|:
 1. Let |aggregatableTriggerData| be the result of running [=parse aggregatable trigger data=]
     with |value|.
 1. If |aggregatableTriggerData| is null, return null.
-1. Let |aggregatableValues| be the result of running [=parse aggregatable values=] with |value|.
-1. If |aggregatableValues| is null, return null.
+1. Let |aggregatableValuesConfigurations| be the result of running [=parse aggregatable values=] with |value|.
+1. If |aggregatableValuesConfigurations| is null, return null.
 1. Let |aggregatableDedupKeys| be the result of running [=parse aggregatable dedup keys=]
     with |value|.
 1. If |aggregatableDedupKeys| is null, return null.
@@ -2548,8 +2549,8 @@ and a [=moment=] |triggerTime|:
     :: |eventTriggers|
     : [=attribution trigger/aggregatable trigger data=]
     :: |aggregatableTriggerData|
-    : [=attribution trigger/aggregatable values=]
-    :: |aggregatableValues|
+    : [=attribution trigger/aggregatable values configurations=]
+    :: |aggregatableValuesConfigurations|
     : [=attribution trigger/aggregatable dedup keys=]
     :: |aggregatableDedupKeys|
     : [=attribution trigger/verifications=]
@@ -2708,23 +2709,23 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
         1. If |aggregationKeys|[|sourceKey|] does not [=map/exist=], [=iteration/continue=].
         1. [=map/Set=] |aggregationKeys|[|sourceKey|] to |aggregationKeys|[|sourceKey|] bitwise-OR |triggerData|'s
             [=aggregatable trigger data/key piece=].
-1. Let |aggregatableValues| be |trigger|'s [=attribution trigger/aggregatable values=].
+1. Let |aggregatableValuesConfigurations| be |trigger|'s [=attribution trigger/aggregatable values configurations=].
 1. Let |contributions| be a new empty [=list=].
-1. [=list/iterate|For each=] |aggregatableValue| of |aggregatableValues|:
-    1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
-        1. If |aggregatableValue|'s [=aggregatable value/values=][|id|] does not [=map/exist=] or if
-            the result of running [=match an attribution source's filter data against filters and negated filters=] with
-            |source|, |aggregatableValue|'s [=aggregatable value/filters=],
-            |aggregatableValue|'s [=aggregatable value/negated filters=], and
-            |trigger|'s [=attribution trigger/trigger time=]
-            is false, [=iteration/continue=].
-        1. Let |contribution| be a new [=aggregatable contribution=] with the items:
-            : [=aggregatable contribution/key=]
-            :: |key|
-            : [=aggregatable contribution/value=]
-            :: |aggregatableValues|[|id|]
-        1. [=list/Append=] |contribution| to |contributions|.
-    1. If |contributions| is not [=list/is empty|empty=], [=iteration/Break=].
+1. [=list/iterate|For each=] |aggregatableValuesConfiguration| of |aggregatableValuesConfigurations|:
+    1. If the result of running [=match an attribution source's filter data against filters and negated filters=] with
+        |source|, |aggregatableValuesConfiguration|'s [=aggregatable values configuration/filters=],
+        |aggregatableValuesConfiguration|'s [=aggregatable values configuration/negated filters=], and
+        |trigger|'s [=attribution trigger/trigger time=] is true: 
+        1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
+            1. Let |aggregatableValues| be |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
+            1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
+            1. Let |contribution| be a new [=aggregatable contribution=] with the items:
+                : [=aggregatable contribution/key=]
+                :: |key|
+                : [=aggregatable contribution/value=]
+                :: |aggregatableValues|[|id|]
+            1. [=list/Append=] |contribution| to |contributions|.
+        1. If |contributions| is not [=list/is empty|empty=], [=iteration/Break=].
 1. Return |contributions|.
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
@@ -3071,7 +3072,7 @@ To <dfn>check if an [=attribution trigger=] contains aggregatable data</dfn> giv
 run the following steps:
 
 1. If |trigger|'s [=attribution trigger/aggregatable trigger data=] is not [=list/is empty|empty=], return true.
-1. If |trigger|'s [=attribution trigger/aggregatable values=] is not [=map/is empty|empty=], return true.
+1. If |trigger|'s [=attribution trigger/aggregatable values configurations=] is not [=map/is empty|empty=], return true.
 1. Return false.
 
 To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |trigger|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -2424,7 +2424,7 @@ To <dfn>parse aggregatable key-values</dfn> given an [=ordered map=] |map|:
 
 To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
 
-1. If |map|["`aggregatable_values`"] does not [=map/exist=], return «[]».
+1. If |map|["`aggregatable_values`"] does not [=map/exist=], return a new [=list/is empty|empty=] [=list=].
 1. Let |values| be |map|["`aggregatable_values`"].
 1. If |values| is not an [=ordered map=] or a [=list=], return null.
 1. Let |aggregatableValuesConfigurations| be a [=list=] of [=aggregatable values configuration=], initially empty.
@@ -2435,9 +2435,9 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
         : [=aggregatable values configuration/values=]
         :: |aggregatableKeyValues|
         : [=aggregatable values configuration/filters=]
-        :: «[]»
+        :: «»
         : [=aggregatable values configuration/negated filters=]
-        :: «[]»
+        :: «»
     1. [=list/Append=] |aggregatableValuesConfiguration| to |aggregatableValuesConfigurations|.
     1. Return |aggregatableValuesConfigurations|.
 1. [=list/iterate|For each=] |value| of |values|:
@@ -2446,7 +2446,7 @@ To <dfn>parse aggregatable values</dfn> given an [=ordered map=] |map|:
     1. Let |aggregatableKeyValues| be the result of running [=parse aggregatable key-values=] with |value|["`values`"].
     1. If |aggregatableKeyValues| is null, return null.
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
-        |aggregatableKeyValues|.
+        |value|.
     1. If |filterPair| is null, return null.
     1. Let |aggregatableValuesConfiguration| be a new [=aggregatable values configuration=] with the items:
         : [=aggregatable values configuration/values=]
@@ -2732,7 +2732,7 @@ To <dfn>create [=aggregatable contributions=]</dfn> given an [=attribution sourc
         |trigger|'s [=attribution trigger/trigger time=] is true:
         1. Return the result of running [=match aggregatable contributions to aggregation keys=] with
             |aggregationKeys| and |aggregatableValuesConfiguration|'s [=aggregatable values configuration/values=].
-1. Return «[]».
+1. Return a new [=list/is empty|empty=] [=list=].
 
 <h3 id="can-source-create-aggregatable-contributions">Can source create aggregatable contributions</h3>
 

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -81,9 +81,9 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           sourceKeys: new Set(['x']),
         },
       ],
-      aggregatableValues: [
+      aggregatableValuesConfigurations: [
         {
-          aggregatableValue: new Map([['x', 5]]),
+          values: new Map([['x', 5]]),
           positive: [],
           negative: [],
         },
@@ -404,6 +404,12 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_values', 0, 'values'],
         msg: 'required',
+      },
+    ],
+    expectedWarnings: [
+      {
+        msg: 'unknown field',
+        path: ['aggregatable_values', 0, 'a'],
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -86,7 +86,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           aggregatableValue: new Map([['x', 5]]),
           positive: [],
           negative: [],
-        }
+        },
       ],
       debugKey: 5n,
       debugReporting: true,
@@ -402,7 +402,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     }`,
     expectedErrors: [
       {
-        path: ['aggregatable_values',0,'values'],
+        path: ['aggregatable_values', 0, 'values'],
         msg: 'required',
       },
     ],
@@ -418,7 +418,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     }`,
     expectedErrors: [
       {
-        path: ['aggregatable_values',0,'values'],
+        path: ['aggregatable_values', 0, 'values'],
         msg: 'must be an object',
       },
     ],

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -347,7 +347,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_values'],
-        msg: 'must be a list or object',
+        msg: 'must be an object or a list',
       },
     ],
   },
@@ -403,7 +403,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_values',0,'values'],
-        msg: 'aggregatable values in a list must be defined in "values" field.',
+        msg: 'required',
       },
     ],
   },
@@ -424,39 +424,40 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     ],
   },
 
-  {
-    name: 'inconsistent-aggregatable-keys',
-    json: `{
-      "aggregatable_trigger_data": [
-        {
-          "key_piece": "0x1",
-          "source_keys": ["a"]
-        },
-        {
-          "key_piece": "0x2",
-          "source_keys": ["b", "a"]
-        }
-      ],
-      "aggregatable_values": {
-        "b": 1,
-        "c": 2
-      }
-    }`,
-    expectedWarnings: [
-      {
-        path: ['aggregatable_trigger_data', 0, 'source_keys'],
-        msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
-      },
-      {
-        path: ['aggregatable_trigger_data', 1, 'source_keys'],
-        msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
-      },
-      {
-        path: ['aggregatable_values', 'c'],
-        msg: 'absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0',
-      },
-    ],
-  },
+  // TODO(apasel422): Uncomment once respective function is updated.
+  // {
+  //   name: 'inconsistent-aggregatable-keys',
+  //   json: `{
+  //     "aggregatable_trigger_data": [
+  //       {
+  //         "key_piece": "0x1",
+  //         "source_keys": ["a"]
+  //       },
+  //       {
+  //         "key_piece": "0x2",
+  //         "source_keys": ["b", "a"]
+  //       }
+  //     ],
+  //     "aggregatable_values": {
+  //       "b": 1,
+  //       "c": 2
+  //     }
+  //   }`,
+  //   expectedWarnings: [
+  //     {
+  //       path: ['aggregatable_trigger_data', 0, 'source_keys'],
+  //       msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
+  //     },
+  //     {
+  //       path: ['aggregatable_trigger_data', 1, 'source_keys'],
+  //       msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
+  //     },
+  //     {
+  //       path: ['aggregatable_values', 'c'],
+  //       msg: 'absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0',
+  //     },
+  //   ],
+  // },
 
   {
     name: 'debug-reporting-wrong-type',

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -81,7 +81,13 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           sourceKeys: new Set(['x']),
         },
       ],
-      aggregatableValues: new Map([['x', 5]]),
+      aggregatableValues: [
+        {
+          aggregatableValue: new Map([['x', 5]]),
+          positive: [],
+          negative: [],
+        }
+      ],
       debugKey: 5n,
       debugReporting: true,
       eventTriggerData: [
@@ -117,6 +123,27 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         },
       ],
     }),
+  },
+  {
+    name: 'aggregatable-values-list-with-filters',
+    json: `{
+      "aggregatable_values": [
+        {
+          "values": {
+            "a": 1
+          },
+          "filters": [{"g": []}, {"h": []}],
+          "not_filters": [{"g": []}, {"h": []}]
+        },
+        {
+          "values": {
+            "b": 2
+          },
+          "filters": [{"i": []}, {"j": []}],
+          "not_filters": [{"i": []}, {"j": []}]
+        }
+      ]
+    }`,
   },
   {
     name: 'or-filters',
@@ -320,7 +347,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_values'],
-        msg: 'must be an object',
+        msg: 'must be a list or object',
       },
     ],
   },
@@ -361,6 +388,38 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_values', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
         msg: 'key exceeds max length per aggregation key identifier (26 > 25)',
+      },
+    ],
+  },
+  {
+    name: 'aggregatable-values-list-values-field-missing',
+    json: `{
+      "aggregatable_values": [
+        {
+          "a": 1
+        }
+      ]
+    }`,
+    expectedErrors: [
+      {
+        path: ['aggregatable_values',0,'values'],
+        msg: 'aggregatable values in a list must be defined in "values" field.',
+      },
+    ],
+  },
+  {
+    name: 'aggregatable-values-list-wrong-type',
+    json: `{
+      "aggregatable_values": [
+        {
+          "values": []
+        }
+      ]
+    }`,
+    expectedErrors: [
+      {
+        path: ['aggregatable_values',0,'values'],
+        msg: 'must be an object',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -431,39 +431,41 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   },
 
   // TODO(apasel422): Uncomment once respective function is updated.
-  // {
-  //   name: 'inconsistent-aggregatable-keys',
-  //   json: `{
-  //     "aggregatable_trigger_data": [
-  //       {
-  //         "key_piece": "0x1",
-  //         "source_keys": ["a"]
-  //       },
-  //       {
-  //         "key_piece": "0x2",
-  //         "source_keys": ["b", "a"]
-  //       }
-  //     ],
-  //     "aggregatable_values": {
-  //       "b": 1,
-  //       "c": 2
-  //     }
-  //   }`,
-  //   expectedWarnings: [
-  //     {
-  //       path: ['aggregatable_trigger_data', 0, 'source_keys'],
-  //       msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
-  //     },
-  //     {
-  //       path: ['aggregatable_trigger_data', 1, 'source_keys'],
-  //       msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
-  //     },
-  //     {
-  //       path: ['aggregatable_values', 'c'],
-  //       msg: 'absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0',
-  //     },
-  //   ],
-  // },
+  /*
+  {
+    name: 'inconsistent-aggregatable-keys',
+    json: `{
+      "aggregatable_trigger_data": [
+        {
+          "key_piece": "0x1",
+          "source_keys": ["a"]
+        },
+        {
+          "key_piece": "0x2",
+          "source_keys": ["b", "a"]
+        }
+      ],
+      "aggregatable_values": {
+        "b": 1,
+        "c": 2
+      }
+    }`,
+    expectedWarnings: [
+      {
+        path: ['aggregatable_trigger_data', 0, 'source_keys'],
+        msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
+      },
+      {
+        path: ['aggregatable_trigger_data', 1, 'source_keys'],
+        msg: 'key "a" will never result in a contribution due to absence from aggregatable_values',
+      },
+      {
+        path: ['aggregatable_values', 'c'],
+        msg: 'absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0',
+      },
+    ],
+  },
+  */
 
   {
     name: 'debug-reporting-wrong-type',

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -61,8 +61,6 @@ function struct<T extends object, C extends Context = Context>(
 
     if (warnUnknown) {
       for (const key in d) {
-        console.log("timestamp: " + Date.now() +" - unknown")
-        console.log(d)
         ctx.scope(key, () => ctx.warning('unknown field'))
       }
     }
@@ -82,7 +80,6 @@ function field<T, C extends Context = Context>(
     ctx.scope(name, () => {
       const v = d[name]
       if (v === undefined) {
-        console.log(name + " not found");
         if (valueIfAbsent === undefined) {
           ctx.error('required')
           return None
@@ -1217,14 +1214,13 @@ function aggregatableKeyValue(
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<AggregatableValue[]> {
   return typeSwitch(ctx, j, {
-    object: (ctx, j) => {console.log(j); return struct(ctx, j, {
+    object: (ctx, j) => struct(ctx, j, {
       aggregatableValue: (ctx, j) => keyValues(ctx, j, aggregatableKeyValue),
-      ...filterFields}).map((v) => [v])},
-      list: (ctx, j) => array(ctx, j, (ctx, j) => struct(ctx, j, {
-        aggregatableValue: field('values', (ctx, j) =>  keyValues(ctx, j, aggregatableKeyValue)),
-        ...filterFields}))
-      }
-    )
+      ...filterFields}, /*warnUnknown=*/false).map((v) => [v]),
+    list: (ctx, j) => array(ctx, j, (ctx, j) => struct(ctx, j, {
+      aggregatableValue: field('values', (ctx, j) =>  keyValues(ctx, j, aggregatableKeyValue)),
+      ...filterFields}, /*warnUnknown=*/false))
+    })
 }
 
 export type EventTriggerDatum = FilterPair &
@@ -1291,6 +1287,7 @@ function aggregatableSourceRegistrationTime(
   return enumerated(ctx, j, AggregatableSourceRegistrationTime)
 }
 
+// TODO(apasel422): Update with new AggregatableValue structure.
 // function warnInconsistentAggregatableKeys(ctx: Context, t: Trigger): void {
 //   const triggerDataKeys = new Set<string>()
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1231,7 +1231,7 @@ function aggregatableValuesConfigurations(
     list: (ctx, j) =>
       array(ctx, j, (ctx, j) =>
         struct(ctx, j, {
-          values: field('values', (ctx, j) => aggregatableKeyValues(ctx, j)),
+          values: field('values', aggregatableKeyValues),
           ...filterFields,
         })
       ),

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1209,6 +1209,9 @@ function aggregatableKeyValue(
 }
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {
+  return typeSwitch(ctx, j, {
+    object: (ctx, j) => keyValues(ctx, j, aggregatableKeyValue)
+    list: (ctx, j) => set(ctx, j, suitableSite, { minLength: 1, maxLength: 3 }),
   return keyValues(ctx, j, aggregatableKeyValue)
 }
 
@@ -1350,7 +1353,7 @@ export type Trigger = CommonDebug &
     aggregatableDedupKeys: AggregatableDedupKey[]
     aggregatableTriggerData: AggregatableTriggerDatum[]
     aggregatableSourceRegistrationTime: AggregatableSourceRegistrationTime
-    aggregatableValues: Map<string, number>
+    aggregatableValues: Map<string, number> | Map<string, number>[]
     aggregationCoordinatorOrigin: string | null
     eventTriggerData: EventTriggerDatum[]
     triggerContextID: string | null

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1209,9 +1209,6 @@ function aggregatableKeyValue(
 }
 
 function aggregatableValues(ctx: Context, j: Json): Maybe<Map<string, number>> {
-  return typeSwitch(ctx, j, {
-    object: (ctx, j) => keyValues(ctx, j, aggregatableKeyValue)
-    list: (ctx, j) => set(ctx, j, suitableSite, { minLength: 1, maxLength: 3 }),
   return keyValues(ctx, j, aggregatableKeyValue)
 }
 
@@ -1353,7 +1350,7 @@ export type Trigger = CommonDebug &
     aggregatableDedupKeys: AggregatableDedupKey[]
     aggregatableTriggerData: AggregatableTriggerDatum[]
     aggregatableSourceRegistrationTime: AggregatableSourceRegistrationTime
-    aggregatableValues: Map<string, number> | Map<string, number>[]
+    aggregatableValues: Map<string, number>
     aggregationCoordinatorOrigin: string | null
     eventTriggerData: EventTriggerDatum[]
     triggerContextID: string | null


### PR DESCRIPTION
This allows for a list of dictionaries to be taken in for the `aggregatable_values` field in trigger registrations, where each dictionary contains a dictionary of aggregatable values as well as a pair of filters, allowing for filtering aggregation keys on the trigger side. This change is backwards compatible and maintains original behavior as well.

Resolves #649.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1149.html" title="Last updated on Feb 12, 2024, 4:34 PM UTC (f1ff596)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1149/5ec6061...f1ff596.html" title="Last updated on Feb 12, 2024, 4:34 PM UTC (f1ff596)">Diff</a>