### PR TITLE
Adjust eligibility-header validation with respect to fetch options

### DIFF
--- a/ts/src/header-validator/validate-eligible.test.ts
+++ b/ts/src/header-validator/validate-eligible.test.ts
@@ -8,16 +8,6 @@ const tests = [
   { input: 'trigger' },
   { input: 'event-source, trigger' },
 
-  // Warnings
-  {
-    input: 'navigation-source',
-    expectedWarnings: [
-      {
-        path: ['navigation-source'],
-        msg: 'may only be specified in browser-initiated requests',
-      },
-    ],
-  },
   {
     input: 'x',
     expectedWarnings: [
@@ -52,6 +42,25 @@ const tests = [
     expectedErrors: [
       {
         msg: 'Error: Parse error: A key must begin with an asterisk or letter (a-z) at offset 0',
+      },
+    ],
+  },
+
+  {
+    input: 'navigation-source, trigger',
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'navigation-source is mutually exclusive with event-source and trigger',
+      },
+    ],
+  },
+  {
+    input: 'navigation-source, event-source',
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'navigation-source is mutually exclusive with event-source and trigger',
       },
     ],
   },


### PR DESCRIPTION
After #757, user code no longer manually sets the
Attribution-Reporting-Eligible header, but the validator was never updated to properly reflect that.

We remove the warning about navigation-source (since the header is effectively always browser-set) and add errors corresponding to [nonexistent key combinations](https://wicg.github.io/attribution-reporting-api/#set-attribution-reporting-headers) (navigation-source always occurs in isolation).