### PR TITLE
Restrict the number of report states per source

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1278,7 +1278,7 @@ controls the default and maximum values that a source registration can specify
 for the epsilon parameter used by [=compute the channel capacity of a source=]
 and [=obtain a randomized source response=].
 
-<dfn>Max cardinality of possible trigger states</dfn> is a positive integer that controls the maximum size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
+<dfn>Max trigger-state cardinality</dfn> is a positive integer that controls the maximum size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
 
 <dfn>Randomized null report rate excluding source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports
@@ -1970,7 +1970,7 @@ To <dfn>compute the channel capacity of a source</dfn> given a [=randomized resp
 1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
 1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
 1. If |states| is 1, return 0.
-1. If |states| is greater than the user agent's [=max cardinality of possible trigger states=], return an error.
+1. If |states| is greater than the user agent's [=max trigger-state cardinality=], return an error.
 1. Let |p| be |pickRate| * (|states| - 1) / |states|.
 1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
 

--- a/index.bs
+++ b/index.bs
@@ -1278,6 +1278,8 @@ controls the default and maximum values that a source registration can specify
 for the epsilon parameter used by [=compute the channel capacity of a source=]
 and [=obtain a randomized source response=].
 
+<dfn>Max cardinality of possible trigger states</dfn> is a positive integer that controls the allowed size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
+
 <dfn>Randomized null report rate excluding source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports
 generated for an [=attribution trigger=] whose [attribution trigger/aggregatable source registration time configuration]
@@ -1968,6 +1970,7 @@ To <dfn>compute the channel capacity of a source</dfn> given a [=randomized resp
 1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
 1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
 1. If |states| is 1, return 0.
+1. If |states| is greater than the user agent's [=max cardinality of possible trigger states=], return an error.
 1. Let |p| be |pickRate| * (|states| - 1) / |states|.
 1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
 
@@ -2294,8 +2297,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Set |epsilon| to |value|["`event_level_epsilon`"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
 1. If [=automation local testing mode=] is true, set |epsilon| to `∞`.
-1. If the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon| is greater than
-    [=max event-level channel capacity per source=][|sourceType|], return null.
+1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
+1. If |channelCapacity| is an error or is greater than [=max event-level channel capacity per source=][|sourceType|], return null.
 1. Let |source| be a new [=attribution source=] struct whose items are:
 
     : [=attribution source/source identifier=]

--- a/index.bs
+++ b/index.bs
@@ -1278,7 +1278,7 @@ controls the default and maximum values that a source registration can specify
 for the epsilon parameter used by [=compute the channel capacity of a source=]
 and [=obtain a randomized source response=].
 
-<dfn>Max cardinality of possible trigger states</dfn> is a positive integer that controls the allowed size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
+<dfn>Max cardinality of possible trigger states</dfn> is a positive integer that controls the maximum size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
 
 <dfn>Randomized null report rate excluding source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports

--- a/index.bs
+++ b/index.bs
@@ -1278,7 +1278,7 @@ controls the default and maximum values that a source registration can specify
 for the epsilon parameter used by [=compute the channel capacity of a source=]
 and [=obtain a randomized source response=].
 
-<dfn>Max trigger-state cardinality</dfn> is a positive integer that controls the maximum size of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
+<dfn>Max trigger-state cardinality</dfn> is a positive integer that controls the maximum [=set/size=] of [=obtain a set of possible trigger states|the set of possible trigger states=] for any one [=attribution source=].
 
 <dfn>Randomized null report rate excluding source registration time</dfn> is a
 double between 0 and 1 (both inclusive) that controls the randomized number of null reports

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1283,61 +1283,31 @@ const testCases: TestCase[] = [
     name: 'trigger-state-cardinality-valid',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.event,
-    noteInfoGain: true,
     vsv: {
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: Infinity,
         [SourceType.navigation]: 0,
       },
       maxSettableEventLevelEpsilon: 14,
-      maxCardinalityOfPossibleTriggerStates: 3,
+      maxTriggerStateCardinality: 3,
     },
-    expectedNotes: [
-      {
-        path: [],
-        msg: 'information gain: 1.58',
-      },
-      {
-        path: [],
-        msg: 'number of possible output states: 3',
-      },
-      {
-        path: [],
-        msg: 'randomized trigger rate: 0.0000025',
-      },
-    ],
   },
   {
     name: 'trigger-state-cardinality-invalid',
     json: `{"destination": "https://a.test"}`,
     sourceType: SourceType.event,
-    noteInfoGain: true,
     vsv: {
       maxEventLevelChannelCapacityPerSource: {
         [SourceType.event]: Infinity,
         [SourceType.navigation]: 0,
       },
       maxSettableEventLevelEpsilon: 14,
-      maxCardinalityOfPossibleTriggerStates: 2,
+      maxTriggerStateCardinality: 2,
     },
     expectedErrors: [
       {
         path: [],
         msg: 'number of possible output states (3) exceeds max cardinality (2)',
-      },
-    ],
-    expectedNotes: [
-      {
-        path: [],
-        msg: 'information gain: 1.58',
-      },
-      {
-        path: [],
-        msg: 'number of possible output states: 3',
-      },
-      {
-        path: [],
-        msg: 'randomized trigger rate: 0.0000025',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1323,7 +1323,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: [],
-        msg: 'number of possible output states: 3 exceeds max trigger-state cardinality (2)',
+        msg: 'number of possible output states (3) exceeds max cardinality (2)',
       },
     ],
     expectedNotes: [

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1324,7 +1324,7 @@ const testCases: TestCase[] = [
       {
         path: [],
         msg: 'number of possible output states: 3 exceeds max trigger-state cardinality (2)',
-      }
+      },
     ],
     expectedNotes: [
       {

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1280,6 +1280,69 @@ const testCases: TestCase[] = [
   },
 
   {
+    name: 'trigger-state-cardinality-valid',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.event,
+    noteInfoGain: true,
+    vsv: {
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: Infinity,
+        [SourceType.navigation]: 0,
+      },
+      maxSettableEventLevelEpsilon: 14,
+      maxCardinalityOfPossibleTriggerStates: 3,
+    },
+    expectedNotes: [
+      {
+        path: [],
+        msg: 'information gain: 1.58',
+      },
+      {
+        path: [],
+        msg: 'number of possible output states: 3',
+      },
+      {
+        path: [],
+        msg: 'randomized trigger rate: 0.0000025',
+      },
+    ],
+  },
+  {
+    name: 'trigger-state-cardinality-invalid',
+    json: `{"destination": "https://a.test"}`,
+    sourceType: SourceType.event,
+    noteInfoGain: true,
+    vsv: {
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: Infinity,
+        [SourceType.navigation]: 0,
+      },
+      maxSettableEventLevelEpsilon: 14,
+      maxCardinalityOfPossibleTriggerStates: 2,
+    },
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'number of possible output states: 3 exceeds max trigger-state cardinality (2)',
+      }
+    ],
+    expectedNotes: [
+      {
+        path: [],
+        msg: 'information gain: 1.58',
+      },
+      {
+        path: [],
+        msg: 'number of possible output states: 3',
+      },
+      {
+        path: [],
+        msg: 'randomized trigger rate: 0.0000025',
+      },
+    ],
+  },
+
+  {
     name: 'event-level-epsilon-valid',
     json: `{
       "destination": "https://a.test",

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -844,7 +844,7 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
 
   if (out.numStates > maxReportStates) {
     ctx.error(
-      `${numStatesWords}: ${out.numStates} exceeds max trigger-state cardinality (${maxReportStates})`
+      `${numStatesWords} (${out.numStates}) exceeds max cardinality (${maxReportStates})`
     )
   }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -844,7 +844,7 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
 
   if (out.numStates > maxReportStates) {
     ctx.error(
-      `${numStatesWords}: ${out.numStates} exceeds max cardinality of possible trigger states (${maxReportStates})`
+      `${numStatesWords}: ${out.numStates} exceeds max trigger-state cardinality (${maxReportStates})`
     )
   }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -819,6 +819,8 @@ function eventLevelEpsilon(ctx: RegistrationContext, j: Json): Maybe<number> {
 }
 
 function channelCapacity(ctx: SourceContext, s: Source): void {
+  const numStatesWords = "number of possible output states"
+
   const perTriggerDataConfigs = s.triggerSpecs.flatMap((spec) =>
     Array(spec.triggerData.size).fill(
       new privacy.PerTriggerDataConfig(
@@ -838,21 +840,29 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
     ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
   )
 
-  const max = ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
+  const maxReportStates = ctx.vsv.maxCardinalityOfPossibleTriggerStates
+
+  if (out.numStates > maxReportStates) {
+    ctx.error(
+      `${numStatesWords}: ${out.numStates} exceeds max cardinality of possible trigger states (${maxReportStates})`
+    )
+  }
+
+  const maxInfoGain = ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
   const infoGainMsg = `information gain: ${out.infoGain.toFixed(2)}`
 
-  if (out.infoGain > max) {
+  if (out.infoGain > maxInfoGain) {
     ctx.error(
       `${infoGainMsg} exceeds max event-level channel capacity per ${
         ctx.sourceType
-      } source (${max.toFixed(2)})`
+      } source (${maxInfoGain.toFixed(2)})`
     )
   } else if (ctx.noteInfoGain) {
     ctx.note(infoGainMsg)
   }
 
   if (ctx.noteInfoGain) {
-    ctx.note(`number of possible output states: ${out.numStates}`)
+    ctx.note(`${numStatesWords}: ${out.numStates}`)
     ctx.note(`randomized trigger rate: ${out.flipProb.toFixed(7)}`)
   }
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -819,7 +819,7 @@ function eventLevelEpsilon(ctx: RegistrationContext, j: Json): Maybe<number> {
 }
 
 function channelCapacity(ctx: SourceContext, s: Source): void {
-  const numStatesWords = "number of possible output states"
+  const numStatesWords = 'number of possible output states'
 
   const perTriggerDataConfigs = s.triggerSpecs.flatMap((spec) =>
     Array(spec.triggerData.size).fill(
@@ -848,7 +848,8 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
     )
   }
 
-  const maxInfoGain = ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
+  const maxInfoGain =
+    ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
   const infoGainMsg = `information gain: ${out.infoGain.toFixed(2)}`
 
   if (out.infoGain > maxInfoGain) {

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -840,11 +840,11 @@ function channelCapacity(ctx: SourceContext, s: Source): void {
     ctx.vsv.maxEventLevelChannelCapacityPerSource[ctx.sourceType]
   )
 
-  const maxReportStates = ctx.vsv.maxCardinalityOfPossibleTriggerStates
+  const maxTriggerStates = ctx.vsv.maxTriggerStateCardinality
 
-  if (out.numStates > maxReportStates) {
+  if (out.numStates > maxTriggerStates) {
     ctx.error(
-      `${numStatesWords} (${out.numStates}) exceeds max cardinality (${maxReportStates})`
+      `${numStatesWords} (${out.numStates}) exceeds max cardinality (${maxTriggerStates})`
     )
   }
 

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -3,7 +3,7 @@ import { SourceType } from './source-type'
 export type VendorSpecificValues = {
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   maxSettableEventLevelEpsilon: number
-  maxCardinalityOfPossibleTriggerStates: number
+  maxTriggerStateCardinality: number
 }
 
 export const Chromium: Readonly<VendorSpecificValues> = {
@@ -12,5 +12,5 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.navigation]: 11.5,
   },
   maxSettableEventLevelEpsilon: 14,
-  maxCardinalityOfPossibleTriggerStates: Infinity,
+  maxTriggerStateCardinality: Infinity,
 }

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -12,5 +12,5 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.navigation]: 11.5,
   },
   maxSettableEventLevelEpsilon: 14,
