### PR TITLE
Deactivate earliest destinations if exceeding distinct destination limit for unexpired sources

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -1148,8 +1148,7 @@ attack, the browser should maintain these limits per reporting site. This
 effectively limits the number of unique sites covered per {source site, reporting site} applied to all unexpired sources regardless of type at source time.
 
 The browser can also limit the number of `destination` sites per {source site, reporting site, 1 day}
-to mitigate the history reconstruction attack as new `destination` sites can be
-registered when the `priority_fifo` algorithm is used.
+to mitigate the history reconstruction attack.
 
 #### Limiting the number of unique destinations per source site
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -1115,30 +1115,23 @@ sites represented by unexpired sources for a source-site.
 
 The browser can place a limit on the number of a source site's unexpired source's
 unique `destination` sites. Source registrations will accept an optional field
-`destination_limit` to allow developers to select the behavior when an attribution
-source is registered for a site that is not already registered by any of the
-unexpired sources and a source site is at its limit.
+`destination_limit_priority` to allow developers to prioritize the destinations
+registered with this source with respect to other destinations for the purpose
+of source deactivation.
 
 ```jsonc
 {
   ..., // existing fields
-  "destination_limit": {
-    "algorithm": "lifo", // or "priority_fifo", defaults to "lifo" if not present
-    "priority": "[64-bit signed integer]" // defaults to 0 if not present
-  }
+  "destination_limit_priority": "[64-bit signed integer]" // defaults to 0 if not present
 }
 ```
 
-The `priority` field is used to prioritize the destinations registered with this
-source with respect to other destinations for the purpose of source deactivation.
-
-The `algorithm` field is used to select the algorithm to determine the final
-`destination` sites that the browser selects. When "lifo" is used, the browser
-will drop the new source if the source site is at its limit. When "priority_fifo"
-is used, the browser will sort the `destination` sites registered by unexpired
-sources, including the new source, by `priority` in descending order and by
-the registration time in descending order. The browser will then select the
-first few `destination` sites within this limit, and delete pending sources and
+When an attribution source is registered for a site that is not already in the
+unexpired sources and a source site is at its limit, the browser will sort the
+`destination` sites registered by unexpired sources, including the new source,
+by `destination_limit_priority` in descending order and by the registration
+time in descending order. The browser will then select the first few
+`destination` sites within this limit, and delete pending sources and
 aggregatable reports associated with the unselected `destination` sites. The
 event-level reports are not deleted as the leak of user's browsing history is
 mitigated by fake reports within differential privacy.

--- a/EVENT.md
+++ b/EVENT.md
@@ -1132,8 +1132,8 @@ unexpired sources and a source site is at its limit, the browser will sort the
 by `destination_limit_priority` in descending order and by the registration
 time in descending order. The browser will then select the first few
 `destination` sites within this limit, and delete pending sources and
-aggregatable reports associated with the unselected `destination` sites. The
-event-level reports are not deleted as the leak of user's browsing history is
+aggregatable reports associated with the unselected `destination` sites. Any
+event-level reports are not deleted, as the leak of user's browsing history is
 mitigated by fake reports within differential privacy.
 
 The lower this value, the harder it is for a reporting origin to use the API to

--- a/EVENT.md
+++ b/EVENT.md
@@ -1114,9 +1114,34 @@ trying to measure user visits on, the browser can limit the number `destination`
 sites represented by unexpired sources for a source-site.
 
 The browser can place a limit on the number of a source site's unexpired source's
-unique `destination` sites. When an attribution source is registered for a site
-that is not already in the unexpired sources and a source site is at its limit,
-the browser will drop the new source.
+unique `destination` sites. Source registrations will accept an optional field
+`destination_limit` to allow developers to select the behavior when an attribution
+source is registered for a site that is not already registered by any of the
+unexpired sources and a source site is at its limit.
+
+```jsonc
+{
+  ..., // existing fields
+  "destination_limit": {
+    "algorithm": "lifo", // or "priority_fifo", defaults to "lifo" if not present
+    "priority": "[64-bit signed integer]" // defaults to 0 if not present
+  }
+}
+```
+
+The `priority` field is used to prioritize the destinations registered with this
+source with respect to other destinations for the purpose of source deactivation.
+
+The `algorithm` field is used to select the algorithm to determine the final
+`destination` sites that the browser selects. When "lifo" is used, the browser
+will drop the new source if the source site is at its limit. When "priority_fifo"
+is used, the browser will sort the `destination` sites registered by unexpired
+sources, including the new source, by `priority` in descending order and by
+the registration time in descending order. The browser will then select the
+first few `destination` sites within this limit, and delete pending sources and
+aggregatable reports associated with the unselected `destination` sites. The
+event-level reports are not deleted as the leak of user's browsing history is
+mitigated by fake reports within differential privacy.
 
 The lower this value, the harder it is for a reporting origin to use the API to
 try and measure user browsing activity not associated with ads being shown.
@@ -1128,6 +1153,10 @@ origin on a site to push the other attribution sources out of the browser. See
 the [denial of service](#denial-of-service) for more details. To prevent this
 attack, the browser should maintain these limits per reporting site. This
 effectively limits the number of unique sites covered per {source site, reporting site} applied to all unexpired sources regardless of type at source time.
+
+The browser can also limit the number of `destination` sites per {source site, reporting site, 1 day}
+to mitigate the history reconstruction attack as new `destination` sites can be
+registered when the `priority_fifo` algorithm is used.
 
 #### Limiting the number of unique destinations per source site
 

--- a/index.bs
+++ b/index.bs
@@ -2375,7 +2375,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>destination</code></dfn>"
-<li>"<dfn><code>destination_limit</code></dfn>"
+<li>"<dfn><code>destination_limit_priority</code></dfn>"
 <li>"<dfn><code>end_times</code></dfn>"
 <li>"<dfn><code>event_level_epsilon</code></dfn>"
 <li>"<dfn><code>event_report_window</code></dfn>"
@@ -2681,19 +2681,10 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     [=parse an optional 64-bit signed integer=] with |value|, "<code>[=source-registration JSON key/priority=]</code>", and
     0.
 1. If |priority| is an error, return null.
-1. Let |destinationLimitAlgorithm| be "<code>[=destination limit algorithm/lifo=]</code>".
-1. Let |destinationLimitPriority| be 0.
-1. If |value|["<code>[=source-registration JSON key/destination_limit=]</code>"] [=map/exists=]:
-    1. Let |destinationLimit| be |value|["<code>[=source-registration JSON key/destination_limit=]</code>"].
-    1. If |destinationLimit| is not a [=map=], return null.
-    1. Set |destinationLimitPriority| to the result of running
-        [=parse an optional 64-bit signed integer=] with |destinationLimit|,
-        "<code>[=source-registration JSON key/priority=]</code>", and 0.
-    1. If |destinationLimitPriority| is an error, return null.
-    1. If |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"] [=map/exists=]:
-        1. If |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"] is not
-            a [=destination limit algorithm=], return null.
-        1. Set |destinationLimitAlgorithm| to |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"].
+1. Let |destinationLimitPriority| be the result of running
+    [=parse an optional 64-bit signed integer=] with |value|,
+    "<code>[=source-registration JSON key/destination_limit_priority=]</code>", and 0.
+1. If |destinationLimitPriority| is an error, return null.
 1. Let |filterData| be a new [=filter map=].
 1. If |value|["<code>[=source-registration JSON key/filter_data=]</code>"] [=map/exists=]:
     1. Set |filterData| to the result of running [=parse filter data=] with
@@ -3018,8 +3009,7 @@ optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
         [=serialize an integer|serialized=].
 
     Note: The "`source_destination_limit`" field may be included to indicate that
-    [=max destinations covered by unexpired sources=] was hit and
-    the [=destination limit algorithm/priority_fifo=] algorithm was applied, which is not
+    [=max destinations covered by unexpired sources=] was hit, which is not
     reported as "<code>[=source debug data type/source-destination-limit=]</code>" to prevent side-channel
     leakage of cross-origin data.
 
@@ -3133,16 +3123,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Let |sourcesToDeleteForDestinationLimit| be the result of running [=get sources to delete for the unexpired destination limit=]
     with |source|.
 1. Let |destinationLimitHit| be false if |sourcesToDeleteForDestinationLimit| [=set/is empty=], true otherwise.
-1. Let |dropNewSource| be false.
-1. If |source|'s [=attribution source/destination limit algorithm=] is:
-    <dl class="switch">
-    : "<code>[=destination limit algorithm/priority_fifo=]</code>"
-    :: Set |dropNewSource| to true if |sourcesToDeleteForDestinationLimit| [=set/contains=] |source|'s [=attribution source/source identifier=].
-    : "<code>[=destination limit algorithm/lifo=]</code>"
-    :: Set |dropNewSource| to |destinationLimitHit|.
-
-    </dl>
-1. If |dropNewSource| is true:
+1. If |sourcesToDeleteForDestinationLimit| [=set/contains=] |source|'s [=attribution source/source identifier=]:
     1. Run [=obtain and deliver a verbose debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
     1. Return.
 1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
@@ -3150,7 +3131,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Let |isNoised| be true if |source|'s [=attribution source/randomized response=]
     is not null, otherwise false.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
-    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>",
+    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-destination-global-rate-limit=]</code>",
         |source|, |isNoised|, and |destinationLimitHit|.
     1. Return.
 1. Let |newRateLimitRecords| be a new [=set=].
@@ -3174,7 +3155,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/destination limit priority=]
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
-        1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>",
+        1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-reporting-origin-limit=]</code>",
             |source|, |isNoised|, and |destinationLimitHit|.
         1. Return.
     1. [=set/Append=] |rateLimitRecord| to |newRateLimitRecords|.

