### PR TITLE
Specify randomized_trigger_rate rounding in report bodies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3574,7 +3574,7 @@ To <dfn>obtain an event-level report body</dfn> given an [=attribution report=] 
     : "`attribution_destination`"
     :: |report|'s [=event-level report/attribution destinations=], [=serialize attribution destinations|serialized=].
     : "`randomized_trigger_rate`"
-    :: |report|'s [=event-level report/randomized trigger rate=]
+    :: |report|'s [=event-level report/randomized trigger rate=], rounded to 7 digits after the decimal point
     : "`source_type`"
     :: |report|'s [=event-level report/source type=]
     : "`source_event_id`"


### PR DESCRIPTION
This matches what the Chromium implementation is already doing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1171.html" title="Last updated on Feb 22, 2024, 3:32 PM UTC (bfe19ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1171/7481d1e...apasel422:bfe19ff.html" title="Last updated on Feb 22, 2024, 3:32 PM UTC (bfe19ff)">Diff</a>