-  maxCardinalityOfPossibleTriggerStates: Infinity
+  maxCardinalityOfPossibleTriggerStates: Infinity,
 }

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -3,6 +3,7 @@ import { SourceType } from './source-type'
 export type VendorSpecificValues = {
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
   maxSettableEventLevelEpsilon: number
+  maxCardinalityOfPossibleTriggerStates: number
 }
 
 export const Chromium: Readonly<VendorSpecificValues> = {
@@ -11,4 +12,5 @@ export const Chromium: Readonly<VendorSpecificValues> = {
     [SourceType.navigation]: 11.5,
   },
   maxSettableEventLevelEpsilon: 14,
+  maxCardinalityOfPossibleTriggerStates: Infinity
 }


### PR DESCRIPTION
Estimated channel capacity when the number of states is sufficiently high is effectively zero, and a randomised source response is effectively guaranteed. Additionally, a very high number of states coupled with the complexity of the flexible event feature can present challenges to performance. Altogether, user-agents may have cause to restrict the total number of report states per source.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giladbarkan-github/attribution-reporting-api/pull/1203.html" title="Last updated on Mar 22, 2024, 12:57 PM UTC (dca4f8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1203/d991bb9...giladbarkan-github:dca4f8d.html" title="Last updated on Mar 22, 2024, 12:57 PM UTC (dca4f8d)">Diff</a>