--- a/index.bs
+++ b/index.bs
@@ -3093,7 +3093,7 @@ and a [=boolean=] |isNoised|:
 
 To <dfn>obtain and deliver debug reports on source registration</dfn>
 given a [=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
-, and an optional [=boolean=] |isNoised| (default false):
+and an optional [=boolean=] |isNoised| (default false):
 
 1. Run [=obtain and deliver a verbose debug report on source registration=]
     with |dataTypes|, |source|, and |isNoised|.
@@ -3226,7 +3226,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=set/Append=] "<code>[=source debug data type/source-success=]</code>" to
     |debugDataTypes|.
 1. Run [=obtain and deliver debug reports on source registration=] with
-    |debugDataTypes|, |source| and |isNoised|.
+    |debugDataTypes|, |source|, and |isNoised|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the

--- a/index.bs
+++ b/index.bs
@@ -2858,12 +2858,12 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
 1. [=set/iterate|For each=] [=attribution source=] |source| of the [=attribution source cache=]:
     1. [=set/Remove=] |source| from the [=attribution source cache=] if |sourcesToDelete|
         [=set/contains=] |source|'s [=attribution source/source identifier=].
+1. Let |deletedEventLevelReports| be a new [=set=].
 1. [=set/iterate|For each=] [=event-level report=] |report| of the [=event-level report cache=]:
-    1. If |report|'s [=event-level report/trigger time=] is greater than or equal to |now|,
-        [=set/remove=] |report| from the [=event-level report cache=].
-
-        Note: This would only delete [=obtain a fake report|fake reports=] that would never be
-        stored if they were true [=event-level reports=].
+    1. If |sourcesToDelete| [=set/contains=] |report|'s [=event-level report/source identifier=]
+        and |report|'s [=event-level report/trigger time=] is greater than or equal to |now|:
+        1. [=set/Append=] |report|'s [=event-level report/report ID=] to |deletedEventLevelReports|.
+        1. [=set/Remove=] |report| from the [=event-level report cache=].
 1. Let |deletedAggregatableReports| be a new [=set=].
 1. [=set/iterate|For each=] [=aggregatable attribution report=] |report| of the [=aggregatable attribution report cache=]:
     1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable attribution report/source identifier=]:
@@ -2875,6 +2875,9 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
         : "<code>[=rate-limit scope/source=]</code>"
         :: Set |record|'s [=attribution rate-limit record/deactivated for unexpired destination limit=] to
             true if |sourcesToDelete| [=set/contains=] |record|'s [=attribution rate-limit record/entity ID=].
+        : "<code>[=rate-limit scope/event-attribution=]</code>"
+        :: [=set/Remove=] |record| from the [=attribution rate-limit cache=] if
+            |deletedEventLevelReports| [=set/contains=] |record|'s [=attribution rate-limit record/entity ID=].
         : "<code>[=rate-limit scope/aggregatable-attribution=]</code>"
         :: [=set/Remove=] |record| from the [=attribution rate-limit cache=] if
             |deletedAggregatableReports| [=set/contains=] |record|'s [=attribution rate-limit record/entity ID=].

--- a/index.bs
+++ b/index.bs
@@ -843,6 +843,8 @@ An attribution source is a [=struct=] with the following items:
 :: Number of [=aggregatable debug reports=] created for this [=attribution source=].
 : <dfn>aggregatable debug reporting config</dfn>
 :: An [=aggregatable debug reporting config=].
+: <dfn>destination limit priority</dfn>
+:: A 64-bit integer.
 
 </dl>
 
@@ -995,7 +997,9 @@ An <dfn>attribution debug info</dfn> is a [=tuple=] with the following items:
 : <dfn>source debug key</dfn>
 :: Null or a [=string=].
 : <dfn>trigger debug key</dfn>
-:: Null or a [=string=].
+:: Null or a non-negative 64-bit integer.
+: <dfn>source identifier</dfn>
+:: A [=string=].
 
 </dl>
 
@@ -1016,8 +1020,6 @@ An event-level report is an [=attribution report=] with the following additional
 :: A 64-bit integer.
 : <dfn>trigger time</dfn>
 :: A [=moment=].
-: <dfn>source identifier</dfn>
-:: A string.
 : <dfn>attribution destinations</dfn>
 :: A [=set=] of [=sites=].
 : <dfn>attribution debug info</dfn>
@@ -1094,8 +1096,14 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 :: A [=moment=].
 : <dfn>expiry time</dfn>
 :: Null or a [=moment=].
-: <dfn>event-level report ID</dfn>
-:: Null or an [=event-level report=]'s [=event-level report/report ID=].
+: <dfn>entity ID</dfn>
+:: Null for [=obtain a fake report|fake reports=] or an [=event-level report=]'s [=event-level report/report ID=] or an
+    [=aggregatable report=]'s [=aggregatable report/report ID=] or an
+    [=attribution source=]'s [=attribution source/source identifier=].
+: <dfn>deactivated for unexpired destination limit</dfn> (default false)
+:: A [=boolean=].
+: <dfn>destination limit priority</dfn> (default null)
+:: Null or a 64-bit integer.
 
 </dl>
 
@@ -1128,6 +1136,7 @@ Possible values are:
 <li>"<dfn><code>source-destination-global-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
+<li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
@@ -1433,6 +1442,11 @@ for [=attribution sources=] with a given [=attribution source/source site=] per 
 The second controls the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
 for [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=])
 per [=destination rate-limit window=].
+
+<dfn>Max destinations per source reporting site per day</dfn> is an integer controls
+the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
+for [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=])
+per day.
 
 <dfn>Max source reporting origins per rate-limit window</dfn> is a positive
 integer that controls the maximum number of distinct
@@ -2361,6 +2375,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>destination</code></dfn>"
+<li>"<dfn><code>destination_limit</code></dfn>"
 <li>"<dfn><code>end_times</code></dfn>"
 <li>"<dfn><code>event_level_epsilon</code></dfn>"
 <li>"<dfn><code>event_report_window</code></dfn>"
@@ -2666,6 +2681,19 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     [=parse an optional 64-bit signed integer=] with |value|, "<code>[=source-registration JSON key/priority=]</code>", and
     0.
 1. If |priority| is an error, return null.
+1. Let |destinationLimitAlgorithm| be "<code>[=destination limit algorithm/lifo=]</code>".
+1. Let |destinationLimitPriority| be 0.
+1. If |value|["<code>[=source-registration JSON key/destination_limit=]</code>"] [=map/exists=]:
+    1. Let |destinationLimit| be |value|["<code>[=source-registration JSON key/destination_limit=]</code>"].
+    1. If |destinationLimit| is not a [=map=], return null.
+    1. Set |destinationLimitPriority| to the result of running
+        [=parse an optional 64-bit signed integer=] with |destinationLimit|,
+        "<code>[=source-registration JSON key/priority=]</code>", and 0.
+    1. If |destinationLimitPriority| is an error, return null.
+    1. If |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"] [=map/exists=]:
+        1. If |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"] is not
+            a [=destination limit algorithm=], return null.
+        1. Set |destinationLimitAlgorithm| to |destinationLimit|["<code>[=source-registration JSON key/algorithm=]</code>"].
 1. Let |filterData| be a new [=filter map=].
 1. If |value|["<code>[=source-registration JSON key/filter_data=]</code>"] [=map/exists=]:
     1. Set |filterData| to the result of running [=parse filter data=] with
