### PR TITLE
Show information gain in header validator output

### DIFF
--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -117,16 +117,18 @@ config.peek((config) => {
 
   console.log(`Number of possible different output states: ${out.numStates}`)
   console.log(`Information gain: ${out.infoGain.toFixed(2)} bits`)
-  console.log(`Flip percent: ${(100 * out.flipProb).toFixed(5)}%`)
+  console.log(`Randomized trigger rate: ${out.flipProb.toFixed(7)}`)
 
   if (out.excessive) {
     const e = out.excessive
     console.log(
       `WARNING: info gain > ${infoGainMax.toFixed(2)} for ${
         options.source_type
-      } sources. Would require a ${(100 * e.newFlipProb).toFixed(
-        5
-      )}% flip chance (effective epsilon = ${e.newEps.toFixed(3)}) to resolve.`
+      } sources. Would require a ${e.newFlipProb.toFixed(
+        7
+      )} randomized trigger rate (effective epsilon = ${e.newEps.toFixed(
+        3
+      )}) to resolve.`
     )
   }
 })

--- a/ts/src/header-validator/context.ts
+++ b/ts/src/header-validator/context.ts
@@ -8,11 +8,16 @@ export type Issue = {
 export type ValidationResult = {
   errors: Issue[]
   warnings: Issue[]
+  notes: Issue[]
 }
 
 export class Context {
   private readonly path: PathComponent[] = []
-  private readonly result: ValidationResult = { errors: [], warnings: [] }
+  private readonly result: ValidationResult = {
+    errors: [],
+    warnings: [],
+    notes: [],
+  }
 
   scope<T>(c: PathComponent, f: () => T): T {
     this.path.push(c)
@@ -31,6 +36,10 @@ export class Context {
 
   warning(msg: string): void {
     this.result.warnings.push(this.issue(msg))
+  }
+
+  note(msg: string): void {
+    this.result.notes.push(this.issue(msg))
   }
 
   finish(topLevelError?: string): ValidationResult {

--- a/ts/src/header-validator/index.html
+++ b/ts/src/header-validator/index.html
@@ -85,6 +85,8 @@ textarea {
         <ul id=errors></ul>
         <p>Warnings:
         <ul id=warnings></ul>
+        <p>Notes:
+        <ul id=notes></ul>
       </output>
     </fieldset>
   </div>

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -71,7 +71,7 @@ function validate(): void {
         vsv.Chromium,
         sourceType(),
         flexCheckbox.checked,
-        /*noteInfoGain=*/true,
+        /*noteInfoGain=*/ true
       )[0]
       break
     case 'trigger':

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -13,7 +13,7 @@ const sourceTypeRadios = form.elements.namedItem(
 )! as RadioNodeList
 const errorList = document.querySelector('#errors')!
 const warningList = document.querySelector('#warnings')!
-const noteList = document.querySelector('#note')!
+const noteList = document.querySelector('#notes')!
 const successDiv = document.querySelector('#success')!
 const sourceTypeFieldset = document.querySelector(
   '#source-type'

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -13,6 +13,7 @@ const sourceTypeRadios = form.elements.namedItem(
 )! as RadioNodeList
 const errorList = document.querySelector('#errors')!
 const warningList = document.querySelector('#warnings')!
+const noteList = document.querySelector('#note')!
 const successDiv = document.querySelector('#success')!
 const sourceTypeFieldset = document.querySelector(
   '#source-type'
@@ -69,7 +70,8 @@ function validate(): void {
         input.value,
         vsv.Chromium,
         sourceType(),
-        flexCheckbox.checked
+        flexCheckbox.checked,
+        /*noteInfoGain=*/true,
       )[0]
       break
     case 'trigger':
@@ -103,6 +105,7 @@ function validate(): void {
 
   errorList.replaceChildren(...result.errors.map(makeLi))
   warningList.replaceChildren(...result.warnings.map(makeLi))
+  noteList.replaceChildren(...result.notes.map(makeLi))
 }
 
 form.addEventListener('input', validate)

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -11,6 +11,7 @@ import * as jsontest from './validate-json.test'
 
 type TestCase = jsontest.TestCase<Source> & {
   sourceType?: SourceType
+  noteInfoGain?: boolean
 }
 
 const testCases: TestCase[] = [
@@ -1220,7 +1221,7 @@ const testCases: TestCase[] = [
   },
 
   {
-    name: 'channel-capacity-default-event',
+    name: 'channel-capacity-default-event-custom-max',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.event,
     vsv: {
@@ -1233,12 +1234,12 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'exceeds max event-level channel capacity per event source (1.58 > 0.00)',
+        msg: 'exceeds max event-level channel capacity per event source (1.585 > 0.000)',
       },
     ],
   },
   {
-    name: 'channel-capacity-default-navigation',
+    name: 'channel-capacity-default-navigation-custom-max',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.navigation,
     vsv: {
@@ -1251,7 +1252,53 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'exceeds max event-level channel capacity per navigation source (11.46 > 0.00)',
+        msg: 'exceeds max event-level channel capacity per navigation source (11.462 > 0.000)',
+      },
+    ],
+  },
+  {
+    name: 'channel-capacity-default-event-notes',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.event,
+    noteInfoGain: true,
+    vsv: {
+      maxSettableEventLevelEpsilon: 14,
+    },
+    expectedNotes: [
+      {
+        path: [],
+        msg: 'number of possible output states: 3',
+      },
+      {
+        path: [],
+        msg: 'information gain: 1.585',
+      },
+      {
+        path: [],
+        msg: 'randomized response rate: 0.00025%',
+      },
+    ],
+  },
+  {
+    name: 'channel-capacity-default-navigation-notes',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.navigation,
+    noteInfoGain: true,
+    vsv: {
+      maxSettableEventLevelEpsilon: 14,
+    },
+    expectedNotes: [
+      {
+        path: [],
+        msg: 'number of possible output states: 2925',
+      },
+      {
+        path: [],
+        msg: 'information gain: 11.462',
+      },
+      {
+        path: [],
+        msg: 'randomized response rate: 0.24263%',
       },
     ],
   },
@@ -1833,7 +1880,8 @@ testCases.forEach((tc) =>
       tc.json,
       { ...vsv.Chromium, ...tc.vsv },
       tc.sourceType ?? SourceType.navigation,
-      tc.parseFullFlex ?? false
+      tc.parseFullFlex ?? false,
+      tc.noteInfoGain ?? false
     )
   )
 )

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1235,7 +1235,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'information gain: 1.585 exceeds max event-level channel capacity per event source (0.000)',
+        msg: 'information gain: 1.58 exceeds max event-level channel capacity per event source (0.00)',
       },
     ],
     expectedNotes: [
@@ -1245,7 +1245,7 @@ const testCases: TestCase[] = [
       },
       {
         path: [],
-        msg: 'randomized response rate: 0.00025%',
+        msg: 'randomized response rate: 0.0000025',
       },
     ],
   },
@@ -1264,7 +1264,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'information gain: 11.462 exceeds max event-level channel capacity per navigation source (0.000)',
+        msg: 'information gain: 11.46 exceeds max event-level channel capacity per navigation source (0.00)',
       },
     ],
     expectedNotes: [
@@ -1274,7 +1274,7 @@ const testCases: TestCase[] = [
       },
       {
         path: [],
-        msg: 'randomized response rate: 0.24263%',
+        msg: 'randomized response rate: 0.0024263',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1245,7 +1245,7 @@ const testCases: TestCase[] = [
       },
       {
         path: [],
-        msg: 'randomized response rate: 0.0000025',
+        msg: 'randomized trigger rate: 0.0000025',
       },
     ],
   },
@@ -1274,7 +1274,7 @@ const testCases: TestCase[] = [
       },
       {
         path: [],
-        msg: 'randomized response rate: 0.0024263',
+        msg: 'randomized trigger rate: 0.0024263',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1221,9 +1221,10 @@ const testCases: TestCase[] = [
   },
 
   {
-    name: 'channel-capacity-default-event-custom-max',
+    name: 'channel-capacity-default-event',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.event,
+    noteInfoGain: true,
     vsv: {
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: 0,
@@ -1234,14 +1235,25 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'exceeds max event-level channel capacity per event source (1.585 > 0.000)',
+        msg: 'information gain: 1.585 exceeds max event-level channel capacity per event source (0.000)',
+      },
+    ],
+    expectedNotes: [
+      {
+        path: [],
+        msg: 'number of possible output states: 3',
+      },
+      {
+        path: [],
+        msg: 'randomized response rate: 0.00025%',
       },
     ],
   },
   {
-    name: 'channel-capacity-default-navigation-custom-max',
+    name: 'channel-capacity-default-navigation',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.navigation,
+    noteInfoGain: true,
     vsv: {
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: Infinity,
@@ -1252,49 +1264,13 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'exceeds max event-level channel capacity per navigation source (11.462 > 0.000)',
+        msg: 'information gain: 11.462 exceeds max event-level channel capacity per navigation source (0.000)',
       },
     ],
-  },
-  {
-    name: 'channel-capacity-default-event-notes',
-    json: `{"destination": "https://a.test"}`,
-    sourceType: SourceType.event,
-    noteInfoGain: true,
-    vsv: {
-      maxSettableEventLevelEpsilon: 14,
-    },
-    expectedNotes: [
-      {
-        path: [],
-        msg: 'number of possible output states: 3',
-      },
-      {
-        path: [],
-        msg: 'information gain: 1.585',
-      },
-      {
-        path: [],
-        msg: 'randomized response rate: 0.00025%',
-      },
-    ],
-  },
-  {
-    name: 'channel-capacity-default-navigation-notes',
-    json: `{"destination": "https://a.test"}`,
-    sourceType: SourceType.navigation,
-    noteInfoGain: true,
-    vsv: {
-      maxSettableEventLevelEpsilon: 14,
-    },
     expectedNotes: [
       {
         path: [],
         msg: 'number of possible output states: 2925',
-      },
-      {
-        path: [],
-        msg: 'information gain: 11.462',
       },
       {
         path: [],

--- a/ts/src/header-validator/util.test.ts
+++ b/ts/src/header-validator/util.test.ts
@@ -5,6 +5,7 @@ import * as context from './context'
 export type TestCase = {
   expectedWarnings?: context.Issue[]
   expectedErrors?: context.Issue[]
+  expectedNotes?: context.Issue[]
 }
 
 export function run(
@@ -17,6 +18,7 @@ export function run(
     assert.deepEqual(result, {
       errors: tc.expectedErrors ?? [],
       warnings: tc.expectedWarnings ?? [],
+      notes: tc.expectedNotes ?? [],
     })
   })
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -839,13 +839,13 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
   )
 
   const max = ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
-  const infoGainMsg = `information gain: ${out.infoGain.toFixed(3)}`
+  const infoGainMsg = `information gain: ${out.infoGain.toFixed(2)}`
 
   if (out.infoGain > max) {
     ctx.error(
       `${infoGainMsg} exceeds max event-level channel capacity per ${
         ctx.sourceType
-      } source (${max.toFixed(3)})`
+      } source (${max.toFixed(2)})`
     )
   } else if (ctx.noteInfoGain) {
     ctx.note(infoGainMsg)
@@ -853,7 +853,7 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
 
   if (ctx.noteInfoGain) {
     ctx.note(`number of possible output states: ${out.numStates}`)
-    ctx.note(`randomized response rate: ${(100 * out.flipProb).toFixed(5)}%`)
+    ctx.note(`randomized response rate: ${out.flipProb.toFixed(7)}`)
   }
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -853,7 +853,7 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
 
   if (ctx.noteInfoGain) {
     ctx.note(`number of possible output states: ${out.numStates}`)
-    ctx.note(`randomized response rate: ${out.flipProb.toFixed(7)}`)
+    ctx.note(`randomized trigger rate: ${out.flipProb.toFixed(7)}`)
   }
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -839,15 +839,20 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
   )
 
   const max = ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
+  const infoGainMsg = `information gain: ${out.infoGain.toFixed(3)}`
+
   if (out.infoGain > max) {
     ctx.error(
-      `exceeds max event-level channel capacity per ${
+      `${infoGainMsg} exceeds max event-level channel capacity per ${
         ctx.sourceType
-      } source (${out.infoGain.toFixed(3)} > ${max.toFixed(3)})`
+      } source (${max.toFixed(3)})`
     )
   } else if (ctx.noteInfoGain) {
+    ctx.note(infoGainMsg)
+  }
+
+  if (ctx.noteInfoGain) {
     ctx.note(`number of possible output states: ${out.numStates}`)
-    ctx.note(`information gain: ${out.infoGain.toFixed(3)}`)
     ctx.note(`randomized response rate: ${(100 * out.flipProb).toFixed(5)}%`)
   }
 }


### PR DESCRIPTION
We also change the command-line output to resemble that of the event-level reports by using `randomized trigger rate` instead of `flip probability` and decimals instead of percentages.