### PR TITLE
Remove potentially trustworthy URL warning from validator

### DIFF
--- a/ts/src/header-validator/validate-os.test.ts
+++ b/ts/src/header-validator/validate-os.test.ts
@@ -13,6 +13,7 @@ const tests: TestCase[] = [
   { input: '"https://a.test/", "https://b.test/"' },
   { input: '"https://a.test/"; debug-reporting' },
   { input: '"https://a.test/"; debug-reporting=?0' },
+  { input: '"http://a.test"' },
 
   // Warnings
   {
@@ -60,17 +61,6 @@ const tests: TestCase[] = [
       {
         path: [0],
         msg: 'ignored, must contain a valid URL',
-      },
-    ],
-  },
-
-  // Untrustworthy URL
-  {
-    input: '"http://a.test"',
-    expectedWarnings: [
-      {
-        path: [0],
-        msg: 'ignored, must contain a potentially trustworthy URL',
       },
     ],
   },

--- a/ts/src/header-validator/validate-os.ts
+++ b/ts/src/header-validator/validate-os.ts
@@ -7,22 +7,10 @@ function validateURL(ctx: Context, member: InnerList | Item): void {
     return
   }
 
-  let url
   try {
-    url = new URL(member[0])
+    new URL(member[0])
   } catch {
     ctx.warning('ignored, must contain a valid URL')
-    return
-  }
-
-  if (
-    url.protocol !== 'https:' &&
-    !(
-      url.protocol === 'http:' &&
-      (url.hostname === 'localhost' || url.hostname === '127.0.0.1')
-    )
-  ) {
-    ctx.warning('ignored, must contain a potentially trustworthy URL')
     return
   }
 


### PR DESCRIPTION
[The spec](https://wicg.github.io/attribution-reporting-api/#get-os-registrations-from-a-header-value) and [the implementation](https://source.chromium.org/chromium/chromium/src/+/main:components/attribution_reporting/os_registration.cc;l=47?q=os_registration.cc&ss=chromium%2Fchromium%2Fsrc) are not checking that the URL is potentially trustworthy.

This PR aligns the validator with it.