### PR TITLE
Split attribution rate-limit into separate event & aggregate rate-limits

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -1059,7 +1059,7 @@ sent through this API in a given time period for a user. The browser should set
 a maximum number of attributions per
 <source site, destination site, reporting site, user> tuple per time period. If this
 threshold is hit, the browser will stop scheduling reports the API for the
-rest of the time period for attributions matching that tuple. This attribution limit is separate for event-level & aggregate reporting.
+rest of the time period for attributions matching that tuple. This attribution limit is separate for event-level and aggregate reporting.
 
 The longer the cooldown windows are, the harder it is to abuse the API and join
 identity. Ideally attribution thresholds should be low enough to avoid leaking too

--- a/EVENT.md
+++ b/EVENT.md
@@ -1059,7 +1059,7 @@ sent through this API in a given time period for a user. The browser should set
 a maximum number of attributions per
 <source site, destination site, reporting site, user> tuple per time period. If this
 threshold is hit, the browser will stop scheduling reports the API for the
-rest of the time period for attributions matching that tuple.
+rest of the time period for attributions matching that tuple. This attribution limit is separate for event-level & aggregate reporting.
 
 The longer the cooldown windows are, the harder it is to abuse the API and join
 identity. Ideally attribution thresholds should be low enough to avoid leaking too

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -296,7 +296,7 @@ The values are summed (to 8) and reported in the following reports after 7 days:
   "trigger_summary_bucket": [5, 9]
 }
 ```
-
+Instead of these triggers being counted as 3 attributions from rate-limit perspective, they will be only counted as 1 attribution because 1 
 In the subsequent 7 days, the following triggers are registered:
 
 ```jsonc
@@ -426,6 +426,10 @@ is dropped.
 ```
 
 We encourage developers to suggest different use cases they may have for this API extension, and we will update this explainer with sample configurations for those use cases.
+
+## Attribution Rate Limit
+
+Attribution rate-limit behavior will be based on the numbers of reports generated rather than number of triggers that lead to report generation. For example: The 1st report in the [Reporting trigger value buckets](#reporting-trigger-value-buckets) example will be counted as 1 contribution towards the [max attribution per rate-limit window](https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window) limit despite it being a result of contributions from 3 triggers.
 
 ## Privacy considerations
 

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -296,7 +296,6 @@ The values are summed (to 8) and reported in the following reports after 7 days:
   "trigger_summary_bucket": [5, 9]
 }
 ```
-Instead of these triggers being counted as 3 attributions from rate-limit perspective, they will be only counted as 1 attribution because 1 
 In the subsequent 7 days, the following triggers are registered:
 
 ```jsonc

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -296,6 +296,7 @@ The values are summed (to 8) and reported in the following reports after 7 days:
   "trigger_summary_bucket": [5, 9]
 }
 ```
