### PR TITLE
Add TypeScript implementation of aggregatable-histogram creation

### DIFF
--- a/ts/src/header-validator/aggregatable-contributions.test.ts
+++ b/ts/src/header-validator/aggregatable-contributions.test.ts
@@ -1,0 +1,281 @@
+import { strict as assert } from 'assert'
+import test from 'node:test'
+import { SourceType } from '../source-type'
+import { createAggregatableContributions } from './aggregatable-contributions'
+import {
+  AggregatableTriggerDatum,
+  AggregatableValuesConfiguration,
+  AggregationKeys,
+  FilterData,
+} from './validate-json'
+
+const sourceTime = 1
+const triggerTime = sourceTime + 5
+
+test('basic', () => {
+  const filterData: FilterData = new Map([['filter', new Set(['value'])]])
+
+  const aggregationKeys: AggregationKeys = new Map([
+    ['key1', 345n],
+    ['key2', 5n],
+    ['key3', 123n],
+  ])
+
+  const aggregatableTriggerData: AggregatableTriggerDatum[] = [
+    // Applies to key1, key3
+    {
+      keyPiece: 1024n,
+      sourceKeys: new Set(['key1', 'key3']),
+      positive: [
+        {
+          map: new Map([['filter', new Set(['value'])]]),
+          lookbackWindow: null,
+        },
+      ],
+      negative: [],
+    },
+    // Applies to key2; key4 is ignored
+    {
+      keyPiece: 2688n,
+      sourceKeys: new Set(['key2', 'key4']),
+      positive: [
+        {
+          map: new Map([['a', new Set(['b', 'c'])]]),
+          lookbackWindow: null,
+        },
+      ],
+      negative: [],
+    },
+    // Ignored due to mismatched filters
+    {
+      keyPiece: 4096n,
+      sourceKeys: new Set(['key1', 'key2']),
+      positive: [
+        {
+          map: new Map([['filter', new Set()]]),
+          lookbackWindow: null,
+        },
+      ],
+      negative: [],
+    },
+    // Ignored due to mismatched negative filters
+    {
+      keyPiece: 4096n,
+      sourceKeys: new Set(['key1', 'key2']),
+      positive: [],
+      negative: [
+        {
+          map: new Map([['filter', new Set(['value'])]]),
+          lookbackWindow: null,
+        },
+      ],
+    },
+    // Ignored due to mismatched lookback window
+    {
+      keyPiece: 4096n,
+      sourceKeys: new Set(['key1', 'key3']),
+      positive: [
+        {
+          map: new Map([['filter', new Set(['value'])]]),
+          lookbackWindow: 4.9,
+        },
+      ],
+      negative: [],
+    },
+  ]
+
+  const aggregatableValuesCfgs: AggregatableValuesConfiguration[] = [
+    {
+      values: new Map([
+        ['key1', 32768],
+        ['key2', 1664],
+      ]),
+      positive: [],
+      negative: [],
+    },
+  ]
+
+  const actual = createAggregatableContributions(
+    filterData,
+    SourceType.event,
+    sourceTime,
+    triggerTime,
+    aggregationKeys,
+    aggregatableTriggerData,
+    aggregatableValuesCfgs
+  )
+  assert.deepEqual(actual, [
+    // key3 is not present as no value is found
+    {
+      key: 1369n,
+      value: 32768,
+    },
+    {
+      key: 2693n,
+      value: 1664,
+    },
+  ])
+})
+
+test('values-filtered', async (t) => {
+  const filterData: FilterData = new Map([['product', new Set(['1'])]])
+
+  const aggregationKeys: AggregationKeys = new Map([
+    ['key1', 345n],
+    ['key2', 5n],
+  ])
+
+  const aggregatableTriggerData: AggregatableTriggerDatum[] = [
+    {
+      keyPiece: 1024n,
+      sourceKeys: new Set(['key1', 'key2']),
+      positive: [],
+      negative: [],
+    },
+  ]
+
+  const createWith = (
+    aggregatableValuesCfgs: AggregatableValuesConfiguration[]
+  ) =>
+    createAggregatableContributions(
+      filterData,
+      SourceType.event,
+      sourceTime,
+      triggerTime,
+      aggregationKeys,
+      aggregatableTriggerData,
+      aggregatableValuesCfgs
+    )
+
+  await t.test('filter-not-matching', () =>
+    assert.deepEqual(
+      createWith([
+        {
+          values: new Map([['key1', 32768]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['2'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+      ]),
+      []
+    )
+  )
+
+  await t.test('first-entry-skipped', () =>
+    assert.deepEqual(
+      createWith([
+        {
+          values: new Map([['key1', 32768]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['2'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+        {
+          values: new Map([['key2', 1664]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+      ]),
+      [{ key: 1029n, value: 1664 }]
+    )
+  )
+
+  await t.test('second-entry-ignored', () =>
+    assert.deepEqual(
+      createWith([
+        {
+          values: new Map([['key1', 32768]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+        {
+          values: new Map([['key2', 1664]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+      ]),
+      [{ key: 1369n, value: 32768 }]
+    )
+  )
+
+  await t.test('filters-matched-keys-mismatched-no-contributions', () =>
+    assert.deepEqual(
+      createWith([
+        {
+          values: new Map([['key3', 32768]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+        // Shouldn't contribute as only the first aggregatable values
+        // entry with matching filters is considered
+        {
+          values: new Map([['key2', 1664]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+      ]),
+      []
+    )
+  )
+
+  await t.test('not-filter-matching-first-entry-skipped', () =>
+    assert.deepEqual(
+      createWith([
+        {
+          values: new Map([['key1', 32768]]),
+          positive: [],
+          negative: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+        },
+        {
+          values: new Map([['key2', 1664]]),
+          positive: [
+            {
+              map: new Map([['product', new Set(['1'])]]),
+              lookbackWindow: null,
+            },
+          ],
+          negative: [],
+        },
+      ]),
+      [{ key: 1029n, value: 1664 }]
+    )
+  )
+})

--- a/ts/src/header-validator/aggregatable-contributions.ts
+++ b/ts/src/header-validator/aggregatable-contributions.ts
@@ -1,0 +1,84 @@
+import { SourceType } from '../source-type'
+import * as filters from './filters'
+import {
+  AggregatableTriggerDatum,
+  AggregatableValues,
+  AggregatableValuesConfiguration,
+  AggregationKeys,
+  FilterData,
+} from './validate-json'
+
+export type AggregatableContribution = {
+  key: bigint
+  value: number
+}
+
+// https://wicg.github.io/attribution-reporting-api/#create-aggregatable-contributions-from-aggregation-keys-and-aggregatable-values
+function createAggregatableContributionsFromKeysAndValues(
+  aggregationKeys: AggregationKeys,
+  aggregatableValues: AggregatableValues
+): AggregatableContribution[] {
+  const contributions = []
+  for (const [id, key] of aggregationKeys) {
+    const value = aggregatableValues.get(id)
+    if (value === undefined) {
+      continue
+    }
+    contributions.push({ key, value })
+  }
+  return contributions
+}
+
+// https://wicg.github.io/attribution-reporting-api/#create-aggregatable-contributions
+export function createAggregatableContributions(
+  filterData: FilterData,
+  sourceType: SourceType,
+  sourceTime: number,
+  triggerTime: number,
+  aggregationKeys: AggregationKeys,
+  aggregatableTriggerData: readonly AggregatableTriggerDatum[],
+  aggregatableValuesConfigurations: readonly AggregatableValuesConfiguration[]
+): AggregatableContribution[] {
+  aggregationKeys = new Map(aggregationKeys)
+
+  for (const triggerData of aggregatableTriggerData) {
+    if (
+      !filters.match(
+        sourceTime,
+        filterData,
+        sourceType,
+        triggerData,
+        triggerTime
+      )
+    ) {
+      continue
+    }
+
+    for (const sourceKey of triggerData.sourceKeys) {
+      const value = aggregationKeys.get(sourceKey)
+      if (value == undefined) {
+        continue
+      }
+      aggregationKeys.set(sourceKey, value | triggerData.keyPiece)
+    }
+  }
+
+  for (const aggregatableValuesConfiguration of aggregatableValuesConfigurations) {
+    if (
+      filters.match(
+        sourceTime,
+        filterData,
+        sourceType,
+        aggregatableValuesConfiguration,
+        triggerTime
+      )
+    ) {
+      return createAggregatableContributionsFromKeysAndValues(
+        aggregationKeys,
+        aggregatableValuesConfiguration.values
+      )
+    }
+  }
+
+  return []
+}

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -746,7 +746,7 @@ function aggregationKey(ctx: Context, [key, j]: [string, Json]): Maybe<bigint> {
   return hex128(ctx, j)
 }
 
-function aggregationKeys(ctx: Context, j: Json): Maybe<Map<string, bigint>> {
+function aggregationKeys(ctx: Context, j: Json): Maybe<AggregationKeys> {
   return keyValues(
     ctx,
     j,
@@ -1154,10 +1154,12 @@ function warnInconsistentMaxEventLevelReportsAndTriggerSpecs(
   }
 }
 
+export type AggregationKeys = Map<string, bigint>
+
 export type Source = CommonDebug &
   Priority & {
     aggregatableReportWindow: number
-    aggregationKeys: Map<string, bigint>
+    aggregationKeys: AggregationKeys
     destination: Set<string>
     expiry: number
     filterData: FilterData
@@ -1279,8 +1281,10 @@ function aggregatableTriggerData(
   )
 }
 
+export type AggregatableValues = Map<string, number>
+
 export type AggregatableValuesConfiguration = FilterPair & {
-  values: Map<string, number>
+  values: AggregatableValues
 }
 
 function aggregatableKeyValue(
@@ -1300,7 +1304,7 @@ function aggregatableKeyValue(
 function aggregatableKeyValues(
   ctx: Context,
   j: Json
-): Maybe<Map<string, number>> {
+): Maybe<AggregatableValues> {
   return keyValues(ctx, j, aggregatableKeyValue)
 }
 


### PR DESCRIPTION
Test cases are derived from
https://source.chromium.org/chromium/chromium/src/+/main:content/browser/attribution_reporting/aggregatable_attribution_utils_unittest.cc;drc=5ab0488632f969a12609bbbf09be18df61825e22

We will add an interactive form for experimenting with these in a followup change.