@@ -2772,6 +2800,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |aggregatableDebugBudget|
     : [=attribution source/aggregatable debug reporting config=]
     :: |aggregatableDebugReportingConfig|
+    : [=attribution source/destination limit priority=]
+    :: |destinationLimitPriority|
 1. Return |source|.
 
 Issue: Determine proper charset-handling for the JSON header value.
@@ -2812,19 +2842,119 @@ To <dfn>check if an [=attribution source=] exceeds the time-based destination li
 Note: When both limits are hit, we interpret it as "<code>[=destination rate-limit result/hit reporting limit=]</code>"
 for debug reporting.
 
-To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an
-[=attribution source=] |source|, run the following steps:
+To <dfn>check if an [=attribution source=] exceeds the per day destination limits</dfn>
+given an [=attribution source=] |source|, run the following steps:
 
-1. Let |unexpiredSources| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
+1. Let |matchingSources| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is "<code>[=rate-limit scope/source=]</code>"
      * |record|'s [=attribution rate-limit record/source site=] and |source|'s [=attribution source/source site=] are equal
-     * |record|'s [=attribution rate-limit record/reporting origin=] and |source|'s [=attribution source/reporting origin=] are [=same site=]
+     * |record|'s [=attribution rate-limit record/reporting origin=] is [=same site=] with
+        |source|'s [=attribution source/reporting origin=]
      * |record|'s [=attribution rate-limit record/expiry time=] is greater than |source|'s [=attribution source/source time=]
-1. Let |unexpiredDestinations| be a new [=set=].
-1. For each [=attribution rate-limit record=] |unexpiredRecord| of |unexpiredSources|:
-    1. [=set/Append=] |unexpiredRecord|'s [=attribution rate-limit record/attribution destination=] to |unexpiredDestinations|.
-1. Let |newDestinations| be the result of taking the [=set/union=] of |unexpiredDestinations| and |source|'s [=attribution source/attribution destinations=].
-1. Return whether |newDestinations|'s [=set/size=] is greater than the user agent's [=max destinations covered by unexpired sources=].
+     * The [=duration from=] |record|'s [=attribution rate-limit record/time=] and |source|'s [=attribution source/source time=]
+        is less than 1 day
+1. Let |destinations| be the [=set=] of every [=attribution rate-limit record/attribution destination=] in |matchingSources|,
+    [=set/union|unioned=] with |source|'s [=attribution source/attribution destinations=].
+1. Return whether |destination|'s [=set/size=] is greater than [=max destinations per source reporting site per day=].
+
+To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
+[=attribution source/source identifiers=] |sourcesToDelete| and a [=moment=] |now|:
+
+1. If |sourcesToDelete| [=set/is empty=], return.
+1. [=set/iterate|For each=] [=attribution source=] |source| of the [=attribution source cache=]:
+    1. [=set/Remove=] |source| from the [=attribution source cache=] if |sourcesToDelete|
+        [=set/contains=] |source|'s [=attribution source/source identifier=].
+1. [=set/iterate|For each=] [=event-level report=] |report| of the [=event-level report cache=]:
+    1. If |report|'s [=event-level report/trigger time=] is greater than or equal to |now|,
+        [=set/remove=] |report| from the [=event-level report cache=].
+
+        Note: This would only delete [=obtain a fake report|fake reports=] that would never be
+        stored if they were true [=event-level reports=].
+1. Let |deletedAggregatableReports| be a new [=set=].
+1. [=set/iterate|For each=] [=aggregatable report=] |report| of the [=aggregatable report cache=]:
+    1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable report/source identifier=]:
+        1. [=set/Append=] |report|'s [=attribution report/report ID=] to |deletedAggregatableReports|.
+        1. [=set/Remove=] |report| from the [=aggregatable report cache=].
+1. [=set/iterate|For each=] [=attribution rate-limit record=] |record| of the [=attribution rate-limit cache=]:
+    1. If |record|'s [=attribution rate-limit record/scope=] is:
+        <dl class="switch">
+        : "<code>[=rate-limit scope/source=]</code>"
+        :: Set |record|'s [=attribution rate-limit record/deactivated for unexpired destination limit=] to
+            true if |sourcesToDelete| [=set/contains=] |record|'s [=attribution rate-limit record/entity ID=].
+        : "<code>[=rate-limit scope/aggregatable-attribution=]</code>"
+        :: [=set/Remove=] |record| from the [=attribution rate-limit cache=] if
+            |deletedAggregatableReports| [=set/contains=] |record|'s [=attribution rate-limit record/entity ID=].
+
+        </dl>
+
+A <dfn>destination limit record</dfn> is a [=struct=] with the following items:
+
+<dl dfn-for="destination limit record">
+: <dfn>attribution destination</dfn>
+:: A [=site=].
+: <dfn>priority</dfn>
+:: A 64-bit integer.
+: <dfn>time</dfn>
+:: A [=moment=]
+: <dfn>source identifier</dfn>
+:: A [=string=].
+
+</dl>
+
+To <dfn>get sources to delete for the unexpired destination limit</dfn> given an
+[=attribution source=] |source|, run the following steps:
+1. Let |destinationRecords| be a new [=list=].
+1. [=set/iterate|For each=] [=attribution rate-limit record=] |record| of the [=attribution rate-limit cache=]:
+    1. If |record|'s [=attribution rate-limit record/scope=] is not "<code>[=rate-limit scope/source=]</code>", [=iteration/continue=].
+    1. If |record|'s [=attribution rate-limit record/deactivated for unexpired destination limit=] is true, [=iteration/continue=].
+    1. If |record|'s [=attribution rate-limit record/source site=] and |source|'s [=attribution source/source site=] are not equal, [=iteration/continue=].
+    1. If |record|'s [=attribution rate-limit record/reporting origin=] and |source|'s [=attribution source/reporting origin=] are not [=same site=], [=iteration/continue=].
+    1. If |record|'s [=attribution rate-limit record/expiry time=] is less than or equal to |source|'s [=attribution source/source time=], [=iteration/continue=].
+    1. [=Assert=]: |record|'s [=attribution rate-limit record/destination limit priority=] is not null.
+    1. [=Assert=]: |record|'s [=attribution rate-limit record/entity ID=] is not null.
+    1. Let |destinationRecord| be a new [=destination limit record=] struct whose items are:
+
+        : [=destination limit record/attribution destination=]
+        :: |record|'s [=attribution rate-limit record/attribution destination=]
+        : [=destination limit record/priority=]
+        :: |record|'s [=attribution rate-limit record/destination limit priority=]
+        : [=destination limit record/time=]
+        :: |record|'s [=attribution rate-limit record/time=]
+        : [=destination limit record/source identifier=]
+        :: |record|'s [=attribution rate-limit record/entity ID=]
+
+    1. [=list/Append=] |destinationRecord| to |destinationRecords|.
+1. [=set/iterate|For each=] [=site=] |destination| of |source|'s [=attribution source/attribution destinations=]:
+    1. Let |destinationRecord| be a new [=destination limit record=] struct whose items are:
+
+        : [=destination limit record/attribution destination=]
+        :: |destination|
+        : [=destination limit record/priority=]
+        :: |source|'s [=attribution source/destination limit priority=]
+        : [=destination limit record/time=]
+        :: |source|'s [=attribution source/source time=]
+        : [=destination limit record/source identifier=]
+        :: |record|'s [=attribution source/source identifier=]
+
+    1. [=list/Append=] |destinationRecord| to |destinationRecords|.
+1. [=list/sort in descending order|Sort=] |destinationRecords| in descending order, with |a| less than |b| if the following steps return true:
+    1. If |a|'s [=destination limit record/priority=] is less than |b|'s [=destination limit record/priority=], return true.
+    1. If |a|'s [=destination limit record/priority=] is greater than |b|'s [=destination limit record/priority=], return false.
+    1. If |a|'s [=destination limit record/time=] is less than |b|'s [=destination limit record/time=], return true.
+    1. If |a|'s [=destination limit record/time=] is greater than |b|'s [=destination limit record/time=], return false.
+    1. If |a|'s <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>
+        [=destination limit record/attribution destination=]
+        is less than |b|'s <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>
+        [=destination limit record/attribution destination=], return true.
+    1. Return false.
+1. Let |sourcesToDelete| be a new [=set=].
+1. [=set/iterate|For each=] [=destination limit record=] |record| of |destinationRecords|:
+    1. Let |destination| be |record|'s [=destination limit record/attribution destination=].
+    1. If |newDestinations|'s [=set/size=] is less than the user agent's [=max destinations covered by unexpired sources=],
+        [=set/append=] |destination| to |newDestinations|.
+    1. Otherwise, if |newDestinations| does not [=set/contain=] |destination|:
+        1. [=set/Append=] |record|'s [=destination limit record/source identifier=] to |sourcesToDelete|.
+1. Return |sourcesToDelete|.
 
 To <dfn>check if an [=attribution source=] should be blocked by reporting-origin per site limit</dfn> given an [=attribution source=] |source|:
 
