### PR TITLE
Prevent coalescing for web source/trigger headers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -67,7 +67,6 @@ spec: structured header; type: dfn; urlPrefix: https://httpwg.org/specs/rfc8941;
         text: token; url: #token
 spec: infra; type: dfn; urlPrefix: https://infra.spec.whatwg.org/
     text: starts with; url: #string-starts-with
-    text: byte case insensitive; url: #byte-case-insensitive
 spec: fenced-frame; type: dfn; urlPrefix: https://wicg.github.io/fenced-frame/;
     for: navigable
         text: top-level traversable; url: #navigable-top-level-traversable
@@ -1839,17 +1838,16 @@ a [=header value=] or null |webTriggerHeader|, a [=header value=] or null
 
      </dl>
 
-To <dfn export>get the first non-coalesced header</dfn> given a [=response/header list=] |headers|,
+To <dfn>get the first non-coalesced header</dfn> given a [=response/header list=] |headers|
 and a [=header name=] header:
 1. Let |non-coalesced-headers| be the result of [=get non-coalesced headers=] with |headers| and |header|.
 1. If |non-coalesced-headers| [=list/is empty=], return null.
 1. Return |non-coalesced-headers|[0].
 
-To <dfn export>get non-coalesced headers</dfn> given a [=response/header list=] |headers|,
+To <dfn>get non-coalesced headers</dfn> given a [=response/header list=] |headers|
 and a [=header name=] header:
-1. If |headers| does not [=header list/contain=] |header|, return a new [=list=].
 1. Return the [=header value|values=] of all [=header|headers=] in |headers| whose [=header name|name=]
-    is a [=byte case insensitive=] match for |header|, in order.
+    is a [=byte-case-insensitive=] match for |header|, in order.
 
 To <dfn export>process an attribution eligible response</dfn> given a [=suitable origin=]
 |contextOrigin|, an [=eligibility=] |eligibility|, and a [=response=] |response|:

--- a/index.bs
+++ b/index.bs
@@ -1840,10 +1840,10 @@ a [=header value=] or null |webTriggerHeader|, a [=header value=] or null
 
      </dl>
 
-To <dfn>get the first non-coalesced header</dfn> given a [=response/header list=] |headers|
+To <dfn>get non-coalesced header</dfn> given a [=response/header list=] |headers|
 and a [=header name=] header:
 1. Let |non-coalesced-headers| be the result of [=get non-coalesced headers=] with |headers| and |header|.
-1. If |non-coalesced-headers| [=list/is empty=], return null.
+1. If |non-coalesced-headers|'s [=list/size=] is not equal to 1, return null.
 1. Return |non-coalesced-headers|[0].
 
 To <dfn>get non-coalesced headers</dfn> given a [=response/header list=] |headers|
@@ -1871,10 +1871,10 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
     "<code>[=eligibility/event-source-or-trigger=]</code>".
 1. Let |reportingOrigin| be |response|'s [=response/URL=]'s [=url/origin=].
 1. If |reportingOrigin| is not [=check if an origin is suitable|suitable=], return.
-1. Let |sourceHeader| be the result of [=get the first non-coalesced header|getting=]
+1. Let |sourceHeader| be the result of [=get non-coalesced header|getting=]
     "`Attribution-Reporting-Register-Source`" from |response|'s
     [=response/header list=].
-1. Let |triggerHeader| be the result of [=get the first non-coalesced header|getting=]
+1. Let |triggerHeader| be the result of [=get non-coalesced header|getting=]
     "`Attribution-Reporting-Register-Trigger`" from |response|'s
     [=response/header list=].
 1. Let |osSourceHeader| be the result of [=header list/get|getting=]

--- a/index.bs
+++ b/index.bs
@@ -1840,12 +1840,6 @@ a [=header value=] or null |webTriggerHeader|, a [=header value=] or null
 
      </dl>
 
-To <dfn>get non-coalesced header</dfn> given a [=response/header list=] |headers|
-and a [=header name=] header:
-1. Let |non-coalesced-headers| be the result of [=get non-coalesced headers=] with |headers| and |header|.
-1. If |non-coalesced-headers|'s [=list/size=] is not equal to 1, return null.
-1. Return |non-coalesced-headers|[0].
-
 To <dfn>get non-coalesced headers</dfn> given a [=response/header list=] |headers|
 and a [=header name=] header:
 1. Return the [=header value|values=] of all [=header|headers=] in |headers| whose [=header name|name=]
@@ -1871,12 +1865,16 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
     "<code>[=eligibility/event-source-or-trigger=]</code>".
 1. Let |reportingOrigin| be |response|'s [=response/URL=]'s [=url/origin=].
 1. If |reportingOrigin| is not [=check if an origin is suitable|suitable=], return.
