### PR TITLE
Spec verbose debug report for max channel capacity and max trigger states cardinality

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2441,8 +2441,10 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
          [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-storage-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
+         [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=],
+         [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
     ::
         1. Let |sourceType| be |source|'s [=attribution source/source type=].

--- a/index.bs
+++ b/index.bs
@@ -787,7 +787,7 @@ An attribution source is a [=struct=] with the following items:
 :: A [=randomized source response=].
 : <dfn>randomized trigger rate</dfn> (default 0)
 :: A number between 0 and 1 (both inclusive).
-: <dfn>epsilon</dfn>
+: <dfn>event-level epsilon</dfn>
 :: A double.
 : <dfn>filter data</dfn>
 :: A [=filter map=].
@@ -1052,7 +1052,7 @@ Possible values are:
 <ul dfn-for="source debug data type">
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
-<li>"<dfn><code>source-invalid-randomized-response-config</code></dfn>"
+<li>"<dfn><code>source-output-space-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
@@ -2329,7 +2329,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |sourceType|
     : [=attribution source/max number of event-level reports=]
     :: |maxAttributionsPerSource|
-    : [=attribution source/epsilon=]
+    : [=attribution source/event-level epsilon=]
     :: |epsilon|
     : [=attribution source/filter data=]
     :: |filterData|
@@ -2461,10 +2461,11 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     : [=randomized response output configuration/trigger specs=]
     :: |source|'s [=trigger specs=]
 
+1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
 1. Let |sourceType| be |source|'s [=attribution source/source type=].
 1. If |channelCapacity| is an error or is greater than [=max event-level channel capacity per source=][|sourceType|]:
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-invalid-randomized-response-config=]</code>" and |source|.
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-output-space-limit=]</code>" and |source|.
     1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
     [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.

--- a/index.bs
+++ b/index.bs
@@ -2443,12 +2443,12 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
          [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
     ::
         1. Let |sourceType| be |source|'s [=attribution source/source type=].
-        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=][|sourceType|].
+        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
+    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
+        [=serialize an integer|serialized=].
 
     </dl>
 1. Let |data| be a new [=attribution debug data=] with the items:

--- a/index.bs
+++ b/index.bs
@@ -783,10 +783,12 @@ An attribution source is a [=struct=] with the following items:
 :: A [=boolean=].
 : <dfn>dedup keys</dfn>
 :: [=ordered set=] of [=event-level trigger configuration/dedup keys=] associated with this [=attribution source=].
-: <dfn>randomized response</dfn>
+: <dfn>randomized response</dfn> (default null)
 :: A [=randomized source response=].
-: <dfn>randomized trigger rate</dfn>
+: <dfn>randomized trigger rate</dfn> (default 0)
 :: A number between 0 and 1 (both inclusive).
+: <dfn>epsilon</dfn>
+:: A double.
 : <dfn>filter data</dfn>
 :: A [=filter map=].
 : <dfn>debug key</dfn>
@@ -1050,6 +1052,7 @@ Possible values are:
 <ul dfn-for="source debug data type">
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
+<li>"<dfn><code>source-invalid-randomized-response-config</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
@@ -2296,19 +2299,10 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
     |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
 1. If |triggerSpecs| is an error, return null.
-1. Let |randomizedResponseConfig| be a new [=randomized response output configuration=] whose items are:
-
-    : [=randomized response output configuration/max attributions per source=]
-    :: |maxAttributionsPerSource|
-    : [=randomized response output configuration/trigger specs=]
-    :: |triggerSpecs|
-
 1. Let |epsilon| be the user agent's [=max settable event-level epsilon=].
 1. Set |epsilon| to |value|["`event_level_epsilon`"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
 1. If [=automation local testing mode=] is true, set |epsilon| to `∞`.
-1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
-1. If |channelCapacity| is an error or is greater than [=max event-level channel capacity per source=][|sourceType|], return null.
 1. Let |source| be a new [=attribution source=] struct whose items are:
 
     : [=attribution source/source identifier=]
@@ -2335,10 +2329,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |sourceType|
     : [=attribution source/max number of event-level reports=]
     :: |maxAttributionsPerSource|
-    : [=attribution source/randomized response=]
-    :: The result of [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
-    : [=attribution source/randomized trigger rate=]
-    :: The result of [=obtaining a randomized source response pick rate=] with |randomizedResponseConfig| and |epsilon|.
+    : [=attribution source/epsilon=]
+    :: |epsilon|
     : [=attribution source/filter data=]
     :: |filterData|
     : [=attribution source/debug key=]
@@ -2462,6 +2454,22 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 
 1. Let |cache| be the user agent's [=attribution source cache=].
 1. [=list/Remove=] all [=attribution sources=] |entry| in |cache| where |entry|'s [=attribution source/expiry time=] is less than |source|'s [=attribution source/source time=].
+1. Let |randomizedResponseConfig| be a new [=randomized response output configuration=] whose items are:
+
+    : [=randomized response output configuration/max attributions per source=]
+    :: |source|'s [=attribution source/max number of event-level reports=]
+    : [=randomized response output configuration/trigger specs=]
+    :: |source|'s [=trigger specs=]
+
+1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
+1. Let |sourceType| be |source|'s [=attribution source/source type=].
+1. If |channelCapacity| is an error or is greater than [=max event-level channel capacity per source=][|sourceType|]:
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-invalid-randomized-response-config=]</code>" and |source|.
+    1. Return.
+1. Set |source|'s [=attribution source/randomized response=] to the result of
+    [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
+1. Set |source|'s [=attribution source/randomized trigger rate=] to the result of
+    [=obtaining a randomized source response pick rate=] with |randomizedResponseConfig| and |epsilon|.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
     [=attribution sources=] |pendingSource| of |cache| where |pendingSource|'s
     [=attribution source/source origin=] and |source|'s

--- a/index.bs
+++ b/index.bs
@@ -1050,12 +1050,13 @@ A <dfn>source debug data type</dfn> is a [=debug data type=] for source registra
 Possible values are:
 
 <ul dfn-for="source debug data type">
+<li>"<dfn><code>source-channel-capacity-limit</code></dfn>"
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
-<li>"<dfn><code>source-output-space-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
+<li>"<dfn><code>source-trigger-state-cardinality-limit</code></dfn>"
 <li>"<dfn><code>source-unknown-error</code></dfn>"
 </ul>
 
@@ -2440,6 +2441,10 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
          [=serialize an integer|serialized=].
     : "<code>[=source debug data type/source-storage-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
+    : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=],
+    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
          [=serialize an integer|serialized=].
 
     </dl>
@@ -2464,8 +2469,11 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
 1. Let |sourceType| be |source|'s [=attribution source/source type=].
-1. If |channelCapacity| is an error or is greater than [=max event-level channel capacity per source=][|sourceType|]:
-    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-output-space-limit=]</code>" and |source|.
+1. If |channelCapacity| is an error:
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" and |source|.
+    1. Return.
+1. If |channelCapacity| is greater than [=max event-level channel capacity per source=][|sourceType|]:
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-channel-capacity-limit=]</code>" and |source|.
     1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
     [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.

--- a/index.bs
+++ b/index.bs
@@ -2468,10 +2468,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
-1. Let |sourceType| be |source|'s [=attribution source/source type=].
 1. If |channelCapacity| is an error:
     1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" and |source|.
     1. Return.
+1. Let |sourceType| be |source|'s [=attribution source/source type=].
 1. If |channelCapacity| is greater than [=max event-level channel capacity per source=][|sourceType|]:
     1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-channel-capacity-limit=]</code>" and |source|.
     1. Return.

