### PR TITLE
Update EVENT.md

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -725,7 +725,7 @@ are already capable of user tracking, the browser will check (at both source
 and trigger registration) for the presence of a special cookie
 set by the reporting origin:
 ```http
-Set-Cookie: ar_debug=1; SameSite=None; Secure; HttpOnly
+Set-Cookie: ar_debug=1; SameSite=None; Secure; Path=/; HttpOnly
 ```
 If a cookie of this form is not present, debugging information will be ignored. Additionally,
 browsers may choose to enable debugging for specific use-cases (for example, reporting origins


### PR DESCRIPTION
Updating the "Set-Cookie" to include the `Path=/` to make sure that wherever the adtech sets the cookie, it will take the index path instead of the path where the cookie is set.