+
 In the subsequent 7 days, the following triggers are registered:
 
 ```jsonc
@@ -428,7 +429,7 @@ We encourage developers to suggest different use cases they may have for this AP
 
 ## Attribution Rate Limit
 
-Attribution rate-limit behavior will be based on the numbers of reports generated rather than number of triggers that lead to report generation. For example: The 1st report in the [Reporting trigger value buckets](#reporting-trigger-value-buckets) example will be counted as 1 contribution towards the [max attribution per rate-limit window](https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window) limit despite it being a result of contributions from 3 triggers.
+Attribution rate-limit behavior will be based on the number of reports generated rather than the number of triggers that lead to report generation. For example: The first report in the ["Reporting trigger value buckets"](#reporting-trigger-value-buckets) example will be counted as 1 contribution towards the [max attribution per rate-limit window](https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window) limit despite it being the result of contributions from 3 triggers.
 
 ## Privacy considerations
 

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -429,7 +429,13 @@ We encourage developers to suggest different use cases they may have for this AP
 
 ## Attribution Rate Limit
 
-Attribution rate-limit behavior will be based on the number of reports generated rather than the number of triggers that lead to report generation. For example: The first report in the ["Reporting trigger value buckets"](#reporting-trigger-value-buckets) example will be counted as 1 contribution towards the [max attribution per rate-limit window](https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window) limit despite it being the result of contributions from 3 triggers.
+Attribution rate-limit behavior will be based on the number of reports generated
+rather than the number of triggers that lead to report generation. For example:
+The first report in the
+["Reporting trigger value buckets"](#reporting-trigger-value-buckets) example
+will be counted as 1 contribution towards the
+[max attribution per rate-limit window](https://wicg.github.io/attribution-reporting-api/#max-attributions-per-rate-limit-window)
+limit despite it being the result of contributions from 3 triggers.
 
 ## Privacy considerations
 

--- a/index.bs
+++ b/index.bs
@@ -3382,9 +3382,9 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 1. [=list/iterate|For each=] |item| of |matchingSources|:
     1. [=set/Remove=] |item| from the [=attribution source cache=].
 1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=]
-    with |trigger|, |sourceToAttribute|.
+    with |trigger| and |sourceToAttribute|.
 1. Let |aggregatableResult| be the result of running [=trigger aggregatable attribution=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|.
+    with |trigger| and |sourceToAttribute|.
 1. Let |eventLevelDebugData| be |eventLevelResult|'s [=triggering result/debug data=].
 1. Let |aggregatableDebugData| be |aggregatableResult|'s [=triggering result/debug data=].
 1. Let |debugDataList| be an [=list/is empty|empty=] [=list=].

--- a/index.bs
+++ b/index.bs
@@ -2884,10 +2884,9 @@ Given an [=attribution trigger=] |trigger|, [=attribution source=] |sourceToAttr
 Given an [=attribution rate-limit record=] |newRecord|:
 
 1. Let |max| be [=max source reporting origins per rate-limit window=].
-1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>", set |max| to
-     [=max event attribution reporting origins per rate-limit window=].
-1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |max| to
-     [=max aggregatable attribution reporting origins per rate-limit window=].
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
+     or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |max| to
+     [=max attribution reporting origins per rate-limit window=].
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] and |newRecord|'s [=attribution rate-limit record/scope=] are equal
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
@@ -3098,7 +3097,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
     [=attribution rate-limit record/entity id=] is equal to |report|'s [=event-level report/report id=]
-    and [=attribution rate-limit record/=] is equal to [=rate-limit scope/event-attribution=].
+    and [=attribution rate-limit record/scope=] is equal to [=rate-limit scope/event-attribution=].
 1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 

--- a/index.bs
+++ b/index.bs
@@ -1615,11 +1615,11 @@ This algorithm will return either a non-negative 128-bit integer or an error.
 Given an [=attribution rate-limit record=] |newRecord|:
 
 1. Let |max| be [=max source reporting origins per rate-limit window=].
-1. Let |scopeSet| be «"<code>[=rate-limit scope/source=]</code>"».
+1. Let |scopeSet| be « "<code>[=rate-limit scope/source=]</code>" ».
 1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
      or "<code>[=rate-limit scope/aggregatable-attribution=]</code>":
      1. Set |max| to [=max attribution reporting origins per rate-limit window=].
-     1. Set |scopeSet| to «"<code>[=rate-limit scope/event-attribution=]</code>", "<code>[=rate-limit scope/aggregatable-attribution=]</code>"».
+     1. Set |scopeSet| to « "<code>[=rate-limit scope/event-attribution=]</code>", "<code>[=rate-limit scope/aggregatable-attribution=]</code>" ».
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |scopeSet| [=set/contains=] |record|'s [=attribution rate-limit record/scope=]
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal

--- a/index.bs
+++ b/index.bs
@@ -1037,8 +1037,8 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 :: A [=moment=].
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
-: <dfn>entity id</dfn>
-:: A [=event-level report=]'s [=event-level report/report id=] or [=aggregatable report=]'s [=aggregatable report/report id=] or [=attribution source/source identifier=].
+: <dfn>entity ID</dfn>
+:: A [=event-level report=]'s [=event-level report/report ID=] or [=aggregatable report=]'s [=aggregatable report/report ID=] or [=attribution source/source identifier=].
 
 </dl>
 
@@ -1070,7 +1070,7 @@ Possible values are:
 <li>"<dfn><code>trigger-aggregate-storage-limit</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-report-window-passed</code></dfn>"
 <li>"<dfn><code>trigger-event-attributions-per-source-destination-limit</code></dfn>"
-<li>"<dfn><code>trigger-aggregatable-attributions-per-source-destination-limit</code></dfn>"
+<li>"<dfn><code>trigger-aggregate-attributions-per-source-destination-limit</code></dfn>"
 <li>"<dfn><code>trigger-event-deduplicated</code></dfn>"
 <li>"<dfn><code>trigger-event-excessive-reports</code></dfn>"
 <li>"<dfn><code>trigger-event-low-priority</code></dfn>"
@@ -1618,8 +1618,8 @@ This algorithm will return either a non-negative 128-bit integer or an error.
 
 Given an [=attribution rate-limit record=] |record| and a [=moment=] |now|:
 1. If the [=duration from=] |record|'s [=attribution rate-limit record|time=] and |now| is <= [=attribution rate-limit window=] , return false.
-1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>", return true.
-1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return true.
+1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
+    or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return true.
 1. If |record|'s [=attribution rate-limit record/expiry time=] is after |now|, return false.
 1. Return true.
 
@@ -2542,7 +2542,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             :: |source|'s [=attribution source/source time=]
             : [=attribution rate-limit record/expiry time=]
             :: null
-            : [=attribution rate-limit record/entity id=]
+            : [=attribution rate-limit record/entity ID=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
     1. Set |debugDataType| to "<code>[=source debug data type/source-noised=]</code>".
@@ -2866,7 +2866,7 @@ To <dfn>match an attribution source against filters and negated filters</dfn> gi
 
 <h3 dfn id="should-block-attribution-for-attribution-limit">Should attribution be blocked by attribution rate limit</h3>
 
-Given an [=attribution trigger=] |trigger|, [=attribution source=] |sourceToAttribute| and [=attribution rate-limit record/scope=] |rateLimitScope| :
+Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToAttribute|, and an [=attribution rate-limit record/scope=] |rateLimitScope|:
 
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| of [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is |rateLimitScope|
@@ -2874,8 +2874,8 @@ Given an [=attribution trigger=] |trigger|, [=attribution source=] |sourceToAttr
      * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
      * |record|'s [=attribution rate-limit record/reporting origin=] and |trigger|'s [=attribution trigger/reporting origin=] are [=same site=]
      * |record|'s [=attribution rate-limit record/time=] is greater than [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
-1. Let |limit| be [=max aggregatable attributions per rate-limit window=]
-1. If |rateLimitScope| is [=rate-limit scope/event-attribution=], set |limit| = [=max event attributions per rate-limit window=]
+1. Let |limit| be [=max aggregatable attributions per rate-limit window=].
+1. If |rateLimitScope| is "<code>[=rate-limit scope/event-attribution=]</code>", set |limit| to [=max event attributions per rate-limit window=].
 1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to |limit|, return <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
 
@@ -2916,12 +2916,12 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|
     and |scope| is <strong>blocked</strong>:
     1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
-    2. If |scope| is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |debugDataType| to 
-        "<code>[=trigger debug data type/trigger-aggregatable-attributions-per-source-destination-limit=]</code>"
-    3. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+    1. If |scope| is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |debugDataType| to 
+        "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
+    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with |debugDataType|, |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
-    4. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=should processing be blocked by reporting-origin limit=] with
     |newRecord| is <strong>blocked</strong>:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -2997,7 +2997,7 @@ an optional [=attribution source=] <dfn for="obtain debug data body on trigger r
     : "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event attributions per rate-limit window=],
          [=serialize an integer|serialized=].
-    : "<code>[=trigger debug data type/trigger-aggregatable-attributions-per-source-destination-limit=]</code>"
+    : "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max aggregatable attributions per rate-limit window=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>"
@@ -3096,7 +3096,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. [=set/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
-    [=attribution rate-limit record/entity id=] is equal to |report|'s [=event-level report/report id=]
+    [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=]
     and [=attribution rate-limit record/scope=] is equal to [=rate-limit scope/event-attribution=].
 1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
@@ -3105,7 +3105,7 @@ Issue: This algorithm is not compatible with the behavior proposed for
 [=experimental Flexible Event support=] with differing
 [=trigger spec/event-level report windows=] for a given source.
 
-To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger|, and an
+To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger| and an
 [=attribution source=] |sourceToAttribute|, run the following steps:
 
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
@@ -3184,8 +3184,8 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/entity id=]
-    :: |report|'s [=event-level report/report id=]
+    : [=attribution rate-limit record/entity ID=]
+    :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=should attribution be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
     return it.
@@ -3227,16 +3227,16 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
     [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
+1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. If |triggeringStatus| is "<code>[=triggering status/attributed=]</code>" and
     |report|'s [=event-level report/source debug key=] is not null and |report|'s
     [=event-level report/trigger debug key=] is not null, [=queue a task=] to
     [=attempt to deliver a debug report=] with |report|.
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Return the [=triggering result=] (|triggeringStatus|, |debugData|).
 
 <h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>
 
-To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger|, and an
+To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger| and an
 [=attribution source=] |sourceToAttribute|, run the following steps:
 
 1. If the result of running [=check if an attribution trigger contains aggregatable data=] is false,
@@ -3291,8 +3291,8 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/entity id=]
-    :: |report|'s [=aggregatable report/report id=]
+    : [=attribution rate-limit record/entity ID=]
+    :: |report|'s [=aggregatable report/report ID=]
 1. If the result of running [=should attribution be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
     return it.
@@ -3311,11 +3311,11 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. Increment |sourceToAttribute|'s [=attribution source/aggregatable budget consumed=] value by
     |report|'s [=aggregatable report/required aggregatable budget=].
 1. If |matchedDedupKey| is not null, [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].
+1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Run [=generate null reports and assign private state tokens=] with |trigger| and |report|.
 1. If |report|'s [=aggregatable report/source debug key=] is not null and |report|'s
     [=aggregatable report/trigger debug key=] is not null, [=queue a task=] to
     [=attempt to deliver a debug report=] with |report|.
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Return the [=triggering result=] ("<code>[=triggering status/attributed=]</code>", null).
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
@@ -3461,7 +3461,7 @@ a 64-bit integer priority |priority|, and a [=trigger spec map=] [=map/entry=]
     :: |triggerTime|.
     : [=event-level report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
-    : [=event-level report/report id=]
+    : [=event-level report/report ID=]
     :: The result of [=generating a random UUID=].
     : [=event-level report/source debug key=]
     :: |source|'s [=attribution source/debug key=].
@@ -3491,7 +3491,7 @@ an [=attribution trigger=] |trigger|:
     :: |source|'s [=attribution source/source time=].
     : [=aggregatable report/report time=]
     :: |reportTime|.
-    : [=aggregatable report/report id=]
+    : [=aggregatable report/report ID=]
     :: The result of [=generating a random UUID=].
     : [=aggregatable report/source debug key=]
     :: |source|'s [=attribution source/debug key=].
@@ -3524,7 +3524,7 @@ To <dfn>obtain a null report</dfn> given an [=attribution trigger=] |trigger| an
     :: |sourceTime|
     : [=aggregatable report/report time=]
     :: |reportTime|
-    : [=aggregatable report/report id=]
+    : [=aggregatable report/report ID=]
     :: The result of [=generating a random UUID=]
     : [=aggregatable report/source debug key=]
     :: null

--- a/index.bs
+++ b/index.bs
@@ -1038,7 +1038,9 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
 : <dfn>entity ID</dfn>
-:: A [=event-level report=]'s [=event-level report/report ID=] or [=aggregatable report=]'s [=aggregatable report/report ID=] or [=attribution source/source identifier=].
+:: An [=event-level report=]'s [=event-level report/report ID=] or an
+    [=aggregatable report=]'s [=aggregatable report/report ID=] or an
+    [=attribution source=]'s [=attribution source/source identifier=].
 
 </dl>
 
@@ -2911,13 +2913,13 @@ Given an [=attribution rate-limit record=] |newRecord|:
 <h3 dfn id="should-block-attribution-for-rate-limits">Should attribution be blocked by rate limits</h3>
 
 Given an [=attribution trigger=] |trigger|, an [=attribution source=]
-|sourceToAttribute|, and an [=attribution rate-limit record/scope=] |scope|:
+|sourceToAttribute|, and an [=attribution rate-limit record=] |newRecord|:
 
 1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|
-    and |scope| is <strong>blocked</strong>:
+    and |newRecord|'s [=attribution rate-limit record/scope=] is <strong>blocked</strong>:
     1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
-    1. If |scope| is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |debugDataType| to 
-        "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
+    1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>",
+        set |debugDataType| to "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with |debugDataType|, |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
@@ -3187,8 +3189,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     : [=attribution rate-limit record/entity ID=]
     :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=should attribution be blocked by rate limits=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
-    return it.
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
     is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -3294,8 +3295,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     : [=attribution rate-limit record/entity ID=]
     :: |report|'s [=aggregatable report/report ID=]
 1. If the result of running [=should attribution be blocked by rate limits=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
-    return it.
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
 1. If |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value is equal to [=max aggregatable reports per source=], then:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=] with
         "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", |trigger|, |sourceToAttribute|, and |report|.

--- a/index.bs
+++ b/index.bs
@@ -2873,7 +2873,7 @@ Given an [=attribution rate-limit record=] |newRecord|:
      1. Set |scopeSet| to «"<code>[=rate-limit scope/event-attribution=]</code>", "<code>[=rate-limit scope/aggregatable-attribution=]</code>"».
 
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
-     * |record|'s [=attribution rate-limit record/scope=] is present in |scopeSet|
+     * |scopeSet| [=set/contains=] |record|'s [=attribution rate-limit record/scope=]
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
      * |record|'s [=attribution rate-limit record/attribution destination=] and |newRecord|'s [=attribution rate-limit record/attribution destination=] are equal
      * The [=duration from=] |record|'s [=attribution rate-limit record/time=] and  |newRecord|'s [=attribution rate-limit record/time=] is <= [=attribution rate-limit window=]

--- a/index.bs
+++ b/index.bs
@@ -1038,9 +1038,7 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
 : <dfn>entity ID</dfn>
-:: Null or an [=event-level report=]'s [=event-level report/report ID=] or an
-    [=aggregatable report=]'s [=aggregatable report/report ID=] or an
-    [=attribution source=]'s [=attribution source/source identifier=].
+:: Null or an [=event-level report=]'s [=event-level report/report ID=].
 
 </dl>
 
@@ -1358,7 +1356,7 @@ controls the maximum number of attributions for a
 ([=attribution rate-limit record/source site=],
 [=attribution rate-limit record/attribution destination=],
 [=attribution rate-limit record/reporting origin=] [=site=]) per
-[=attribution rate-limit window=].
+[=attribution rate-limit window=]. This attribution limit is separate for event-level and aggregate reporting.
 
 <dfn>Randomized aggregatable report delay</dfn> is a positive [=duration=] that controls the
 random delay to deliver an [=aggregatable report=]. If [=automation local testing mode=] is true,
@@ -2495,7 +2493,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         : [=attribution rate-limit record/expiry time=]
         :: |source|'s [=attribution source/expiry time=]
         : [=attribution rate-limit record/entity ID=]
-        :: |source|'s [=attribution source/source identifier=]
+        :: null
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
         1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-success=]</code>" and |source|.
@@ -2852,7 +2850,7 @@ To <dfn>match an attribution source against filters and negated filters</dfn> gi
 
 <h3 dfn id="should-block-attribution-for-attribution-limit">Should attribution be blocked by attribution rate limit</h3>
 
-Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToAttribute|, and an [=attribution rate-limit record/scope=] |rateLimitScope|:
+Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToAttribute|, and a [=attribution rate-limit record/scope=] |rateLimitScope|:
 
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| of [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is |rateLimitScope|
@@ -2868,11 +2866,13 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToA
 Given an [=attribution rate-limit record=] |newRecord|:
 
 1. Let |max| be [=max source reporting origins per rate-limit window=].
+1. Let |scopeSet| be a [=set=] of [=rate-limit scope=] containing "<code>[=rate-limit scope/source=]</code>"
 1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
-     or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |max| to
-     [=max attribution reporting origins per rate-limit window=].
+     or "<code>[=rate-limit scope/aggregatable-attribution=]</code>":
+     1. Set |max| to [=max attribution reporting origins per rate-limit window=].
+     1. Set |scopeSet| be a [=set=] containing "<code>[=rate-limit scope/event-attribution=]</code>" and "<code>[=rate-limit scope/aggregatable-attribution=]</code>".
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
-     * |record|'s [=attribution rate-limit record/scope=] and |newRecord|'s [=attribution rate-limit record/scope=] are equal
+     * |record|'s [=attribution rate-limit record/scope=] is present in |scopeSet|
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
      * |record|'s [=attribution rate-limit record/attribution destination=] and |newRecord|'s [=attribution rate-limit record/attribution destination=] are equal
      * The [=duration from=] |record|'s [=attribution rate-limit record/time=] and  |newRecord|'s [=attribution rate-limit record/time=] is <= [=attribution rate-limit window=]
@@ -3078,8 +3078,9 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. [=set/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
-    [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=]
+    [=attribution rate-limit record/entity ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
     and [=attribution rate-limit record/scope=] is equal to "<code>[=rate-limit scope/event-attribution=]</code>".
+1. [=Assert=]: |rateLimitRecord| is not null.
 1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 
@@ -3196,7 +3197,9 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. If |sourceToAttribute|'s [=attribution source/randomized response=] is:
     <dl class="switch">
     : null
-    :: [=set/Append=] |report| to the [=event-level report cache=].
+    :: 
+        1. [=set/Append=] |report| to the [=event-level report cache=].
+        1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
     : not null
     ::
         1. Set |triggeringStatus| to "<code>[=triggering status/noised=]</code>".
@@ -3208,7 +3211,6 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Increment |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. If |matchedConfig|'s [=event-level trigger configuration/dedup key=] is not null,
     [=list/append=] it to |sourceToAttribute|'s [=attribution source/dedup keys=].
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. If |triggeringStatus| is "<code>[=triggering status/attributed=]</code>" and
     |report|'s [=event-level report/source debug key=] is not null and |report|'s
     [=event-level report/trigger debug key=] is not null, [=queue a task=] to
@@ -3273,7 +3275,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     : [=attribution rate-limit record/expiry time=]
     :: null
     : [=attribution rate-limit record/entity ID=]
-    :: |report|'s [=aggregatable report/report ID=]
+    :: null
 1. If the result of running [=should attribution be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
     return it.

--- a/index.bs
+++ b/index.bs
@@ -2866,7 +2866,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToA
 Given an [=attribution rate-limit record=] |newRecord|:
 
 1. Let |max| be [=max source reporting origins per rate-limit window=].
-1. Let |scopeSet| be a [=set=] of [=rate-limit scope=] containing "<code>[=rate-limit scope/source=]</code>"
+1. Let |scopeSet| be «"<code>[=rate-limit scope/source=]</code>"».
 1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
      or "<code>[=rate-limit scope/aggregatable-attribution=]</code>":
      1. Set |max| to [=max attribution reporting origins per rate-limit window=].

--- a/index.bs
+++ b/index.bs
@@ -1351,15 +1351,8 @@ positive integer that controls the maximum number of distinct
 [=attribution rate-limit record/attribution destination=]) that can create
 [=event-level reports=] per [=attribution rate-limit window=].
 
-<dfn>Max event attributions per rate-limit window</dfn> is a positive integer that
-controls the maximum number of event attributions for a
-([=attribution rate-limit record/source site=],
-[=attribution rate-limit record/attribution destination=],
-[=attribution rate-limit record/reporting origin=] [=site=]) per
-[=attribution rate-limit window=].
-
-<dfn>Max aggregatable attributions per rate-limit window</dfn> is a positive integer that
-controls the maximum number of aggregatable attributions for a
+<dfn>Max attributions per rate-limit window</dfn> is a positive integer that
+controls the maximum number of attributions for a
 ([=attribution rate-limit record/source site=],
 [=attribution rate-limit record/attribution destination=],
 [=attribution rate-limit record/reporting origin=] [=site=]) per
@@ -2876,9 +2869,7 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=] |sourceToA
      * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
      * |record|'s [=attribution rate-limit record/reporting origin=] and |trigger|'s [=attribution trigger/reporting origin=] are [=same site=]
      * |record|'s [=attribution rate-limit record/time=] is greater than [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
-1. Let |limit| be [=max aggregatable attributions per rate-limit window=].
-1. If |rateLimitScope| is "<code>[=rate-limit scope/event-attribution=]</code>", set |limit| to [=max event attributions per rate-limit window=].
-1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to |limit|, return <strong>blocked</strong>.
+1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to [=max attributions per rate-limit window=], return <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
 
 <h3 dfn id="should-block-processing-for-reporting-origin-limit">Should processing be blocked by reporting-origin limit</h3>
@@ -2915,13 +2906,13 @@ Given an [=attribution rate-limit record=] |newRecord|:
 Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 |sourceToAttribute|, and an [=attribution rate-limit record=] |newRecord|:
 
-1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|
+1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|,
     and |newRecord|'s [=attribution rate-limit record/scope=] is <strong>blocked</strong>:
     1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
     1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>",
         set |debugDataType| to "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with |debugDataType|, |trigger|, |sourceToAttribute| and
+        with |debugDataType|, |trigger|, |sourceToAttribute|, and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=should processing be blocked by reporting-origin limit=] with
@@ -2997,10 +2988,10 @@ an optional [=attribution source=] <dfn for="obtain debug data body on trigger r
 1. If |dataType| is:
     <dl class="switch">
     : "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event attributions per rate-limit window=],
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attributions per rate-limit window=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max aggregatable attributions per rate-limit window=],
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attributions per rate-limit window=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attribution reporting origins per rate-limit window=],
@@ -3099,7 +3090,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
     [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=]
-    and [=attribution rate-limit record/scope=] is equal to [=rate-limit scope/event-attribution=].
+    and [=attribution rate-limit record/scope=] is equal to "<code>[=rate-limit scope/event-attribution=]</code>".
 1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 

--- a/index.bs
+++ b/index.bs
@@ -2507,6 +2507,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/source time=]
         : [=attribution rate-limit record/expiry time=]
         :: |source|'s [=attribution source/expiry time=]
+        : [=attribution rate-limit record/entity ID=]
+        :: |source|'s [=attribution source/source identifier=]
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
         1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-success=]</code>" and |source|.

--- a/index.bs
+++ b/index.bs
@@ -1037,7 +1037,7 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 :: A [=moment=].
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
-: <dfn>entity ID</dfn>
+: <dfn>event-level report ID</dfn>
 :: Null or an [=event-level report=]'s [=event-level report/report ID=].
 
 </dl>
@@ -2566,7 +2566,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/source time=]
         : [=attribution rate-limit record/expiry time=]
         :: |source|'s [=attribution source/expiry time=]
-        : [=attribution rate-limit record/entity ID=]
+        : [=attribution rate-limit record/event-level report ID=]
         :: null
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
@@ -2599,7 +2599,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             :: |source|'s [=attribution source/source time=]
             : [=attribution rate-limit record/expiry time=]
             :: null
-            : [=attribution rate-limit record/entity ID=]
+            : [=attribution rate-limit record/event-level report ID=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
@@ -3122,7 +3122,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. [=set/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
-    [=attribution rate-limit record/entity ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
+    [=attribution rate-limit record/event-level report ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
     and [=attribution rate-limit record/scope=] is equal to "<code>[=rate-limit scope/event-attribution=]</code>".
 1. [=Assert=]: |rateLimitRecord| is not null.
 
@@ -3216,7 +3216,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/entity ID=]
+    : [=attribution rate-limit record/event-level report ID=]
     :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
@@ -3323,7 +3323,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/entity ID=]
+    : [=attribution rate-limit record/event-level report ID=]
     :: null
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,

--- a/index.bs
+++ b/index.bs
@@ -2870,7 +2870,8 @@ Given an [=attribution rate-limit record=] |newRecord|:
 1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" 
      or "<code>[=rate-limit scope/aggregatable-attribution=]</code>":
      1. Set |max| to [=max attribution reporting origins per rate-limit window=].
-     1. Set |scopeSet| be a [=set=] containing "<code>[=rate-limit scope/event-attribution=]</code>" and "<code>[=rate-limit scope/aggregatable-attribution=]</code>".
+     1. Set |scopeSet| to «"<code>[=rate-limit scope/event-attribution=]</code>", "<code>[=rate-limit scope/aggregatable-attribution=]</code>"».
+
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is present in |scopeSet|
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal

--- a/index.bs
+++ b/index.bs
@@ -1018,7 +1018,8 @@ A <dfn>rate-limit scope</dfn> is one of the following:
 
 <ul dfn-for="rate-limit scope">
 <li>"<dfn><code>source</code></dfn>"
-<li>"<dfn><code>attribution</code></dfn>"
+<li>"<dfn><code>event-attribution</code></dfn>"
+<li>"<dfn><code>aggregatable-attribution</code></dfn>"
 </ul>
 
 An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following items:
@@ -1036,6 +1037,8 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 :: A [=moment=].
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
+: <dfn>entity id</dfn>
+:: A [=event-level report=]'s [=event-level report/report id=] or [=aggregatable report=]'s [=aggregatable report/report id=] or [=attribution source/source identifier=].
 
 </dl>
 
@@ -1066,7 +1069,8 @@ Possible values are:
 <li>"<dfn><code>trigger-aggregate-insufficient-budget</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-storage-limit</code></dfn>"
 <li>"<dfn><code>trigger-aggregate-report-window-passed</code></dfn>"
-<li>"<dfn><code>trigger-attributions-per-source-destination-limit</code></dfn>"
+<li>"<dfn><code>trigger-event-attributions-per-source-destination-limit</code></dfn>"
+<li>"<dfn><code>trigger-aggregatable-attributions-per-source-destination-limit</code></dfn>"
 <li>"<dfn><code>trigger-event-deduplicated</code></dfn>"
 <li>"<dfn><code>trigger-event-excessive-reports</code></dfn>"
 <li>"<dfn><code>trigger-event-low-priority</code></dfn>"
@@ -1345,8 +1349,15 @@ positive integer that controls the maximum number of distinct
 [=attribution rate-limit record/attribution destination=]) that can create
 [=event-level reports=] per [=attribution rate-limit window=].
 
-<dfn>Max attributions per rate-limit window</dfn> is a positive integer that
-controls the maximum number of attributions for a
+<dfn>Max event attributions per rate-limit window</dfn> is a positive integer that
+controls the maximum number of event attributions for a
+([=attribution rate-limit record/source site=],
+[=attribution rate-limit record/attribution destination=],
+[=attribution rate-limit record/reporting origin=] [=site=]) per
+[=attribution rate-limit window=].
+
+<dfn>Max aggregatable attributions per rate-limit window</dfn> is a positive integer that
+controls the maximum number of aggregatable attributions for a
 ([=attribution rate-limit record/source site=],
 [=attribution rate-limit record/attribution destination=],
 [=attribution rate-limit record/reporting origin=] [=site=]) per
@@ -1607,7 +1618,8 @@ This algorithm will return either a non-negative 128-bit integer or an error.
 
 Given an [=attribution rate-limit record=] |record| and a [=moment=] |now|:
 1. If the [=duration from=] |record|'s [=attribution rate-limit record|time=] and |now| is <= [=attribution rate-limit window=] , return false.
-1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/attribution=]</code>", return true.
+1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>", return true.
+1. If |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return true.
 1. If |record|'s [=attribution rate-limit record/expiry time=] is after |now|, return false.
 1. Return true.
 
@@ -2519,7 +2531,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. [=map/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
         1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
             : [=attribution rate-limit record/scope=]
-            :: "<code>[=rate-limit scope/attribution=]</code>"
+            :: "<code>[=rate-limit scope/event-attribution=]</code>"
             : [=attribution rate-limit record/source site=]
             :: |source|'s [=attribution source/source site=]
             : [=attribution rate-limit record/attribution destination=]
@@ -2529,6 +2541,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/time=]
             :: |source|'s [=attribution source/source time=]
             : [=attribution rate-limit record/expiry time=]
+            :: null
+            : [=attribution rate-limit record/entity id=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
     1. Set |debugDataType| to "<code>[=source debug data type/source-noised=]</code>".
@@ -2852,15 +2866,17 @@ To <dfn>match an attribution source against filters and negated filters</dfn> gi
 
 <h3 dfn id="should-block-attribution-for-attribution-limit">Should attribution be blocked by attribution rate limit</h3>
 
-Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
+Given an [=attribution trigger=] |trigger|, [=attribution source=] |sourceToAttribute| and [=attribution rate-limit record/scope=] |rateLimitScope| :
 
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| of [=attribution rate-limit cache=] where all of the following are true:
-     * |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/attribution=]</code>"
+     * |record|'s [=attribution rate-limit record/scope=] is |rateLimitScope|
      * |record|'s [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
      * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
      * |record|'s [=attribution rate-limit record/reporting origin=] and |trigger|'s [=attribution trigger/reporting origin=] are [=same site=]
      * |record|'s [=attribution rate-limit record/time=] is greater than [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
-1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to [=max attributions per rate-limit window=], return <strong>blocked</strong>.
+1. Let |limit| be [=max aggregatable attributions per rate-limit window=]
+1. If |rateLimitScope| is [=rate-limit scope/event-attribution=], set |limit| = [=max event attributions per rate-limit window=]
+1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to |limit|, return <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
 
 <h3 dfn id="should-block-processing-for-reporting-origin-limit">Should processing be blocked by reporting-origin limit</h3>
@@ -2868,8 +2884,10 @@ Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToA
 Given an [=attribution rate-limit record=] |newRecord|:
 
 1. Let |max| be [=max source reporting origins per rate-limit window=].
-1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/attribution=]</code>", set |max| to
-     [=max attribution reporting origins per rate-limit window=].
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>", set |max| to
+     [=max event attribution reporting origins per rate-limit window=].
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |max| to
+     [=max aggregatable attribution reporting origins per rate-limit window=].
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] and |newRecord|'s [=attribution rate-limit record/scope=] are equal
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
@@ -2881,7 +2899,7 @@ Given an [=attribution rate-limit record=] |newRecord|:
 
     NOTE: [=rate-limit scope/source=] scopes have an auxiliary [=max source reporting origins per source reporting site=] rate limit that also must be enforced.
 
-1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/attribution=]</code>", return <strong>allowed</strong>
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return <strong>allowed</strong>
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/source=]</code>"
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
@@ -2894,14 +2912,17 @@ Given an [=attribution rate-limit record=] |newRecord|:
 <h3 dfn id="should-block-attribution-for-rate-limits">Should attribution be blocked by rate limits</h3>
 
 Given an [=attribution trigger=] |trigger|, an [=attribution source=]
-|sourceToAttribute|, and an [=attribution rate-limit record=] |newRecord|:
+|sourceToAttribute|, and an [=attribution rate-limit record/scope=] |scope|:
 
-1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger| and
-    |sourceToAttribute| is <strong>blocked</strong>:
-    1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
-        with "<code>[=trigger debug data type/trigger-attributions-per-source-destination-limit=]</code>", |trigger|, |sourceToAttribute| and
+1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|
+    and |scope| is <strong>blocked</strong>:
+    1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
+    2. If |scope| is "<code>[=rate-limit scope/aggregatable-attribution=]</code>", set |debugDataType| to 
+        "<code>[=trigger debug data type/trigger-aggregatable-attributions-per-source-destination-limit=]</code>"
+    3. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
+        with |debugDataType|, |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
-    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+    4. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
 1. If the result of running [=should processing be blocked by reporting-origin limit=] with
     |newRecord| is <strong>blocked</strong>:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -2974,8 +2995,11 @@ an optional [=attribution source=] <dfn for="obtain debug data body on trigger r
 1. Let |body| be a new [=map/is empty|empty=] [=map=].
 1. If |dataType| is:
     <dl class="switch">
-    : "<code>[=trigger debug data type/trigger-attributions-per-source-destination-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attributions per rate-limit window=],
+    : "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event attributions per rate-limit window=],
+         [=serialize an integer|serialized=].
+    : "<code>[=trigger debug data type/trigger-aggregatable-attributions-per-source-destination-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max aggregatable attributions per rate-limit window=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-reporting-origin-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attribution reporting origins per rate-limit window=],
@@ -3072,15 +3096,18 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
     return "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>".
 1. [=set/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
+1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose 
+    [=attribution rate-limit record/entity id=] is equal to |report|'s [=event-level report/report id=]
+    and [=attribution rate-limit record/=] is equal to [=rate-limit scope/event-attribution=].
+1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 
 Issue: This algorithm is not compatible with the behavior proposed for
 [=experimental Flexible Event support=] with differing
 [=trigger spec/event-level report windows=] for a given source.
 
-To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger|, an
-[=attribution source=] |sourceToAttribute|, and an
-[=attribution rate-limit record=] |rateLimitRecord|, run the following steps:
+To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |trigger|, and an
+[=attribution source=] |sourceToAttribute|, run the following steps:
 
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=list/is empty=], return the [=triggering result=]
@@ -3142,12 +3169,27 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
         with "<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", |trigger|, |sourceToAttribute| and
         [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
-1. If the result of running [=should attribution be blocked by rate limits=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
-    return it.
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|,
     |trigger|'s [=attribution trigger/trigger time=], |trigger|'s [=attribution trigger/debug key=],
     |matchedConfig|'s [=event-level trigger configuration/priority=], and |specEntry|.
+1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
+    : [=attribution rate-limit record/scope=]
+    :: "<code>[=rate-limit scope/event-attribution=]</code>"
+    : [=attribution rate-limit record/source site=]
+    :: |sourceToAttribute|'s [=attribution source/source site=]
+    : [=attribution rate-limit record/attribution destination=]
+    :: |trigger|'s [=attribution trigger/attribution destination=]
+    : [=attribution rate-limit record/reporting origin=]
+    :: |sourceToAttribute|'s [=attribution source/reporting origin=]
+    : [=attribution rate-limit record/time=]
+    :: |sourceToAttribute|'s [=attribution source/source time=]
+    : [=attribution rate-limit record/expiry time=]
+    :: null
+    : [=attribution rate-limit record/entity id=]
+    :: |report|'s [=event-level report/report id=]
+1. If the result of running [=should attribution be blocked by rate limits=]
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
+    return it.
 1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
     is false:
      1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
@@ -3190,13 +3232,13 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     |report|'s [=event-level report/source debug key=] is not null and |report|'s
     [=event-level report/trigger debug key=] is not null, [=queue a task=] to
     [=attempt to deliver a debug report=] with |report|.
+1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Return the [=triggering result=] (|triggeringStatus|, |debugData|).
 
 <h3 algorithm id="triggering-aggregatable-attribution">Triggering aggregatable attribution</h3>
 
-To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger|, an
-[=attribution source=] |sourceToAttribute|, and an
-[=attribution rate-limit record=] |rateLimitRecord|, run the following steps:
+To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] |trigger|, and an
+[=attribution source=] |sourceToAttribute|, run the following steps:
 
 1. If the result of running [=check if an attribution trigger contains aggregatable data=] is false,
     return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", null).
@@ -3237,8 +3279,23 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
          with "<code>[=trigger debug data type/trigger-aggregate-storage-limit=]</code>", |trigger|, |sourceToAttribute| and
          [=obtain debug data on trigger registration/report=] set to null.
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>", |debugData|).
+1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
+    : [=attribution rate-limit record/scope=]
+    :: "<code>[=rate-limit scope/aggregatable-attribution=]</code>"
+    : [=attribution rate-limit record/source site=]
+    :: |sourceToAttribute|'s [=attribution source/source site=]
+    : [=attribution rate-limit record/attribution destination=]
+    :: |trigger|'s [=attribution trigger/attribution destination=]
+    : [=attribution rate-limit record/reporting origin=]
+    :: |sourceToAttribute|'s [=attribution source/reporting origin=]
+    : [=attribution rate-limit record/time=]
+    :: |sourceToAttribute|'s [=attribution source/source time=]
+    : [=attribution rate-limit record/expiry time=]
+    :: null
+    : [=attribution rate-limit record/entity id=]
+    :: |report|'s [=aggregatable report/report id=]
 1. If the result of running [=should attribution be blocked by rate limits=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|'s [=attribution rate-limit record/scope=] is not null,
     return it.
 1. If |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value is equal to [=max aggregatable reports per source=], then:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=] with
@@ -3259,6 +3316,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. If |report|'s [=aggregatable report/source debug key=] is not null and |report|'s
     [=aggregatable report/trigger debug key=] is not null, [=queue a task=] to
     [=attempt to deliver a debug report=] with |report|.
+1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Return the [=triggering result=] ("<code>[=triggering status/attributed=]</code>", null).
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
@@ -3323,21 +3381,8 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
 1. [=list/iterate|For each=] |item| of |matchingSources|:
     1. [=set/Remove=] |item| from the [=attribution source cache=].
-1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
-    : [=attribution rate-limit record/scope=]
-    :: "<code>[=rate-limit scope/attribution=]</code>"
-    : [=attribution rate-limit record/source site=]
-    :: |sourceToAttribute|'s [=attribution source/source site=]
-    : [=attribution rate-limit record/attribution destination=]
-    :: |trigger|'s [=attribution trigger/attribution destination=]
-    : [=attribution rate-limit record/reporting origin=]
-    :: |sourceToAttribute|'s [=attribution source/reporting origin=]
-    : [=attribution rate-limit record/time=]
-    :: |sourceToAttribute|'s [=attribution source/source time=]
-    : [=attribution rate-limit record/expiry time=]
-    :: null
 1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord|.
+    with |trigger|, |sourceToAttribute|.
 1. Let |aggregatableResult| be the result of running [=trigger aggregatable attribution=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord|.
 1. Let |eventLevelDebugData| be |eventLevelResult|'s [=triggering result/debug data=].
@@ -3353,11 +3398,6 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
 1. If |hasAggregatableData| and |aggregatableResult|'s [=triggering result/status=] is "<code>[=triggering status/dropped=]</code>",
     run [=generate null reports and assign private state tokens=] with |trigger| and
     [=generate null reports and assign private state tokens/report=] set to null.
-1. If both |eventLevelResult|'s [=triggering result/status=] and |aggregatableResult|'s
-    [=triggering result/status=] are "<code>[=triggering status/dropped=]</code>", return.
-1. If neither |eventLevelResult|'s [=triggering result/status=] nor |aggregatableResult|'s
-    [=triggering result/status=] is "<code>[=triggering status/attributed=]</code>", return.
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. [=list/Remove=] all [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if the result of running
     [=can attribution rate-limit record be removed=] with |entry| and |trigger|'s [=attribution trigger/trigger time=] is true.
 

--- a/index.bs
+++ b/index.bs
@@ -3125,6 +3125,11 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
     [=attribution rate-limit record/entity ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
     and [=attribution rate-limit record/scope=] is equal to "<code>[=rate-limit scope/event-attribution=]</code>".
 1. [=Assert=]: |rateLimitRecord| is not null.
+
+    Note: We are making an implicit assumption that [=attribution rate-limit window=] is 
+    greater than or equal to |sourceToAttribute|'s [=attribution source/expiry=]. 
+    If this assumption does not hold then |rateLimitRecord| might be null.
+
 1. [=set/Remove=] |rateLimitRecord| from the [=attribution rate-limit cache=].
 1. Return "<code>[=event-level-report-replacement result/add-new-report=]</code>".
 

--- a/index.bs
+++ b/index.bs
@@ -1038,7 +1038,7 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
 : <dfn>entity ID</dfn>
-:: An [=event-level report=]'s [=event-level report/report ID=] or an
+:: Null or an [=event-level report=]'s [=event-level report/report ID=] or an
     [=aggregatable report=]'s [=aggregatable report/report ID=] or an
     [=attribution source=]'s [=attribution source/source identifier=].
 
@@ -2893,7 +2893,7 @@ Given an [=attribution rate-limit record=] |newRecord|:
 
     NOTE: [=rate-limit scope/source=] scopes have an auxiliary [=max source reporting origins per source reporting site=] rate limit that also must be enforced.
 
-1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return <strong>allowed</strong>
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/event-attribution=]</code>" or "<code>[=rate-limit scope/aggregatable-attribution=]</code>", return <strong>allowed</strong>.
 1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/source=]</code>"
      * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
@@ -2910,9 +2910,9 @@ Given an [=attribution trigger=] |trigger|, an [=attribution source=]
 
 1. If the result of running [=should attribution be blocked by attribution rate limit=] with |trigger|, |sourceToAttribute|,
     and |newRecord|'s [=attribution rate-limit record/scope=] is <strong>blocked</strong>:
-    1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
+    1. Let |debugDataType| be "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>".
     1. If |newRecord|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/aggregatable-attribution=]</code>",
-        set |debugDataType| to "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
+        set |debugDataType| to "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>".
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=]
         with |debugDataType|, |trigger|, |sourceToAttribute|, and
         [=obtain debug data on trigger registration/report=] set to null.
@@ -2990,8 +2990,6 @@ an optional [=attribution source=] <dfn for="obtain debug data body on trigger r
 1. If |dataType| is:
     <dl class="switch">
     : "<code>[=trigger debug data type/trigger-event-attributions-per-source-destination-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attributions per rate-limit window=],
-         [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-aggregate-attributions-per-source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max attributions per rate-limit window=],
          [=serialize an integer|serialized=].
@@ -3288,7 +3286,8 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     : [=attribution rate-limit record/entity ID=]
     :: |report|'s [=aggregatable report/report ID=]
 1. If the result of running [=should attribution be blocked by rate limits=]
-    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
+    with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
+    return it.
 1. If |sourceToAttribute|'s [=attribution source/number of aggregatable reports=] value is equal to [=max aggregatable reports per source=], then:
     1. Let |debugData| be the result of running [=obtain debug data on trigger registration=] with
         "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", |trigger|, |sourceToAttribute|, and |report|.

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -138,7 +138,7 @@ This table defines the fields in the `body` dictionary.
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-attributions-per-source-destination-limit`](#trigger-event-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-aggregate-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-reporting-origin-limit`](#trigger-reporting-origin-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-deduplicated`](#trigger-event-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-no-matching-configurations`](#trigger-event-no-matching-configurations) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -44,10 +44,10 @@ A trigger is rejected due to no matching sources in storage that match <reportin
 A trigger is rejected due to no [matching filter data](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-attribution-filters).
 
 #### `trigger-event-attributions-per-source-destination-limit`
-An event-level report is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
+An event-level attribution is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
 
 #### `trigger-aggregate-attributions-per-source-destination-limit`
-An aggregatable report is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
+An aggregatable attribution is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
 
 #### `trigger-reporting-origin-limit`
 A trigger is rejected due to the [attributed reporting origin limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits).

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -136,7 +136,8 @@ This table defines the fields in the `body` dictionary.
 | [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [`trigger-event-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-reporting-origin-limit`](#trigger-reporting-origin-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-deduplicated`](#trigger-event-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-no-matching-configurations`](#trigger-event-no-matching-configurations) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -137,7 +137,7 @@ This table defines the fields in the `body` dictionary.
 | [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [`trigger-event-attributions-per-source-destination-limit`](#trigger-event-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-reporting-origin-limit`](#trigger-reporting-origin-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [`trigger-event-deduplicated`](#trigger-event-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -43,8 +43,11 @@ A trigger is rejected due to no matching sources in storage that match <reportin
 #### `trigger-no-matching-filter-data`
 A trigger is rejected due to no [matching filter data](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-attribution-filters).
 
-#### `trigger-attributions-per-source-destination-limit`
-A trigger is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
+#### `trigger-event-attributions-per-source-destination-limit`
+An event-level report is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
+
+#### `trigger-aggregate-attributions-per-source-destination-limit`
+An aggregatable report is rejected due to the [max attributions rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits).
 
 #### `trigger-reporting-origin-limit`
 A trigger is rejected due to the [attributed reporting origin limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits).


### PR DESCRIPTION
Currently, we have a single rate-limit which counts the overall attribution (either event or aggregate or both) of the trigger. This change separates the attribution counts for event & aggregate for accurate counting of reported conversions. This will facilitate easier report deletions counting as well as accurate counting for [Full Flex proposal](https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md) where more than 1 event report may be generated per trigger.

#### Deletion Issue:
1. Let's say there is 1 source (event) which is registered at t = 0: S
1. Trigger T1 registered at T = 1 and generates an event report E1 (priority=1) and no aggregatable reports
1. Trigger T2 registered at T = 2 and generates an event report E2 (priority=2) and no aggregatable reports. E2 will replace E1 here due to higher priority.

##### Current Implementation:
We will count this as 2 attribution which is incorrect because E1 is never delivered.

##### With Proposed Changes:
We will count this as 1 event-attribution for E2 and 0 for E1 (rate-limit is deleted when we replace the report)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vikassahu29/attribution-reporting-api/pull/1211.html" title="Last updated on Apr 4, 2024, 5:23 PM UTC (2b78ed3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1211/c21d9ff...vikassahu29:2b78ed3.html" title="Last updated on Apr 4, 2024, 5:23 PM UTC (2b78ed3)">Diff</a>