### PR TITLE
Specify parsing of Full Flex event_trigger_data value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -873,6 +873,8 @@ An event-level trigger configuration is a [=struct=] with the following items:
 :: A [=list=] of [=filter configs=].
 : <dfn>negated filters</dfn>
 :: A [=list=] of [=filter configs=].
+: <dfn>value</dfn>
+:: A positive unsigned 32-bit integer.
 
 </dl>
 
@@ -2539,6 +2541,15 @@ privacy budget of all possible destinations.
 
 <h3 algorithm id="attribution-trigger-creation">Creating an attribution trigger</h3>
 
+To <dfn>parse an event-trigger value</dfn> given a [=map=] |map|:
+
+1. If [=experimental Flexible Event support=] is false or |map|["`value`"] does
+    not [=map/exists|exist=], return 1.
+1. Let |value| be |map|["`value`"].
+1. If |value| is not an integer, cannot be represented by an unsigned 32-bit
+    integer, or is less than or equal to zero, return an error.
+1. Return |value|.
+
 To <dfn>parse event triggers</dfn> given an [=ordered map=] |map|:
 
 1. Let |eventTriggers| be a new [=set=].
@@ -2563,6 +2574,9 @@ To <dfn>parse event triggers</dfn> given an [=ordered map=] |map|:
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
         |value|.
     1. If |filterPair| is null, return null.
+    1. Let |triggerValue| be the result of running
+        [=parse an event-trigger value=] with |value|.
+    1. If |triggerValue| is an error, return null.
     1. Let |eventTrigger| be a new [=event-level trigger configuration=] with
         the items:
         : [=event-level trigger configuration/trigger data=]
@@ -2575,6 +2589,8 @@ To <dfn>parse event triggers</dfn> given an [=ordered map=] |map|:
         :: |filterPair|[0]
         : [=event-level trigger configuration/negated filters=]
         :: |filterPair|[1]
+        : [=event-level trigger configuration/value=]
+        :: |triggerValue|
     1. [=set/Append=] |eventTrigger| to |eventTriggers|.
 1. Return |eventTriggers|.
 

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1110,7 +1110,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'value'],
-        msg: 'must be positive',
+        msg: 'must be >= 1 and <= uint32 max (4294967295)',
       },
     ],
   },
@@ -1121,7 +1121,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'value'],
-        msg: 'must be positive',
+        msg: 'must be >= 1 and <= uint32 max (4294967295)',
       },
     ],
   },
@@ -1133,6 +1133,22 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['event_trigger_data', 0, 'value'],
         msg: 'must be an integer',
+      },
+    ],
+  },
+  {
+    name: 'value-max',
+    json: `{"event_trigger_data": [{"value":4294967295}]}`,
+    parseFullFlex: true,
+  },
+  {
+    name: 'value-gt-max',
+    json: `{"event_trigger_data": [{"value":4294967296}]}`,
+    parseFullFlex: true,
+    expectedErrors: [
+      {
+        path: ['event_trigger_data', 0, 'value'],
+        msg: 'must be >= 1 and <= uint32 max (4294967295)',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1295,6 +1295,20 @@ export type EventTriggerDatum = FilterPair &
     value: number
   }
 
+function eventTriggerValue(ctx: RegistrationContext, j: Json): Maybe<number> {
+  return number(ctx, j)
+    .filter((n) => isInteger(ctx, n))
+    .filter((n) =>
+      isInRange(
+        ctx,
+        n,
+        1,
+        UINT32_MAX,
+        `must be >= 1 and <= uint32 max (${UINT32_MAX})`
+      )
+    )
+}
+
 function eventTriggerData(
   ctx: RegistrationContext,
   j: Json
@@ -1304,7 +1318,7 @@ function eventTriggerData(
       triggerData: field('trigger_data', triggerData, 0n),
 
       value: ctx.parseFullFlex
-        ? field('value', positiveInteger, 1)
+        ? field('value', eventTriggerValue, 1)
         : () => some(1),
 
       ...filterFields,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1192.html" title="Last updated on Mar 13, 2024, 1:07 PM UTC (2efb71d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1192/de3175e...apasel422:2efb71d.html" title="Last updated on Mar 13, 2024, 1:07 PM UTC (2efb71d)">Diff</a>