### PR TITLE
Support attribution scope fields in source and trigger.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -806,6 +806,12 @@ An attribution source is a [=struct=] with the following items:
 :: A [=trigger-data matching mode=].
 : <dfn>debug cookie set</dfn> (default false)
 :: A [=boolean=].
+: <dfn>attribution scope limit</dfn>
+:: Null or a non-negative 32-bit integer, number of distinct [=attribution source/attribution scopes=] allowed per [=attribution source/reporting origin=].
+: <dfn>attribution scopes</dfn>
+:: Null or a list of non-negative 32-bit integers.
+: <dfn>max number of view states</dfn>
+:: Null or a non-negative 32-bit integer, maximum number view states that an API caller plans to use.
 
 </dl>
 
@@ -931,6 +937,8 @@ An attribution trigger is a [=struct=] with the following items:
 :: An [=aggregatable source registration time configuration=].
 : <dfn>trigger context ID</dfn>
 :: Null or a [=string=].
+: <dfn>attribution scope</dfn>
+:: Null or a non-negative 32-bit integer.
 
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -3285,6 +3285,7 @@ To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
 1. Let |matchingSources| be a new [=list/is empty|empty=] [=list=].
 1. [=set/iterate|For each=] |source| of the [=attribution source cache=]:
     1. If |source|'s [=attribution source/attribution destinations=] does not [=set/contains|contain=] |trigger|'s [=attribution trigger/attribution destination=], [=iteration/continue=].
+    1. If |source|'s [=attribution source/attribution scopes=] does not [=set/contains|contain=] |trigger|'s [=attribution trigger/attribution scope=], [=iteration/continue=].
     1. If |source|'s [=attribution source/reporting origin=] and |trigger|'s [=attribution trigger/reporting origin=] are not [=same origin=], [=iteration/continue=].
     1. If |source|'s [=attribution source/expiry time=] is less than or equal to |trigger|'s [=attribution trigger/trigger time=], [=iteration/continue=].
     1. [=list/Append=] |source| to |matchingSources|.


### PR DESCRIPTION
- Source fields:
         -- attribution scope limit
         -- attribution scopes
         -- max num view states
- Trigger field: attribution scope


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/feifeiji89/attribution-reporting-api/pull/1197.html" title="Last updated on Mar 18, 2024, 5:28 PM UTC (f476b8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1197/d991bb9...feifeiji89:f476b8c.html" title="Last updated on Mar 18, 2024, 5:28 PM UTC (f476b8c)">Diff</a>