### PR TITLE
Add TypeScript implementation of filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(OUT_DIR)/index.html: index.bs $(OUT_DIR)
 		exit 22 \
 	);
 
-validator: $(OUT_DIR)/validate-headers.html $(OUT_DIR)/validate-headers.js
+validator: $(OUT_DIR)/validate-headers.html $(OUT_DIR)/validate-headers.js $(OUT_DIR)/filters.html $(OUT_DIR)/filters-main.js
 
 $(OUT_DIR)/validate-headers.html: ts/src/header-validator/index.html $(OUT_DIR)
 	@ cp $< $@
@@ -29,9 +29,15 @@ $(OUT_DIR)/validate-headers.js: ts/dist/header-validator/main.js $(OUT_DIR)
 $(OUT_DIR):
 	@ mkdir -p $@
 
-ts/dist/header-validator/main.js: ts/package.json ts/tsconfig.json ts/webpack.config.js ts/src/*.ts ts/src/*/*.ts
+ts/dist/header-validator/main.js ts/dist/header-validator/filters-main.js: ts/package.json ts/tsconfig.json ts/webpack.config.js ts/src/*.ts ts/src/*/*.ts
 	@ npm ci --prefix ./ts
 	@ npm run pack --prefix ./ts
 
 clean:
 	@ rm -rf $(OUT_DIR)
+
+$(OUT_DIR)/filters.html: ts/src/header-validator/filters.html $(OUT_DIR)
+	@ cp $< $@
+
+$(OUT_DIR)/filters-main.js: ts/dist/header-validator/filters-main.js $(OUT_DIR)
+	@ cp $< $@

--- a/ts/src/header-validator/filters-index.ts
+++ b/ts/src/header-validator/filters-index.ts
@@ -1,0 +1,112 @@
+import { SourceType } from '../source-type'
+import { Context, Issue, PathComponent } from './context'
+import * as filters from './filters'
+import { validateJSON, filterPair, filterData } from './validate-json'
+
+const form = document.querySelector('form')! as HTMLFormElement
+const sourceAgeInput = form.elements.namedItem(
+  'source-age'
+)! as HTMLInputElement
+const filterDataInput = form.elements.namedItem(
+  'filter-data'
+)! as HTMLTextAreaElement
+const filtersInput = form.elements.namedItem('filters')! as HTMLTextAreaElement
+const sourceTypeRadios = form.elements.namedItem(
+  'source-type'
+)! as RadioNodeList
+const sourceErrorList = document.querySelector('#source-errors')!
+const sourceWarningList = document.querySelector('#source-warnings')!
+const triggerErrorList = document.querySelector('#trigger-errors')!
+const triggerWarningList = document.querySelector('#trigger-warnings')!
+const matchesSpan = document.querySelector('#matches')! as HTMLElement
+
+const pathfulTmpl = document.querySelector(
+  '#pathful-issue'
+) as HTMLTemplateElement
+
+function pathPart(p: PathComponent): string {
+  return typeof p === 'string' ? `["${p}"]` : `[${p}]`
+}
+
+function makeLi({ path, msg }: Issue): HTMLElement {
+  let li
+
+  if (Array.isArray(path)) {
+    if (path.length === 0) {
+      li = document.createElement('li')
+      li.textContent = msg
+    } else {
+      li = pathfulTmpl.content.cloneNode(true) as HTMLElement
+      li.querySelector('code')!.textContent = path.map(pathPart).join('')
+      li.querySelector('span')!.textContent = msg
+    }
+  } else {
+    li = document.createElement('li')
+    li.textContent = msg
+  }
+
+  return li
+}
+
+function sourceType(): SourceType {
+  const v = sourceTypeRadios.value
+  if (v in SourceType) {
+    return v as SourceType
+  }
+  throw new TypeError()
+}
+
+const minSourceAge = 0
+const maxSourceAge = 30 * 24 * 60 * 60
+
+function validate(): void {
+  sourceErrorList.replaceChildren()
+  sourceWarningList.replaceChildren()
+  triggerErrorList.replaceChildren()
+  triggerWarningList.replaceChildren()
+
+  const sourceAge = sourceAgeInput.valueAsNumber
+  if (!(sourceAge >= minSourceAge && sourceAge <= maxSourceAge)) {
+    sourceErrorList.append(
+      makeLi({
+        msg: `source age must be in the range [${minSourceAge}, ${maxSourceAge}]`,
+      })
+    )
+  }
+
+  const [filterDataResult, parsedFilterData] = validateJSON(
+    new Context(),
+    filterDataInput.value,
+    filterData
+  )
+  sourceErrorList.append(...filterDataResult.errors.map(makeLi))
+  sourceWarningList.append(...filterDataResult.warnings.map(makeLi))
+
+  const [filtersResult, parsedFilters] = validateJSON(
+    new Context(),
+    filtersInput.value,
+    filterPair
+  )
+  triggerErrorList.append(...filtersResult.errors.map(makeLi))
+  triggerWarningList.append(...filtersResult.warnings.map(makeLi))
+
+  if (
+    parsedFilterData.value === undefined ||
+    parsedFilters.value === undefined
+  ) {
+    matchesSpan.innerText = 'false'
+  } else {
+    matchesSpan.innerText = filters
+      .match(
+        /*sourceTime=*/ 0,
+        parsedFilterData.value,
+        sourceType(),
+        parsedFilters.value,
+        /*triggerTime=*/ sourceAgeInput.valueAsNumber
+      )
+      .toString()
+  }
+}
+
+form.addEventListener('input', validate)
+validate()