@@ -2842,8 +2972,7 @@ a [=trigger state=] |triggerState|:
 
 1. Let |specEntry| be the [=map/entry=] for
     |source|'s [=attribution source/trigger specs=][|triggerState|'s [=trigger state/trigger data=]].
-1. Let |triggerTime| be the greatest [=moment=] that is strictly less than
-    |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
+1. Let |triggerTime| be |triggerState|'s [=trigger state/report window=]'s [=report window/start=].
 1. Let |priority| be 0.
 1. Let |fakeReport| be the result of running [=obtain an event-level report=] with |source|,
     |triggerTime|, [=obtain an event-level report/triggerDebugKey=] set to null,
@@ -2853,8 +2982,9 @@ a [=trigger state=] |triggerState|:
 1. Return |fakeReport|.
 
 To <dfn>obtain and deliver a verbose debug report on source registration</dfn> given a
-[=source debug data type=] |dataType|, an [=attribution source=] |source|, and
-a [=boolean=] |isNoised|:
+[=source debug data type=] |dataType|, an [=attribution source=] |source|, an
+optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
+|destinationLimitHit| (default false):
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
 1. If |source|'s [=attribution source/debug cookie set=] is false, return.
@@ -2882,8 +3012,22 @@ a [=boolean=] |isNoised|:
     : "<code>[=source debug data type/source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
          [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-success=]</code>"
+    : "<code>[=source debug data type/source-noised=]</code>"
+    :: If |destinationLimitHit| is true, [=map/set=] |body|["`source_destination_limit`"] to the user agent's [=max destinations covered by unexpired sources=],
+        [=serialize an integer|serialized=].
+
+    Note: The "`source_destination_limit`" field may be included to indicate that
+    [=max destinations covered by unexpired sources=] was hit and
+    the [=destination limit algorithm/priority_fifo=] algorithm was applied, which is not
+    reported as "<code>[=source debug data type/source-destination-limit=]</code>" to prevent side-channel
+    leakage of cross-origin data.
+
     : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
+         [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
          [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-storage-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
@@ -2978,22 +3122,36 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     to the user agent's [=max pending sources per source origin=]:
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-storage-limit=]</code>" and |source|.
     1. Return.
-1. If the result of running [=check if an attribution source exceeds the unexpired destination limit=]
-    with |source| is true:
-    1. Run [=obtain and deliver debug reports on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
-    1. Return.
-1. If the result of running [=check if an attribution source should be blocked by reporting-origin per site limit=]
-    with |source| is <strong>blocked</strong>:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>" and |source|.
-    1. Return.
 1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
     1. Return.
+1. If the result of running [=check if an attribution source exceeds the per day destination limit=]
+    with |source| is true:
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>" and |source|.
+    1. Return.
+1. Let |sourcesToDeleteForDestinationLimit| be the result of running [=get sources to delete for the unexpired destination limit=]
+    with |source|.
+1. Let |destinationLimitHit| be false if |sourcesToDeleteForDestinationLimit| [=set/is empty=], true otherwise.
+1. Let |dropNewSource| be false.
+1. If |source|'s [=attribution source/destination limit algorithm=] is:
+    <dl class="switch">
+    : "<code>[=destination limit algorithm/priority_fifo=]</code>"
+    :: Set |dropNewSource| to true if |sourcesToDeleteForDestinationLimit| [=set/contains=] |source|'s [=attribution source/source identifier=].
+    : "<code>[=destination limit algorithm/lifo=]</code>"
+    :: Set |dropNewSource| to |destinationLimitHit|.
+
+    </dl>
+1. If |dropNewSource| is true:
+    1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
+    1. Return.
+1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
+1. Let |debugDataType| be "<code>[=source debug data type/source-success=]</code>".
 1. Let |isNoised| be true if |source|'s [=attribution source/randomized response=]
     is not null, otherwise false.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-destination-global-rate-limit=]</code>", |source|, and |isNoised|.
+    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>",
+        |source|, |isNoised|, and |destinationLimitHit|.
     1. Return.
 1. Let |newRateLimitRecords| be a new [=set=].
 1. [=set/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
@@ -3010,13 +3168,14 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/source time=]
         : [=attribution rate-limit record/expiry time=]
         :: |source|'s [=attribution source/expiry time=]
-        : [=attribution rate-limit record/event-level report ID=]
-        :: null
+        : [=attribution rate-limit record/entity ID=]
+        :: |source|'s [=attribution source/source identifier=]
+        : [=attribution rate-limit record/destination limit priority=]
+        :: |source|'s [=attribution source/destination limit priority=]
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
-        1. Run [=obtain and deliver debug reports on source registration=] with
-            "<code>[=source debug data type/source-reporting-origin-limit=]</code>", |source|,
-            and |isNoised|.
+        1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-success=]</code>",
+            |source|, |isNoised|, and |destinationLimitHit|.
         1. Return.
     1. [=set/Append=] |rateLimitRecord| to |newRateLimitRecords|.
 1. [=set/iterate|For each=] |record| of |newRateLimitRecords|, [=set/append=] |record| to
@@ -3045,12 +3204,11 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             :: |source|'s [=attribution source/source time=]
             : [=attribution rate-limit record/expiry time=]
             :: null
