### PR TITLE
Allow empty trigger context ID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2781,7 +2781,7 @@ and a [=moment=] |triggerTime|:
 1. Let |triggerContextID| be null.
 1. If |value|["`trigger_context_id`"] [=map/exists=]:
     1. If |value|["`trigger_context_id`"] is not a [=string=], return null.
-    1. If |value|["`trigger_context_id`"]'s [=string/length=] is 0 or is greater than the [=max length per trigger context ID=],
+    1. If |value|["`trigger_context_id`"]'s [=string/length=] is greater than the [=max length per trigger context ID=],
         return null.
     1. If |aggregatableSourceRegTimeConfig| is not "<code>[=aggregatable source registration time configuration/exclude=]</code>", return null.
     1. Set |triggerContextID| to |value|["`trigger_context_id`"].

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1046,16 +1046,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     ],
   },
   {
-    name: 'trigger-context-id-empty',
-    json: `{"trigger_context_id": ""}`,
-    expectedErrors: [
-      {
-        path: ['trigger_context_id'],
-        msg: 'cannot be empty',
-      },
-    ],
-  },
-  {
     name: 'trigger-context-id-too-long',
     json: `{"trigger_context_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`,
     expectedErrors: [

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1420,10 +1420,6 @@ function triggerContextID(
   aggregatableSourceRegTime: Maybe<AggregatableSourceRegistrationTime>
 ): Maybe<string> {
   return string(ctx, j).filter((s) => {
-    if (s.length === 0) {
-      ctx.error(`cannot be empty`)
-      return false
-    }
     if (s.length > constants.maxLengthPerTriggerContextID) {
       ctx.error(
         `exceeds max length per trigger context ID (${s.length} > ${constants.maxLengthPerTriggerContextID})`


### PR DESCRIPTION
This is more aligned with other strings fields, e.g. filters.