-1. Let |sourceHeader| be the result of [=get non-coalesced header|getting=]
-    "`Attribution-Reporting-Register-Source`" from |response|'s
-    [=response/header list=].
-1. Let |triggerHeader| be the result of [=get non-coalesced header|getting=]
-    "`Attribution-Reporting-Register-Trigger`" from |response|'s
-    [=response/header list=].
+1. Let |sourceHeaders| be the result of [=get non-coalesced headers=] with |response|'s
+    [=response/header list=] and "`Attribution-Reporting-Register-Source`".
+1. If |sourceHeaders|'s [=list/size=] is greater than 1, return.
+1. Let |sourceHeader| be null.
+1. If |sourceHeaders|'s [=list/size=] is equal to 1, set |sourceHeader| to |sourceHeaders|[0].
+1. Let |triggerHeaders| be the result of [=get non-coalesced headers=] with |response|'s
+    [=response/header list=] and "`Attribution-Reporting-Register-Trigger`".
+1. If |triggerHeaders|'s [=list/size=] is greater than 1, return.
+1. Let |triggerHeader| be null.
+1. If |triggerHeaders|'s [=list/size=] is equal to 1, set |triggerHeader| to |triggerHeaders|[0].
 1. Let |osSourceHeader| be the result of [=header list/get|getting=]
     "`Attribution-Reporting-Register-OS-Source`" from |response|'s
     [=response/header list=].

--- a/index.bs
+++ b/index.bs
@@ -67,6 +67,7 @@ spec: structured header; type: dfn; urlPrefix: https://httpwg.org/specs/rfc8941;
         text: token; url: #token
 spec: infra; type: dfn; urlPrefix: https://infra.spec.whatwg.org/
     text: starts with; url: #string-starts-with
+    text: byte case insensitive; url: #byte-case-insensitive
 spec: fenced-frame; type: dfn; urlPrefix: https://wicg.github.io/fenced-frame/;
     for: navigable
         text: top-level traversable; url: #navigable-top-level-traversable
@@ -1838,6 +1839,18 @@ a [=header value=] or null |webTriggerHeader|, a [=header value=] or null
 
      </dl>
 
+To <dfn export>get the first non-coalesced header</dfn> given a [=response/header list=] |headers|,
+and a [=header name=] header:
+1. Let |non-coalesced-headers| be the result of [=get non-coalesced headers=] with |headers| and |header|.
+1. If |non-coalesced-headers| [=list/is empty=], return null.
+1. Return |non-coalesced-headers|[0].
+
+To <dfn export>get non-coalesced headers</dfn> given a [=response/header list=] |headers|,
+and a [=header name=] header:
+1. If |headers| does not [=header list/contain=] |header|, return a new [=list=].
+1. Return the [=header value|values=] of all [=header|headers=] in |headers| whose [=header name|name=]
+    is a [=byte case insensitive=] match for |header|, in order.
+
 To <dfn export>process an attribution eligible response</dfn> given a [=suitable origin=]
 |contextOrigin|, an [=eligibility=] |eligibility|, and a [=response=] |response|:
 
@@ -1858,10 +1871,10 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
     "<code>[=eligibility/event-source-or-trigger=]</code>".
 1. Let |reportingOrigin| be |response|'s [=response/URL=]'s [=url/origin=].
 1. If |reportingOrigin| is not [=check if an origin is suitable|suitable=], return.
-1. Let |sourceHeader| be the result of [=header list/get|getting=]
+1. Let |sourceHeader| be the result of [=get the first non-coalesced header|getting=]
     "`Attribution-Reporting-Register-Source`" from |response|'s
     [=response/header list=].
-1. Let |triggerHeader| be the result of [=header list/get|getting=]
+1. Let |triggerHeader| be the result of [=get the first non-coalesced header|getting=]
     "`Attribution-Reporting-Register-Trigger`" from |response|'s
     [=response/header list=].
 1. Let |osSourceHeader| be the result of [=header list/get|getting=]


### PR DESCRIPTION
fixes: https://github.com/WICG/attribution-reporting-api/issues/1202

- Prevent header coalescing when receiving the web registration headers.
- Reject the headers if more than 1 is received.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/agarant/attribution-reporting-api/pull/1212.html" title="Last updated on Mar 27, 2024, 3:39 PM UTC (30f5805)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1212/7e8b4c9...agarant:30f5805.html" title="Last updated on Mar 27, 2024, 3:39 PM UTC (30f5805)">Diff</a>