### PR TITLE
Gate all source verbose debug reports behind cookie access

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2410,28 +2410,11 @@ a [=trigger state=] |triggerState|:
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
 
-To <dfn>check if debug reporting is allowed</dfn> given a [=source debug data type=] |dataType|
-and a [=boolean=] |debugCookieSet|:
-1. If |dataType| is:
-    <dl class="switch">
-    : "<code>[=source debug data type/source-destination-limit=]</code>"
-    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
-    :: Return <strong>allowed</strong>.
-    : "<code>[=source debug data type/source-noised=]</code>"
-    : "<code>[=source debug data type/source-storage-limit=]</code>"
-    : "<code>[=source debug data type/source-success=]</code>"
-    : "<code>[=source debug data type/source-unknown-error=]</code>"
-    ::  1. If |debugCookieSet| is true, return <strong>allowed</strong>.
-        1. Otherwise, return <strong>blocked</strong>.
-
-    </dl>
-
 To <dfn>obtain and deliver a debug report on source registration</dfn> given a
 [=source debug data type=] |dataType| and an [=attribution source=] |source|:
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
-1. If the result of running [=check if debug reporting is allowed=] with |dataType| and |source|'s
-    [=attribution source/debug cookie set=] is <strong>blocked</strong>, return.
+1. If |source|'s [=attribution source/debug cookie set=] is false, return.
 1. Let |body| be a new [=map=] with the following key/value pairs:
     : "`attribution_destination`"
     :: |source|'s [=attribution source/attribution destinations=], [=serialize attribution destinations|serialized=].


### PR DESCRIPTION
The privacy-neutral argument would depend on the order of the checks. To reduce complexity, gate all source verbose debug reports behind cookie access.

Note that this change is backwards incompatible as source-destination-limit and source-destination-rate-limit debug reports now require ar_debug cookie. There is no major concern as we expect that ad-techs that enable source verbose debug reports would already set ar_debug cookie.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1204.html" title="Last updated on Mar 19, 2024, 11:48 PM UTC (f9e10a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1204/8501298...linnan-github:f9e10a6.html" title="Last updated on Mar 19, 2024, 11:48 PM UTC (f9e10a6)">Diff</a>