### PR TITLE
Fix broken spec references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1280,13 +1280,13 @@ and [=obtain a randomized source response=].
 
 <dfn>Randomized null report rate excluding source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports
-generated for an [=attribution trigger=] whose [attribution trigger/aggregatable source registration time configuration]
+generated for an [=attribution trigger=] whose [=attribution trigger/aggregatable source registration time configuration=]
 is "<code>[=aggregatable source registration time configuration/exclude=]</code>". If [=automation local testing mode=] is true,
 this is 0.
 
 <dfn>Randomized null report rate including source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports
-generated for an [=attribution trigger=] whose [attribution trigger/aggregatable source registration time configuration]
+generated for an [=attribution trigger=] whose [=attribution trigger/aggregatable source registration time configuration=]
 is "<code>[=aggregatable source registration time configuration/include=]</code>". If [=automation local testing mode=] is true,
 this is 0.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1200.html" title="Last updated on Mar 19, 2024, 6:00 PM UTC (5a5ee33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1200/e4b0497...apasel422:5a5ee33.html" title="Last updated on Mar 19, 2024, 6:00 PM UTC (5a5ee33)">Diff</a>