### PR TITLE
Return value for obtaining possible trigger states algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1947,6 +1947,7 @@ To <dfn>obtain a set of possible trigger states</dfn> given a [=randomized respo
 1. [=set/iterate|For each=] integer |attributions| of [=the range=] 0 to |config|'s [=randomized response output configuration/max attributions per source=], inclusive:
     1. [=set/Append=] to |possibleValues| all distinct |attributions|-length combinations of
         |possibleTriggerStates|.
+1. Return |possibleValues|.
 
 To <dfn>obtain a randomized source response pick rate</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
 


### PR DESCRIPTION
This is to fix the algorithm which should return the set.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1206.html" title="Last updated on Mar 20, 2024, 3:24 PM UTC (48146a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1206/8501298...linnan-github:48146a3.html" title="Last updated on Mar 20, 2024, 3:24 PM UTC (48146a3)">Diff</a>