### PR TITLE
Parse OS items in preparation for showing effective value

### DIFF
--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -84,10 +84,8 @@ function validate(): void {
       )[0]
       break
     case 'os-source':
-      result = validateOsRegistration(input.value)
-      break
     case 'os-trigger':
-      result = validateOsRegistration(input.value)
+      result = validateOsRegistration(input.value)[0]
       break
     case 'eligible':
       result = validateEligible(input.value)


### PR DESCRIPTION
In a followup change, we will show the effective value of the header (i.e. with invalid values removed and defaults applied) in the interactive form.