--- a/index.bs
+++ b/index.bs
@@ -2444,8 +2444,9 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
     : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=],
     : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
-         [=serialize an integer|serialized=].
+    ::
+        1. Let |sourceType| be |source|'s [=attribution source/source type=].
+        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=][|sourceType|].
 
     </dl>
 1. Let |data| be a new [=attribution debug data=] with the items:

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -33,7 +33,8 @@ A source is rejected due to the [destinations per source and reporting site rate
 System error.
 
 #### `source-output-space-limit`
-A source is rejected due to exceeding output space limit of the event-level reports.
+A source is rejected due to exceeding the [channel capacity limit](https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source)
+or [max trigger-state cardinality](https://wicg.github.io/attribution-reporting-api/#max-trigger-state-cardinality).
 
 ### Trigger debugging reports
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -132,13 +132,13 @@ This table defines the fields in the `body` dictionary.
 
 | `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | `trigger_debug_key` |
 | --- | --- | --- | --- | --- | --- | --- |
-| [`source-channel-capacity-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`source-channel-capacity-limit`](#source-channel-capacity-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
-| [`source-trigger-state-cardinality-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`source-trigger-state-cardinality-limit`](#source-trigger-state-cardinality-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -32,9 +32,11 @@ A source is rejected due to the [destinations per source and reporting site rate
 #### `source-unknown-error`
 System error.
 
-#### `source-output-space-limit`
-A source is rejected due to exceeding the [channel capacity limit](https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source)
-or [max trigger-state cardinality](https://wicg.github.io/attribution-reporting-api/#max-trigger-state-cardinality).
+#### `source-channel-capacity-limit`
+A source is rejected due to exceeding the [channel capacity limit](https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source).
+
+#### `source-trigger-state-cardinality-limit`
+A source is rejected due to exceeding the [max trigger-state cardinality](https://wicg.github.io/attribution-reporting-api/#max-trigger-state-cardinality).
 
 ### Trigger debugging reports
 
@@ -130,12 +132,13 @@ This table defines the fields in the `body` dictionary.
 
 | `type` | `attribution_destination`| `limit` | `source_debug_key` | `source_event_id` | `source_site` | `trigger_debug_key` |
 | --- | --- | --- | --- | --- | --- | --- |
+| [`source-channel-capacity-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-output-space-limit`](#source-output-space-limit) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
+| [`source-trigger-state-cardinality-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-unknown-error`](#source-unknown-error) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`trigger-no-matching-source`](#trigger-no-matching-source) | ✓ | ❌ | ❌ | ❌ | ❌ | ✓ |
 | [`trigger-no-matching-filter-data`](#trigger-no-matching-filter-data) | ✓ | ❌ | ✓ | ✓ | ✓ | ✓ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -33,7 +33,7 @@ A source is rejected due to the [destinations per source and reporting site rate
 System error.
 
 #### `source-output-space-limit`
-A source is rejected due to invalid randomized response configuration.
+A source is rejected due to exceeding output space limit.
 
 ### Trigger debugging reports
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -32,6 +32,9 @@ A source is rejected due to the [destinations per source and reporting site rate
 #### `source-unknown-error`
 System error.
 
+#### `source-invalid-randomized-response-config`
+A source is rejected due to invalid randomized response configuration.
+
 ### Trigger debugging reports
 
 Here are the debugging reports supported for [attribution trigger
@@ -128,6 +131,7 @@ This table defines the fields in the `body` dictionary.
 | --- | --- | --- | --- | --- | --- | --- |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
+| [`source-invalid-randomized-response-config`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -33,7 +33,7 @@ A source is rejected due to the [destinations per source and reporting site rate
 System error.
 
 #### `source-channel-capacity-limit`
-A source is rejected due to exceeding the [channel capacity limit](https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source).
+A source is rejected due to exceeding the [channel-capacity limit](https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source).
 
 #### `source-trigger-state-cardinality-limit`
 A source is rejected due to exceeding the [max trigger-state cardinality](https://wicg.github.io/attribution-reporting-api/#max-trigger-state-cardinality).

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -33,7 +33,7 @@ A source is rejected due to the [destinations per source and reporting site rate
 System error.
 
 #### `source-output-space-limit`
-A source is rejected due to exceeding output space limit.
+A source is rejected due to exceeding output space limit of the event-level reports.
 
 ### Trigger debugging reports
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -131,7 +131,7 @@ This table defines the fields in the `body` dictionary.
 | --- | --- | --- | --- | --- | --- | --- |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-output-space-limit`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
+| [`source-output-space-limit`](#source-output-space-limit) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -32,7 +32,7 @@ A source is rejected due to the [destinations per source and reporting site rate
 #### `source-unknown-error`
 System error.
 
-#### `source-invalid-randomized-response-config`
+#### `source-output-space-limit`
 A source is rejected due to invalid randomized response configuration.
 
 ### Trigger debugging reports
@@ -131,7 +131,7 @@ This table defines the fields in the `body` dictionary.
 | --- | --- | --- | --- | --- | --- | --- |
 | [`source-destination-limit`](#source-destination-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-destination-rate-limit`](#source-destination-rate-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
-| [`source-invalid-randomized-response-config`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
+| [`source-output-space-limit`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-noised`](#source-noised) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |
 | [`source-storage-limit`](#source-storage-limit) | ✓ | ✓ | ✓ | ✓ | ✓ | ❌ |
 | [`source-success`](#source-success) | ✓ | ❌ | ✓ | ✓ | ✓ | ❌ |


### PR DESCRIPTION
Move computation of channel capacity out of parsing algorithm for explicit verbose debug reporting.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1223.html" title="Last updated on Apr 6, 2024, 1:14 AM UTC (2ada507)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1223/642d10c...linnan-github:2ada507.html" title="Last updated on Apr 6, 2024, 1:14 AM UTC (2ada507)">Diff</a>