### PR TITLE
Update ara-tester-list.md to include Quantcast as a tester

### DIFF
--- a/ara-tester-list.md
+++ b/ara-tester-list.md
@@ -55,6 +55,7 @@ The usefulness of this page depends on testers sharing information and updates; 
 | Globo | Adtech  | | | adtech-delivery@g.globo |
 | MiQ | Adtech & Managed service  | From 01.01.2024 | coming soon | privacysandbox@miqdigital.com |
 | KelkooGroup | Adtech services for affiliate marketing | From 01.12.2023 | | privacysandbox@kelkoogroup.com |
+| Quantcast | Demand-side platform (DSP) | Testing ongoing | | chrome-privacy-sandbox@quantcast.com |
 
 ## Table - Publishers and Advertisers Interested in Testing or Early Adoption
 Companies who may be interested in participating in tests and early adoption opportunities provided by ad tech companies.


### PR DESCRIPTION
One line change to documentation to include Quantcast in the list of companies that are test the Attribution Reporting API