--- a/ts/src/header-validator/filters.html
+++ b/ts/src/header-validator/filters.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Attribution Reporting Filters</title>
+<style>
+* {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  height: 100%;
+  margin: 0;
+  padding: 1em;
+  width: 100%;
+}
+
+form {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+form > fieldset {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 0.5em;
+}
+
+form > fieldset > textarea {
+  flex: 1;
+  resize: none;
+}
+</style>
+<body>
+<form>
+  <noscript>JavaScript is required to use this form.</noscript>
+  <fieldset>
+    <legend>Input</legend>
+    <div>
+      <label>Seconds Between Source and Trigger Time: <input type=number min=0 max=2592000 value=2592000 name=source-age required></label>
+      Source Type:
+      <label><input type=radio name=source-type value=event checked>event</label>
+      <label><input type=radio name=source-type value=navigation>navigation</label>
+    </div>
+    <label for=filter-data>Source Filter Data (JSON):</label>
+    <textarea id=filter-data name=filter-data required>{}</textarea>
+    <label for=filters>Trigger Filters (JSON):</label>
+    <textarea id=filters name=filters required>{"filters": [], "not_filters": []}</textarea>
+  </fieldset>
+  <fieldset>
+    <legend>Output</legend>
+    <output>
+      <p>Matches: <span id=matches>false</span>
+      <fieldset>
+        <legend>Source</legend>
+        <p>Errors: <ul id=source-errors></ul>
+        <p>Warnings: <ul id=source-warnings></ul>
+      </fieldset>
+      <fieldset>
+        <legend>Trigger</legend>
+        <p>Errors: <ul id=trigger-errors></ul>
+        <p>Warnings: <ul id=trigger-warnings></ul>
+      </fieldset>
+    </output>
+  </fieldset>
+</form>
+<template id="pathful-issue">
+  <li><code></code> <span></span></li>
+</template>
+<script src="filters-main.js"></script>

--- a/ts/src/header-validator/filters.test.ts
+++ b/ts/src/header-validator/filters.test.ts
@@ -1,0 +1,214 @@
+import { strict as assert } from 'assert'
+import test from 'node:test'
+import { SourceType } from '../source-type'
+import * as filters from './filters'
+import { FilterData, FilterConfig } from './validate-json'
+
+type TestCase = {
+  name: string
+
+  sourceData?: FilterData
+  sourceType?: SourceType
+  filters: FilterConfig[]
+
+  expectedPositive: boolean
+  expectedNegative: boolean
+}
+
+const sourceTime = 1
+const triggerTime = sourceTime + 5
+
+const testCases: TestCase[] = [
+  {
+    name: 'empty',
+    filters: [],
+    expectedPositive: true,
+    expectedNegative: true,
+  },
+
+  {
+    name: 'key-in-source-not-trigger',
+    sourceData: new Map([['x', new Set()]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map(),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: true,
+  },
+  {
+    name: 'key-in-trigger-not-source',
+    sourceData: new Map(),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set()]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: true,
+  },
+  {
+    name: 'key-in-both-empty',
+    sourceData: new Map([['x', new Set()]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set()]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+  {
+    name: 'key-in-both-value-contained',
+    sourceData: new Map([['x', new Set(['1', '2'])]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['2', '4'])]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+  {
+    name: 'key-in-both-value-not-contained',
+    sourceData: new Map([['x', new Set(['1', '2'])]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['3'])]]),
+      },
+    ],
+    expectedPositive: false,
+    expectedNegative: true,
+  },
+
+  {
+    name: 'source_type-navigation',
+    sourceType: SourceType.navigation,
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['source_type', new Set(['navigation'])]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+  {
+    name: 'source_type-event',
+    sourceType: SourceType.event,
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['source_type', new Set(['event'])]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+
+  {
+    name: 'disjunction-match',
+    sourceData: new Map([['x', new Set(['y'])]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['z'])]]),
+      },
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['y'])]]),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: true,
+  },
+  {
+    name: 'disjunction-no-match',
+    sourceData: new Map([['x', new Set(['w'])]]),
+    filters: [
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['z'])]]),
+      },
+      {
+        lookbackWindow: null,
+        map: new Map([['x', new Set(['y'])]]),
+      },
+    ],
+    expectedPositive: false,
+    expectedNegative: true,
+  },
+
+  {
+    name: 'lookback-lt',
+    filters: [
+      {
+        lookbackWindow: triggerTime - sourceTime + 1,
+        map: new Map(),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+  {
+    name: 'lookback-eq',
+    filters: [
+      {
+        lookbackWindow: triggerTime - sourceTime,
+        map: new Map(),
+      },
+    ],
+    expectedPositive: true,
+    expectedNegative: false,
+  },
+  {
+    name: 'lookback-gt',
+    filters: [
+      {
+        lookbackWindow: triggerTime - sourceTime - 1,
+        map: new Map(),
+      },
+    ],
+    expectedPositive: false,
+    expectedNegative: true,
+  },
+]
+
+testCases.forEach((tc) => {
+  const sourceData = tc.sourceData ?? new Map()
+  const sourceType = tc.sourceType ?? SourceType.navigation
+
+  test(`${tc.name}-positive`, () => {
+    const actual = filters.match(
+      sourceTime,
+      sourceData,
+      sourceType,
+      {
+        positive: tc.filters,
+        negative: [],
+      },
+      triggerTime
+    )
+    assert.equal(actual, tc.expectedPositive)
+  })
+
+  test(`${tc.name}-negative`, () => {
+    const actual = filters.match(
+      sourceTime,
+      sourceData,
+      sourceType,
+      {
+        positive: [],
+        negative: tc.filters,
+      },
+      triggerTime
+    )
+    assert.equal(actual, tc.expectedNegative)
+  })
+})

--- a/ts/src/header-validator/filters.ts
+++ b/ts/src/header-validator/filters.ts
@@ -1,0 +1,154 @@
+import { SourceType } from '../source-type'
+import { FilterData, FilterConfig, FilterPair } from './validate-json'
+
+// https://wicg.github.io/attribution-reporting-api/#does-filter-data-match
+function matchFilterValues(a: Set<string>, b: Set<string>): boolean {
+  if (b.size === 0) {
+    if (a.size === 0) {
+      return true
+    }
+    return false
+  }
+
+  for (const ia of a) {
+    if (b.has(ia)) {
+      return true
+    }
+  }
+  return false
+}
+
+// https://wicg.github.io/attribution-reporting-api/#match-filter-values-with-negation
+function matchFilterValuesWithNegation(
+  a: Set<string>,
+  b: Set<string>
+): boolean {
+  if (b.size === 0) {
+    if (a.size > 0) {
+      return true
+    }
+    return false
+  }
+
+  for (const ia of a) {
+    if (b.has(ia)) {
+      return false
+    }
+  }
+  return true
+}
+
+// https://wicg.github.io/attribution-reporting-api/#match-an-attribution-source-against-a-filter-config
+function matchSourceAgainstFilterConfig(
+  sourceTime: number,
+  sourceData: FilterData,
+  { lookbackWindow, map: filterMap }: FilterConfig,
+  moment: number,
+  isNegated: boolean
+): boolean {
+  if (lookbackWindow !== null) {
+    if (moment - sourceTime > lookbackWindow) {
+      if (!isNegated) {
+        return false
+      }
+    } else if (isNegated) {
+      return false
+    }
+  }
+
+  for (const [key, filterValues] of filterMap) {
+    const sourceValues = sourceData.get(key)
+    if (sourceValues === undefined) {
+      continue
+    }
+    if (!isNegated) {
+      if (!matchFilterValues(sourceValues, filterValues)) {
+        return false
+      }
+    } else {
+      if (!matchFilterValuesWithNegation(sourceValues, filterValues)) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+// https://wicg.github.io/attribution-reporting-api/#match-an-attribution-source-against-filters
+function matchSourceAgainstFilters(
+  sourceTime: number,
+  sourceData: FilterData,
+  filters: FilterConfig[],
+  moment: number,
+  isNegated: boolean
+): boolean {
+  if (filters.length === 0) {
+    return true
+  }
+
+  for (const filter of filters) {
+    if (
+      matchSourceAgainstFilterConfig(
+        sourceTime,
+        sourceData,
+        filter,
+        moment,
+        isNegated
+      )
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+// https://wicg.github.io/attribution-reporting-api/#match-an-attribution-source-against-filters-and-negated-filters
+function matchSourceAgainstFiltersAndNegatedFilters(
+  sourceTime: number,
+  sourceData: FilterData,
+  { positive: filters, negative: notFilters }: FilterPair,
+  moment: number
+): boolean {
+  if (
+    !matchSourceAgainstFilters(
+      sourceTime,
+      sourceData,
+      filters,
+      moment,
+      /*isNegated=*/ false
+    )
+  ) {
+    return false
+  }
+
+  if (
+    !matchSourceAgainstFilters(
+      sourceTime,
+      sourceData,
+      notFilters,
+      moment,
+      /*isNegated=*/ true
+    )
+  ) {
+    return false
+  }
+  return true
+}
+
+export function match(
+  sourceTime: number,
+  sourceData: FilterData,
+  sourceType: SourceType,
+  fp: FilterPair,
+  moment: number
+): boolean {
+  sourceData = new Map(sourceData)
+  sourceData.set('source_type', new Set([sourceType]))
+  return matchSourceAgainstFiltersAndNegatedFilters(
+    sourceTime,
+    sourceData,
+    fp,
+    moment
+  )
+}

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -627,7 +627,7 @@ function filterDataKeyValue(
 
 export type FilterData = Map<string, Set<string>>
 
-function filterData(ctx: Context, j: Json): Maybe<FilterData> {
+export function filterData(ctx: Context, j: Json): Maybe<FilterData> {
   return keyValues(
     ctx,
     j,
@@ -693,6 +693,10 @@ export type FilterPair = {
 const filterFields: StructFields<FilterPair> = {
   positive: field('filters', orFilters, []),
   negative: field('not_filters', orFilters, []),
+}
+
+export function filterPair(ctx: Context, j: Json): Maybe<FilterPair> {
+  return struct(ctx, j, filterFields)
 }
 
 export type CommonDebug = {
@@ -1534,7 +1538,7 @@ function trigger(ctx: RegistrationContext, j: Json): Maybe<Trigger> {
     .peek((t) => warnInconsistentAggregatableKeys(ctx, t))
 }
 
-function validateJSON<T, C extends Context = Context>(
+export function validateJSON<T, C extends Context = Context>(
   ctx: C,
   json: string,
   f: CtxFunc<C, Json, Maybe<T>>

--- a/ts/webpack.config.js
+++ b/ts/webpack.config.js
@@ -1,7 +1,10 @@
 const path = require('path')
 
 module.exports = {
-  entry: './src/header-validator/index.ts',
+  entry: {
+    main: './src/header-validator/index.ts',
+    'filters-main': './src/header-validator/filters-index.ts',
+  },
   module: {
     rules: [
       {
@@ -19,7 +22,7 @@ module.exports = {
     extensions: ['.ts', '.js'],
   },
   output: {
-    filename: 'main.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, 'dist', 'header-validator'),
   },
 }


### PR DESCRIPTION
This change adds an interactive form like the header validator to make it easier to experiment with this logic, which is non-trivial.

![filters](https://github.com/WICG/attribution-reporting-api/assets/8644784/85d17bb9-c140-453a-bfff-7c8fafdee15e)