### PR TITLE
Move time-based destination limit check later

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2299,13 +2299,6 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
 
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
-1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
-1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
-    1. Return.
-1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>" and |source|.
-    1. Return.
 1. Let |cache| be the user agent's [=attribution source cache=].
 1. [=list/Remove=] all [=attribution sources=] |entry| in |cache| where |entry|'s [=attribution source/expiry time=] is less than |source|'s [=attribution source/source time=].
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
@@ -2319,6 +2312,13 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. If the result of running [=check if an attribution source exceeds the unexpired destination limit=]
     with |source| is true:
     1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
+    1. Return.
+1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
+1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
+    1. Return.
+1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>" and |source|.
     1. Return.
 1. [=set/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
     1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:


### PR DESCRIPTION
We only report the first encountered error in the attribution registration.

To better mitigate security concerns on the global destination limit, moving the check later so that whether the limit is actually hit cannot be inferred from the presence of other explicitly reported errors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1170.html" title="Last updated on Feb 21, 2024, 7:39 PM UTC (1e93546)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1170/7481d1e...linnan-github:1e93546.html" title="Last updated on Feb 21, 2024, 7:39 PM UTC (1e93546)">Diff</a>