### PR TITLE
OS registration header validator - replace invalid urls errors with warnings

### DIFF
--- a/ts/src/header-validator/validate-os.test.ts
+++ b/ts/src/header-validator/validate-os.test.ts
@@ -36,19 +36,19 @@ const tests: TestCase[] = [
   // Not a string
   {
     input: '"https://a.test", x',
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [1],
-        msg: 'must be a string',
+        msg: 'ignored, must be a string',
       },
     ],
   },
   {
     input: '("https://a.test/")',
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [0],
-        msg: 'must be a string',
+        msg: 'ignored, must be a string',
       },
     ],
   },
@@ -56,10 +56,10 @@ const tests: TestCase[] = [
   // Invalid URL
   {
     input: '"a.test"',
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [0],
-        msg: 'must contain a valid URL',
+        msg: 'ignored, must contain a valid URL',
       },
     ],
   },
@@ -67,10 +67,10 @@ const tests: TestCase[] = [
   // Untrustworthy URL
   {
     input: '"http://a.test"',
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [0],
-        msg: 'must contain a potentially trustworthy URL',
+        msg: 'ignored, must contain a potentially trustworthy URL',
       },
     ],
   },
@@ -78,10 +78,10 @@ const tests: TestCase[] = [
   // debug-reporting not a boolean
   {
     input: '"https://b.test/", "https://a.test/"; debug-reporting=1',
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [1, 'debug-reporting'],
-        msg: 'must be a boolean',
+        msg: 'ignored, must be a boolean',
       },
     ],
   },

--- a/ts/src/header-validator/validate-os.ts
+++ b/ts/src/header-validator/validate-os.ts
@@ -3,7 +3,7 @@ import { InnerList, Item, parseList } from 'structured-headers'
 
 function validateURL(ctx: Context, member: InnerList | Item): void {
   if (typeof member[0] !== 'string') {
-    ctx.error('must be a string')
+    ctx.warning('ignored, must be a string')
     return
   }
 
@@ -11,7 +11,7 @@ function validateURL(ctx: Context, member: InnerList | Item): void {
   try {
     url = new URL(member[0])
   } catch {
-    ctx.error('must contain a valid URL')
+    ctx.warning('ignored, must contain a valid URL')
     return
   }
 
@@ -22,7 +22,7 @@ function validateURL(ctx: Context, member: InnerList | Item): void {
       (url.hostname === 'localhost' || url.hostname === '127.0.0.1')
     )
   ) {
-    ctx.error('must contain a potentially trustworthy URL')
+    ctx.warning('ignored, must contain a potentially trustworthy URL')
     return
   }
 
@@ -30,7 +30,7 @@ function validateURL(ctx: Context, member: InnerList | Item): void {
     ctx.scope(key, () => {
       if (key === 'debug-reporting') {
         if (typeof value !== 'boolean') {
-          ctx.error('must be a boolean')
+          ctx.warning('ignored, must be a boolean')
         }
       } else {
         ctx.warning('unknown parameter')


### PR DESCRIPTION
[The spec](https://wicg.github.io/attribution-reporting-api/#get-os-registrations-from-a-header-value) and [the implementation](https://source.chromium.org/chromium/chromium/src/+/main:components/attribution_reporting/os_registration.cc;l=47?q=os_registration.cc&ss=chromium%2Fchromium%2Fsrc) are ignoring invalid urls but still consider the header to be valid. 

This PR updates the header validator to issue warnings instead of errors when encountering invalid urls.