-            : [=attribution rate-limit record/event-level report ID=]
+            : [=attribution rate-limit record/entity ID=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
-1. Run [=obtain and deliver debug reports on source registration=] with
-    "<code>[=source debug data type/source-success=]</code>", |source|,
-    and |isNoised|.
+1. Run [=obtain and deliver a verbose debug report on source registration=] with
+    |debugDataType|, |source|, |isNoised|, and |destinationLimitHit|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the
@@ -3603,7 +3761,7 @@ To <dfn>maybe replace event-level report</dfn> given an [=attribution source=]
 1. [=set/Remove=] |lowestPriorityReport| from the [=event-level report cache=].
 1. Decrement |sourceToAttribute|'s [=attribution source/number of event-level reports=] value by 1.
 1. Let |rateLimitRecord| be the element from [=attribution rate-limit cache=] whose
-    [=attribution rate-limit record/event-level report ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
+    [=attribution rate-limit record/entity ID=] is equal to |lowestPriorityReport|'s [=event-level report/report ID=]
     and [=attribution rate-limit record/scope=] is equal to "<code>[=rate-limit scope/event-attribution=]</code>".
 1. [=Assert=]: |rateLimitRecord| is not null.
 
@@ -3678,7 +3836,7 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/event-level report ID=]
+    : [=attribution rate-limit record/entity ID=]
     :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
@@ -3777,7 +3935,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     :: |sourceToAttribute|'s [=attribution source/source time=]
     : [=attribution rate-limit record/expiry time=]
     :: null
-    : [=attribution rate-limit record/event-level report ID=]
+    : [=attribution rate-limit record/entity ID=]
     :: null
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
@@ -4032,6 +4190,8 @@ an [=attribution trigger=] |trigger|:
     :: |trigger|'s [=attribution trigger/aggregatable source registration time configuration=].
     : [=aggregatable attribution report/trigger context ID=]
     :: |trigger|'s [=attribution trigger/trigger context ID=]
+    : [=aggregatable report/source identifier=]
+    :: |source|'s [=attribution source/source identifier=].
 1. Return |report|.
 
 <h3 id="generating-randomized-null-attribution-reports">Generating randomized null attribution reports</h3>

--- a/index.bs
+++ b/index.bs
@@ -3128,7 +3128,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Return.
 1. If the result of running [=check if an attribution source exceeds the per day destination limit=]
     with |source| is true:
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>" and |source|.
     1. Return.
 1. Let |sourcesToDeleteForDestinationLimit| be the result of running [=get sources to delete for the unexpired destination limit=]
     with |source|.
@@ -3143,7 +3143,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 
     </dl>
 1. If |dropNewSource| is true:
-    1. Run [=obtain and deliver a debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver a verbose debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
     1. Return.
 1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
 1. Let |debugDataType| be "<code>[=source debug data type/source-success=]</code>".

--- a/index.bs
+++ b/index.bs
@@ -2976,9 +2976,22 @@ a [=trigger state=] |triggerState|:
     |triggerState|'s [=trigger state/report window=]'s [=report window/end=].
 1. Return |fakeReport|.
 
+To <dfn>check if a source debug data type is a verbose debug data type</dfn>
+given a [=source debug data type=] |dataType|:
+
+1. If |dataType| is:
+    <dl class="switch">
+    : "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
+    : "<code>[=source debug data type/source-destination-limit-replaced=]</code>"
+    : "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
+    :: Return false.
+
+    </dl>
+1. Return true.
+
 To <dfn>obtain and deliver a verbose debug report on source registration</dfn> given a
-[=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|, an
-optional [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHit|:
+[=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
+and a [=boolean=] |isNoised|:
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
 1. If |source|'s [=attribution source/debug cookie set=] is false, return.
@@ -2991,19 +3004,23 @@ optional [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHi
     :: |source|'s [=attribution source/source site=], <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. If |source|'s [=attribution source/debug key=] is not null, [=map/set=] |body|["`source_debug_key`"]
     to |source|'s [=attribution source/debug key=], [=serialize an integer|serialized=].
-1. Let |dataList| be a new [=list=].
+1. Let |dataTypeToReport| be null.
 1. [=set/iterate|For each=] |dataType| of |dataTypes|:
-    1. Let |dataTypeToReport| be |dataType|.
+    1. Let |effectiveDataType| be |dataType|.
     1. If |dataType| is:
         <dl class="switch">
             : "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
             : "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
-            :: Set |dataTypeToReport| to "<code>[=source debug data type/source-success=]</code>".
+            :: Set |effectiveDataType| to "<code>[=source debug data type/source-success=]</code>".
 
         </dl>
-    1. If |dataTypeToReport| is "<code>[=source debug data type/source-success=]</code>"
-        and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
-    1. If |dataTypeToReport| is:
+    1. If |effectiveDataType| is "<code>[=source debug data type/source-success=]</code>"
+        and |isNoised| is true, set |effectiveDataType| to "<code>[=source debug data type/source-noised=]</code>".
+    1. If the result of [=checking if a source debug data type is a verbose debug data type=]
+        is true:
+        1. [=Assert=]: |dataTypeToReport| is null.
+        1. Set |dataTypeToReport| to |effectiveDataType|.
+    1. If |effectiveDataType| is:
         <dl class="switch">
         : "<code>[=source debug data type/source-destination-limit=]</code>"
         :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
@@ -3038,18 +3055,18 @@ optional [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHi
             [=serialize an integer|serialized=].
 
         </dl>
-    1. Let |data| be a new [=verbose debug data=] with the items:
-        : [=verbose debug data/data type=]
-        :: |dataTypeToReport|
-        : [=verbose debug data/body=]
-        :: |body|
-    1. [=list/Append=] |data| to |dataList|.
-1. Run [=obtain and deliver a verbose debug report=] with |dataList|, |source|'s [=attribution source/reporting origin=],
+1. [=Assert=]: |dataTypeToReport| is not null.
+1. Let |data| be a new [=verbose debug data=] with the items:
+    : [=verbose debug data/data type=]
+    :: |dataTypeToReport|
+    : [=verbose debug data/body=]
+    :: |body|
+1. Run [=obtain and deliver a verbose debug report=] with « |data| », |source|'s [=attribution source/reporting origin=],
     and |source|'s [=attribution source/fenced=].
 
 To <dfn>obtain and deliver an aggregatable debug report on source registration</dfn>
 given a [=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
-a [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHit|:
+and a [=boolean=] |isNoised|:
 
 1. If |source|'s [=attribution source/fenced=] is true, return.
 1. Let |config| be |source|'s [=attribution source/aggregatable debug reporting config=].
@@ -3076,13 +3093,12 @@ a [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHit|:
 
 To <dfn>obtain and deliver debug reports on source registration</dfn>
 given a [=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
-, an optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
-|destinationLimitHit| (default false):
+, and an optional [=boolean=] |isNoised| (default false):
 
 1. Run [=obtain and deliver a verbose debug report on source registration=]
-    with |dataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
+    with |dataTypes|, |source|, and |isNoised|.
 1. Run [=obtain and deliver an aggregatable debug report on source registration=]
-    with |dataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
+    with |dataTypes|, |source|, and |isNoised|.
 
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
@@ -3149,7 +3165,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. [=set/Append=] "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
         to |debugDataTypes|.
     1. Run [=obtain and deliver debug reports on source registration=]
-        with |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
+        with |debugDataTypes|, |source|, and |isNoised|.
     1. Return.
 1. Let |newRateLimitRecords| be a new [=set=].
 1. [=set/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
@@ -3175,7 +3191,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         1. [=set/Append=] "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
             to |debugDataTypes|.
         1. Run [=obtain and deliver debug reports on source registration=]
-            with |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
+            with |debugDataTypes|, |source|, and |isNoised|.
         1. Return.
     1. [=set/Append=] |rateLimitRecord| to |newRateLimitRecords|.
 1. [=set/iterate|For each=] |record| of |newRateLimitRecords|, [=set/append=] |record| to
@@ -3210,7 +3226,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=set/Append=] "<code>[=source debug data type/source-success=]</code>" to
     |debugDataTypes|.
 1. Run [=obtain and deliver debug reports on source registration=] with
-    |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
+    |debugDataTypes|, |source| and |isNoised|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the

--- a/index.bs
+++ b/index.bs
@@ -997,9 +997,7 @@ An <dfn>attribution debug info</dfn> is a [=tuple=] with the following items:
 : <dfn>source debug key</dfn>
 :: Null or a [=string=].
 : <dfn>trigger debug key</dfn>
-:: Null or a non-negative 64-bit integer.
-: <dfn>source identifier</dfn>
-:: A [=string=].
+:: Null or a [=string=].
 
 </dl>
 
@@ -1020,6 +1018,8 @@ An event-level report is an [=attribution report=] with the following additional
 :: A 64-bit integer.
 : <dfn>trigger time</dfn>
 :: A [=moment=].
+: <dfn>source identifier</dfn>
+:: A string.
 : <dfn>attribution destinations</dfn>
 :: A [=set=] of [=sites=].
 : <dfn>attribution debug info</dfn>
@@ -1066,6 +1066,8 @@ An <dfn>aggregatable attribution report</dfn> is an [=aggregatable report=] with
 :: Null or a [=string=].
 : <dfn>attribution debug info</dfn>
 :: An [=attribution debug info=].
+: <dfn>source identifier</dfn>
+:: A [=string=].
 
 </dl>
 
@@ -1098,7 +1100,7 @@ An <dfn>attribution rate-limit record</dfn> is a [=struct=] with the following i
 :: Null or a [=moment=].
 : <dfn>entity ID</dfn>
 :: Null for [=obtain a fake report|fake reports=] or an [=event-level report=]'s [=event-level report/report ID=] or an
-    [=aggregatable report=]'s [=aggregatable report/report ID=] or an
+    [=aggregatable attribution report=]'s [=aggregatable attribution report/report ID=] or an
     [=attribution source=]'s [=attribution source/source identifier=].
 : <dfn>deactivated for unexpired destination limit</dfn> (default false)
 :: A [=boolean=].
@@ -1135,6 +1137,7 @@ Possible values are:
 <li>"<dfn><code>source-channel-capacity-limit</code></dfn>"
 <li>"<dfn><code>source-destination-global-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-limit</code></dfn>"
+<li>"<dfn><code>source-destination-limit-replaced</code></dfn>"
 <li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
@@ -2862,10 +2865,10 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
         Note: This would only delete [=obtain a fake report|fake reports=] that would never be
         stored if they were true [=event-level reports=].
 1. Let |deletedAggregatableReports| be a new [=set=].
-1. [=set/iterate|For each=] [=aggregatable report=] |report| of the [=aggregatable report cache=]:
-    1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable report/source identifier=]:
-        1. [=set/Append=] |report|'s [=attribution report/report ID=] to |deletedAggregatableReports|.
-        1. [=set/Remove=] |report| from the [=aggregatable report cache=].
+1. [=set/iterate|For each=] [=aggregatable attribution report=] |report| of the [=aggregatable attribution report cache=]:
+    1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable attribution report/source identifier=]:
+        1. [=set/Append=] |report|'s [=aggregatable attribution report/report ID=] to |deletedAggregatableReports|.
+        1. [=set/Remove=] |report| from the [=aggregatable attribution report cache=].
 1. [=set/iterate|For each=] [=attribution rate-limit record=] |record| of the [=attribution rate-limit cache=]:
     1. If |record|'s [=attribution rate-limit record/scope=] is:
         <dl class="switch">
@@ -2974,9 +2977,8 @@ a [=trigger state=] |triggerState|:
 1. Return |fakeReport|.
 
 To <dfn>obtain and deliver a verbose debug report on source registration</dfn> given a
-[=source debug data type=] |dataType|, an [=attribution source=] |source|, an
-optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
-|destinationLimitHit| (default false):
+[=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|, an
+optional [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHit|:
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
 1. If |source|'s [=attribution source/debug cookie set=] is false, return.
@@ -2989,80 +2991,83 @@ optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
     :: |source|'s [=attribution source/source site=], <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. If |source|'s [=attribution source/debug key=] is not null, [=map/set=] |body|["`source_debug_key`"]
     to |source|'s [=attribution source/debug key=], [=serialize an integer|serialized=].
-1. Let |dataTypeToReport| be |dataType|.
-1. If |dataType| is:
-    <dl class="switch">
-        : "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
-        : "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
-        :: Set |dataTypeToReport| to "<code>[=source debug data type/source-success=]</code>".
+1. Let |dataList| be a new [=list=].
+1. [=set/iterate|For each=] |dataType| of |dataTypes|:
+    1. Let |dataTypeToReport| be |dataType|.
+    1. If |dataType| is:
+        <dl class="switch">
+            : "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
+            : "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
+            :: Set |dataTypeToReport| to "<code>[=source debug data type/source-success=]</code>".
 
-    </dl>
-1. If |dataTypeToReport| is "<code>[=source debug data type/source-success=]</code>"
-    and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
-1. If |dataTypeToReport| is:
-    <dl class="switch">
-    : "<code>[=source debug data type/source-destination-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-success=]</code>"
-    : "<code>[=source debug data type/source-noised=]</code>"
-    :: If |destinationLimitHit| is true, [=map/set=] |body|["`source_destination_limit`"] to the user agent's [=max destinations covered by unexpired sources=],
-        [=serialize an integer|serialized=].
+        </dl>
+    1. If |dataTypeToReport| is "<code>[=source debug data type/source-success=]</code>"
+        and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
+    1. If |dataTypeToReport| is:
+        <dl class="switch">
+        : "<code>[=source debug data type/source-destination-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-destination-limit-replaced=]</code>"
+        :: [=map/Set=] |body|["`source_destination_limit`"] to the user agent's
+            [=max destinations covered by unexpired sources=], [=serialize an integer|serialized=].
 
-    Note: The "`source_destination_limit`" field may be included to indicate that
-    [=max destinations covered by unexpired sources=] was hit, which is not
-    reported as "<code>[=source debug data type/source-destination-limit=]</code>" to prevent side-channel
-    leakage of cross-origin data.
+        Note: The "`source_destination_limit`" field may be included to indicate that
+        [=max destinations covered by unexpired sources=] was hit, which is not
+        reported as "<code>[=source debug data type/source-destination-limit=]</code>" to prevent side-channel
+        leakage of cross-origin data.
 
-    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-storage-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
-    ::
-        1. Let |sourceType| be |source|'s [=attribution source/source type=].
-        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
-    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
-        [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
-         [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
+             [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
+             [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-storage-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
+        ::
+            1. Let |sourceType| be |source|'s [=attribution source/source type=].
+            1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
+        : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
+            [=serialize an integer|serialized=].
 
-    </dl>
-1. Let |data| be a new [=verbose debug data=] with the items:
-    : [=verbose debug data/data type=]
-    :: |dataTypeToReport|
-    : [=verbose debug data/body=]
-    :: |body|
-1. Run [=obtain and deliver a verbose debug report=] with « |data| », |source|'s [=attribution source/reporting origin=],
+        </dl>
+    1. Let |data| be a new [=verbose debug data=] with the items:
+        : [=verbose debug data/data type=]
+        :: |dataTypeToReport|
+        : [=verbose debug data/body=]
+        :: |body|
+    1. [=list/Append=] |data| to |dataList|.
+1. Run [=obtain and deliver a verbose debug report=] with |dataList|, |source|'s [=attribution source/reporting origin=],
     and |source|'s [=attribution source/fenced=].
 
 To <dfn>obtain and deliver an aggregatable debug report on source registration</dfn>
-given a [=source debug data type=] |dataType|, an [=attribution source=] |source|,
-and a [=boolean=] |isNoised|:
+given a [=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
+a [=boolean=] |isNoised|, and an optional [=boolean=] |destinationLimitHit|:
 
 1. If |source|'s [=attribution source/fenced=] is true, return.
 1. Let |config| be |source|'s [=attribution source/aggregatable debug reporting config=].
 1. Let |debugDataMap| be |config|'s [=aggregatable debug reporting config/debug data=].
 1. If |debugDataMap| [=map/is empty=], return.
 1. Let |contributions| be a new [=list=].
-1. Let |dataTypeToReport| be |dataType|.
-1. If |dataTypeToReport| is "<code>[=source debug data type/source-success=]</code>"
-    and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
-1. If |debugDataMap|[|dataTypeToReport|] [=map/exists=]:
-    1. Let |contribution| be a new [=aggregatable contribution=] with items:
-        : [=aggregatable contribution/key=]
-        :: |debugDataMap|[|dataTypeToReport|]'s [=aggregatable contribution/key=] bitwise-OR
-            |config|'s [=aggregatable debug reporting config/key piece=]
-        : [=aggregatable contribution/value=]
-        :: |debugDataMap|[|dataTypeToReport|]'s [=aggregatable contribution/value=]
-    1. [=list/Append=] |contribution| to |contributions|.
+1. [=set/iterate|For each=] |dataType| of |dataTypes|:
+    1. Let |dataTypeToReport| be |dataType|.
+    1. If |dataType| is "<code>[=source debug data type/source-success=]</code>"
+        and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
+    1. If |debugDataMap|[|dataTypeToReport|] [=map/exists=]:
+        1. Let |contribution| be a new [=aggregatable contribution=] with items:
+            : [=aggregatable contribution/key=]
+            :: |debugDataMap|[|dataTypeToReport|]'s [=aggregatable contribution/key=] bitwise-OR
+                |config|'s [=aggregatable debug reporting config/key piece=]
+            : [=aggregatable contribution/value=]
+            :: |debugDataMap|[|dataTypeToReport|]'s [=aggregatable contribution/value=]
+        1. [=list/Append=] |contribution| to |contributions|.
 1. Run [=obtain and deliver an aggregatable debug report on registration=] with |contributions|,
     |source|'s [=attribution source/source site=], |source|'s [=attribution source/reporting origin=],
     |source|, |source|'s [=attribution source/attribution destinations=][0],
@@ -3070,13 +3075,14 @@ and a [=boolean=] |isNoised|:
     and |source|'s [=attribution source/source time=].
 
 To <dfn>obtain and deliver debug reports on source registration</dfn>
-given a [=source debug data type=] |dataType|, an [=attribution source=] |source|,
-and an optional [=boolean=] |isNoised| (default false):
+given a [=set=] of [=source debug data types=] |dataTypes|, an [=attribution source=] |source|,
+, an optional [=boolean=] |isNoised| (default false), and an optional [=boolean=]
+|destinationLimitHit| (default false):
 
 1. Run [=obtain and deliver a verbose debug report on source registration=]
-    with |dataType|, |source|, and |isNoised|.
+    with |dataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
 1. Run [=obtain and deliver an aggregatable debug report on source registration=]
-    with |dataType|, |source|, and |isNoised|.
+    with |dataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
 
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
@@ -3092,11 +3098,13 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
 1. If |channelCapacity| is an error:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        « "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" » and |source|.
     1. Return.
 1. Let |sourceType| be |source|'s [=attribution source/source type=].
 1. If |channelCapacity| is greater than [=max event-level channel capacity per source=][|sourceType|]:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-channel-capacity-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        « "<code>[=source debug data type/source-channel-capacity-limit=]</code>" » and |source|.
     1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
     [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
@@ -3111,29 +3119,37 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     [=attribution source/source origin=] are [=same origin=].
 1. If |pendingSourcesForSourceOrigin|'s [=list/size=] is greater than or equal
     to the user agent's [=max pending sources per source origin=]:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-storage-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        « "<code>[=source debug data type/source-storage-limit=]</code>" » and |source|.
     1. Return.
 1. Let |destinationRateLimitResult| be the result of running [=check if an attribution source exceeds the time-based destination limit=] with |source|.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit reporting limit=]</code>":
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        « "<code>[=source debug data type/source-destination-rate-limit=]</code>" » and |source|.
     1. Return.
 1. If the result of running [=check if an attribution source exceeds the per day destination limit=]
     with |source| is true:
-    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        « "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>" » and |source|.
     1. Return.
 1. Let |sourcesToDeleteForDestinationLimit| be the result of running [=get sources to delete for the unexpired destination limit=]
     with |source|.
-1. Let |destinationLimitHit| be false if |sourcesToDeleteForDestinationLimit| [=set/is empty=], true otherwise.
 1. If |sourcesToDeleteForDestinationLimit| [=set/contains=] |source|'s [=attribution source/source identifier=]:
-    1. Run [=obtain and deliver a verbose debug report on source registration=] with "[=source debug data type/source-destination-limit=]</code>" and |source|.
+    1. Run [=obtain and deliver debug reports on source registration=] with
+        "<code>[=source debug data type/source-destination-limit=]</code>" and |source|.
     1. Return.
+1. Let |debugDataTypes| be a new [=set=].
+1. If |sourcesToDeleteForDestinationLimit| is not [=set/is empty|empty=],
+    [=set/append=] "<code>[=source debug data type/source-destination-limit-replaced=]</code>"
+    to |debugDataTypes|.
 1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
-1. Let |debugDataType| be "<code>[=source debug data type/source-success=]</code>".
 1. Let |isNoised| be true if |source|'s [=attribution source/randomized response=]
     is not null, otherwise false.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
-    1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-destination-global-rate-limit=]</code>",
-        |source|, |isNoised|, and |destinationLimitHit|.
+    1. [=set/Append=] "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
+        to |debugDataTypes|.
+    1. Run [=obtain and deliver debug reports on source registration=]
+        with |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
     1. Return.
 1. Let |newRateLimitRecords| be a new [=set=].
 1. [=set/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
@@ -3156,8 +3172,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/destination limit priority=]
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
-        1. Run [=obtain and deliver a verbose debug report on source registration=] with "<code>[=source debug data type/source-reporting-origin-limit=]</code>",
-            |source|, |isNoised|, and |destinationLimitHit|.
+        1. [=set/Append=] "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
+            to |debugDataTypes|.
+        1. Run [=obtain and deliver debug reports on source registration=]
+            with |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
         1. Return.
     1. [=set/Append=] |rateLimitRecord| to |newRateLimitRecords|.
 1. [=set/iterate|For each=] |record| of |newRateLimitRecords|, [=set/append=] |record| to
@@ -3189,8 +3207,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/entity ID=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
-1. Run [=obtain and deliver a verbose debug report on source registration=] with
-    |debugDataType|, |source|, |isNoised|, and |destinationLimitHit|.
+1. [=set/Append=] "<code>[=source debug data type/source-success=]</code>" to
+    |debugDataTypes|.
+1. Run [=obtain and deliver debug reports on source registration=] with
+    |debugDataTypes|, |source|, |isNoised|, and |destinationLimitHit|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the
@@ -4172,7 +4192,7 @@ an [=attribution trigger=] |trigger|:
     :: |trigger|'s [=attribution trigger/aggregatable source registration time configuration=].
     : [=aggregatable attribution report/trigger context ID=]
     :: |trigger|'s [=attribution trigger/trigger context ID=]
-    : [=aggregatable report/source identifier=]
+    : [=aggregatable attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
 1. Return |report|.
 

--- a/index.bs
+++ b/index.bs
@@ -1135,8 +1135,8 @@ Possible values are:
 <li>"<dfn><code>source-channel-capacity-limit</code></dfn>"
 <li>"<dfn><code>source-destination-global-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-limit</code></dfn>"
-<li>"<dfn><code>source-destination-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
+<li>"<dfn><code>source-destination-rate-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
@@ -1443,7 +1443,7 @@ The second controls the maximum number of distinct [=sites=] across all [=attrib
 for [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=])
 per [=destination rate-limit window=].
 
-<dfn>Max destinations per source reporting site per day</dfn> is an integer controls
+<dfn>Max destinations per source reporting site per day</dfn> is an integer that controls
 the maximum number of distinct [=sites=] across all [=attribution source/attribution destinations=]
 for [=attribution sources=] with a given ([=attribution source/source site=], [=attribution source/reporting origin=] [=site=])
 per day.
@@ -2844,9 +2844,9 @@ given an [=attribution source=] |source|, run the following steps:
      * |record|'s [=attribution rate-limit record/expiry time=] is greater than |source|'s [=attribution source/source time=]
      * The [=duration from=] |record|'s [=attribution rate-limit record/time=] and |source|'s [=attribution source/source time=]
         is less than 1 day
-1. Let |destinations| be the [=set=] of every [=attribution rate-limit record/attribution destination=] in |matchingSources|,
+1. Let |destinations| be the [=set=] of all [=attribution rate-limit record/attribution destination=] in |matchingSources|,
     [=set/union|unioned=] with |source|'s [=attribution source/attribution destinations=].
-1. Return whether |destination|'s [=set/size=] is greater than [=max destinations per source reporting site per day=].
+1. Return whether |destinations|'s [=set/size=] is greater than [=max destinations per source reporting site per day=].
 
 To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
 [=attribution source/source identifiers=] |sourcesToDelete| and a [=moment=] |now|:

--- a/index.bs
+++ b/index.bs
@@ -2939,6 +2939,7 @@ To <dfn>get sources to delete for the unexpired destination limit</dfn> given an
         [=destination limit record/attribution destination=], return true.
     1. Return false.
 1. Let |sourcesToDelete| be a new [=set=].
+1. Let |newDestinations| be a new [=set=].
 1. [=set/iterate|For each=] [=destination limit record=] |record| of |destinationRecords|:
     1. Let |destination| be |record|'s [=destination limit record/attribution destination=].
     1. If |newDestinations|'s [=set/size=] is less than the user agent's [=max destinations covered by unexpired sources=],

--- a/params/chromium-params.md
+++ b/params/chromium-params.md
@@ -17,6 +17,7 @@ Chromium's implementation assigns the following values:
 | [Max destinations covered by unexpired sources][] | [100][max destinations covered by unexpired sources value] |
 | [Destination rate-limit window][] | [1 minute][destination rate-limit window value]
 | [Max destinations per rate-limit window][] | [50][max destinations per rate-limit window per reporting site] per reporting site, [200][max destinations per rate-limit window total] total
+| [Max destinations per reporting site per day][] | [100]
 | [Max source reporting origins per rate-limit window][] | [100][max source reporting origins per rate-limit window value] |
 | [Max source reporting origins per source reporting site][] | [1][max source reporting origins per source reporting site value]
 | [Origin rate-limit window][] | [1 day][origin rate-limit window value]
@@ -48,6 +49,7 @@ Chromium's implementation assigns the following values:
 [Max destinations per rate-limit window]: https://wicg.github.io/attribution-reporting-api/#max-destinations-per-rate-limit-window
 [Max destinations per rate-limit window per reporting site]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:content/browser/attribution_reporting/destination_throttler.h;l=29;drc=1890f3f74c8100eb1a3e945d34d6fd576d2a9061
 [Max destinations per rate-limit window total]: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:content/browser/attribution_reporting/destination_throttler.h;l=28;drc=1890f3f74c8100eb1a3e945d34d6fd576d2a9061
+[Max destinations per reporting site per day]: https://wicg.github.io/attribution-reporting-api/#max-destinations-per-reporting-site-per-day
 [Max source reporting origins per rate-limit window]: https://wicg.github.io/attribution-reporting-api/#max-source-reporting-origins-per-rate-limit-window
 [max source reporting origins per rate-limit window value]: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/attribution_config.h;l=28;drc=3733a639d724a4353463a872605119d11a1e4d37
 [Max source reporting origins per source reporting site]: https://wicg.github.io/attribution-reporting-api/#max-source-reporting-origins-per-source-reporting-site

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -4,7 +4,6 @@ import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
 import { serializeSource } from './to-json'
 import {
-  DestinationLimitAlgorithm,
   Source,
   SummaryWindowOperator,
   TriggerDataMatching,
@@ -35,10 +34,7 @@ const testCases: TestCase[] = [
       "debug_key": "1",
       "debug_reporting": true,
       "destination": "https://a.test",
-      "destination_limit": {
-        "algorithm": "priority_fifo",
-        "priority": "1"
-      },
+      "destination_limit_priority": "1",
       "event_report_window": "3601",
       "expiry": "86400",
       "filter_data": {"b": ["c"]},
@@ -62,10 +58,7 @@ const testCases: TestCase[] = [
       debugKey: 1n,
       debugReporting: true,
       destination: new Set(['https://a.test']),
-      destinationLimit: {
-        algorithm: DestinationLimitAlgorithm.priority_fifo,
-        priority: 1n,
-      },
+      destinationLimitPriority: 1n,
       eventLevelEpsilon: 14,
       expiry: 86400,
       filterData: new Map([['b', new Set(['c'])]]),
@@ -1248,31 +1241,15 @@ const testCases: TestCase[] = [
       },
     ],
   },
-
-  {
-    name: 'destination-limit-wrong-type',
-    json: `{
-      "destination": "https://a.test",
-      "destination_limit": 1
-    }`,
-    expectedErrors: [
-      {
-        path: ['destination_limit'],
-        msg: 'must be an object',
-      },
-    ],
-  },
   {
     name: 'destination-limit-priority-wrong-type',
     json: `{
       "destination": "https://a.test",
-      "destination_limit": {
-        "priority": 1
-       }
+      "destination_limit_priority": 1
     }`,
     expectedErrors: [
       {
-        path: ['destination_limit', 'priority'],
+        path: ['destination_limit_priority'],
         msg: 'must be a string',
       },
     ],
@@ -1281,44 +1258,12 @@ const testCases: TestCase[] = [
     name: 'destination-limit-priority-wrong-format',
     json: `{
       "destination": "https://a.test",
-      "destination_limit": {
-        "priority": "x"
-      }
+      "destination_limit_priority": "x"
     }`,
     expectedErrors: [
       {
-        path: ['destination_limit', 'priority'],
-        msg: 'must be an int64 (must match /^-?[0-9]+$/)',
-      },
-    ],
-  },
-  {
-    name: 'destination-limit-algorithm-wrong-value',
-    json: `{
-      "destination": "https://a.test",
-      "destination_limit": {
-        "algorithm": "x"
-      }
-    }`,
-    expectedErrors: [
-      {
-        path: ['destination_limit', 'algorithm'],
-        msg: 'must be one of the following (case-sensitive): priority_fifo, lifo',
-      },
-    ],
-  },
-  {
-    name: 'destination-limit-lifo-non-default-priority',
-    json: `{
-      "destination": "https://a.test",
-      "destination_limit": {
-        "priority": "123"
-      }
-    }`,
-    expectedNotes: [
-      {
-        path: ['destination_limit', 'priority'],
-        msg: 'non-default priority (123) for algorithm lifo (may still be used by future priority_fifo source)',
+        path: ['destination_limit_priority'],
+        msg: 'string must represent an integer (must match /^-?[0-9]+$/)',
       },
     ],
   },

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -174,6 +174,7 @@ export type Source = CommonDebug &
     aggregation_keys: { [key: string]: string }
     aggregatable_report_window: number
     destination: string[]
+    destination_limit: DestinationLimit
     event_level_epsilon: number
     expiry: number
     filter_data: { [key: string]: string[] }
@@ -205,6 +206,7 @@ export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
 
     aggregatable_report_window: s.aggregatableReportWindow,
     destination: Array.from(s.destination),
+    destination_limit: serializeDestinationLimit(s.destinationLimit),
     event_level_epsilon: s.eventLevelEpsilon,
     expiry: s.expiry,
     max_event_level_reports: s.maxEventLevelReports,

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -174,7 +174,7 @@ export type Source = CommonDebug &
     aggregation_keys: { [key: string]: string }
     aggregatable_report_window: number
     destination: string[]
-    destination_limit: DestinationLimit
+    destination_limit_priority: string
     event_level_epsilon: number
     expiry: number
     filter_data: { [key: string]: string[] }
@@ -206,7 +206,7 @@ export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
 
     aggregatable_report_window: s.aggregatableReportWindow,
     destination: Array.from(s.destination),
-    destination_limit: serializeDestinationLimit(s.destinationLimit),
+    destination_limit_priority: s.destinationLimitPriority.toString(),
     event_level_epsilon: s.eventLevelEpsilon,
     expiry: s.expiry,
     max_event_level_reports: s.maxEventLevelReports,

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -29,6 +29,9 @@ is rejected due to the following limits to mitigate security concerns:
 #### `source-destination-rate-limit`
 A source is rejected due to the [destinations per source and reporting site rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site).
 
+#### `source-destination-per-day-rate-limit`
+A source is rejected due to the [destinations per source and reporting site per day rate limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources).
+
 #### `source-unknown-error`
 System error.
 
@@ -134,34 +137,39 @@ otherwise the dictionary may include the following fields:
 * `source_site`: The site on which source was registered, e.g. `"https://source.example"`.
 * `trigger_debug_key`: The debug key in the trigger registration, omitted if not set.
 
+If `type` is [`source-success`](#source-success) or [`source-noised`](#source-noised), the `body`
+dictionary may include a `source_destination_limit` field if the [destination limit](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources)
+was exceeded.
+
 This table defines the fields in the `body` dictionary.
 
-| `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | `trigger_debug_key` |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`source-channel-capacity-limit`](#source-channel-capacity-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
-| [`source-reporting-origin-per-site-limit`](#source-reporting-origin-per-site-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
-| [`source-trigger-state-cardinality-limit`](#source-trigger-state-cardinality-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
-| [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
-| [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-attributions-per-source-destination-limit`](#trigger-event-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-aggregate-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-reporting-origin-limit`](#trigger-reporting-origin-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-deduplicated`](#trigger-event-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-no-matching-configurations`](#trigger-event-no-matching-configurations) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-noise`](#trigger-event-noise) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-storage-limit`](#trigger-event-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-report-window-not-started`](#trigger-event-report-window-not-started) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-event-report-window-passed`](#trigger-event-report-window-passed) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-deduplicated`](#trigger-aggregate-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-excessive-reports`](#trigger-aggregate-excessive-reports) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-no-contributions`](#trigger-aggregate-no-contributions) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-insufficient-budget`](#trigger-aggregate-insufficient-budget) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-storage-limit`](#trigger-aggregate-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-aggregate-report-window-passed`](#trigger-aggregate-report-window-passed) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
-| [`trigger-unknown-error`](#trigger-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |
+| `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | `trigger_debug_key` | `source_destination_limit` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [`source-channel-capacity-limit`](#source-channel-capacity-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-destination-per-day-rate-limit`](#source-destination-per-day-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ | ✓ |
+| [`source-reporting-origin-per-site-limit`](#source-reporting-origin-per-site-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ | ✓ |
+| [`source-trigger-state-cardinality-limit`](#source-trigger-state-cardinality-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ | ❌ |
+| [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ | ❌ |
+| [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-attributions-per-source-destination-limit`](#trigger-event-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-attributions-per-source-destination-limit`](#trigger-aggregate-attributions-per-source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-reporting-origin-limit`](#trigger-reporting-origin-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-deduplicated`](#trigger-event-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-no-matching-configurations`](#trigger-event-no-matching-configurations) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-noise`](#trigger-event-noise) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-storage-limit`](#trigger-event-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-report-window-not-started`](#trigger-event-report-window-not-started) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-event-report-window-passed`](#trigger-event-report-window-passed) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-deduplicated`](#trigger-aggregate-deduplicated) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-excessive-reports`](#trigger-aggregate-excessive-reports) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-no-contributions`](#trigger-aggregate-no-contributions) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-insufficient-budget`](#trigger-aggregate-insufficient-budget) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-storage-limit`](#trigger-aggregate-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-aggregate-report-window-passed`](#trigger-aggregate-report-window-passed) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`trigger-unknown-error`](#trigger-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ | ❌ |


### PR DESCRIPTION
Fixes #1228 

To preserve the protection of user’s browser history, and also to mitigate utility concern with dropping new sources, we propose to change to FIFO+priority for the destination limit for unexpired sources. This change backwards incompatible.

We also propose a new limit on the max destinations per reporting site per day to mitigate the history reconstruction attack for FIFO.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1217.html" title="Last updated on Jun 10, 2024, 2:32 PM UTC (fd1758b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1217/221f474...linnan-github:fd1758b.html" title="Last updated on Jun 10, 2024, 2:32 PM UTC (fd1758b)">Diff</a>