### PR TITLE
Sort attribution destinations on parsing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1428,15 +1428,16 @@ a [=string=] |key|, and a possibly null 64-bit unsigned integer |default|:
 To <dfn>serialize [=event-level report/attribution destinations=]</dfn> |destinations|, run the following steps:
 
 1. [=Assert=]: |destinations| is not [=set/is empty|empty=].
+1. [=Assert=]: |destinations| is [=list/sort in ascending order|sorted=] in
+    ascending order, with |a| being less than |b| if |a|,
+    <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>,
+    is less than |b|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. Let |destinationStrings| be a [=list=].
 1. [=list/iterate|For each=] |destination| in |destinations|:
     1. [=Assert=]: |destination| is not the [=opaque origin=].
     1. [=list/Append=] |destination| <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a> to |destinationStrings|.
 1. If |destinationStrings|'s [=set/size=] is equal to 1, return |destinationStrings|[0].
 1. Return |destinationStrings|.
-
-Issue: |destinationStrings| should be sorted to avoid revealing the ordering
-of destinations within the original source registration.
 
 To <dfn>check if a scheme is suitable</dfn> given a [=string=] |scheme|:
 
@@ -2084,6 +2085,9 @@ To <dfn>parse attribution destinations</dfn> from a [=map=] |map|:
     1. [=set/Append=] |destination| to |result|.
 1. If |result| [=set/is empty=] or its [=set/size=] is greater than the
     [=max destinations per source=], return null.
+1. [=list/sort in ascending order|Sort=] |result| in ascending order, with |a|
+    being less than |b| if |a|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>,
+    is less than |b|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. Return |result|.
 
 To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, and a

--- a/index.bs
+++ b/index.bs
@@ -1439,6 +1439,12 @@ To <dfn>serialize [=event-level report/attribution destinations=]</dfn> |destina
 1. If |destinationStrings|'s [=set/size=] is equal to 1, return |destinationStrings|[0].
 1. Return |destinationStrings|.
 
+Note: |destinations| is required to be sorted to avoid revealing extra
+information about the original source registration, namely the order of the
+"<code>[=source-registration JSON key/destination=]</code>" field in the
+original JSON registration, which can be used to distinguish semantically
+equivalent registrations.
+
 To <dfn>check if a scheme is suitable</dfn> given a [=string=] |scheme|:
 
 1. If |scheme| is "`http`" or "`https`", return true.
@@ -2089,6 +2095,10 @@ To <dfn>parse attribution destinations</dfn> from a [=map=] |map|:
     being less than |b| if |a|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>,
     is less than |b|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. Return |result|.
+
+Note: Sorting |result| helps ensure that registrations with the same set of
+destinations are equivalent, regardless of the order of sites in the
+registration JSON.
 
 To <dfn>parse a duration</dfn> given a [=map=] |map|, a [=string=] |key|, and a
 tuple of [=durations=] (|clampStart|, |clampEnd|):

--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -345,21 +345,10 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
       "source_type": "navigation",
       "trigger_data": "2"
     }`,
-    expected: Maybe.some({
-      attributionDestination: ['https://d.test', 'https://c.test'],
-      randomizedTriggerRate: 0.4,
-      reportId: 'ac908546-2609-49d9-95b0-b796f9774da6',
-      scheduledReportTime: 789n,
-      sourceDebugKey: null,
-      sourceType: SourceType.navigation,
-      sourceEventId: 1n,
-      triggerData: 2n,
-      triggerDebugKey: null,
-      triggerSummaryBucket: null,
-    }),
-    expectedWarnings: [
+    expected: Maybe.None,
+    expectedErrors: [
       {
-        msg: 'although order is semantically irrelevant, list is expected to be sorted',
+        msg: 'although order is semantically irrelevant, list must be sorted',
         path: ['attribution_destination'],
       },
     ],

--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -334,6 +334,36 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
       },
     ],
   },
+  {
+    name: 'unsorted-destination',
+    json: `{
+      "attribution_destination": ["https://d.test", "https://c.test"],
+      "randomized_trigger_rate": 0.4,
+      "report_id": "ac908546-2609-49d9-95b0-b796f9774da6",
+      "scheduled_report_time": "789",
+      "source_event_id": "1",
+      "source_type": "navigation",
+      "trigger_data": "2"
+    }`,
+    expected: Maybe.some({
+      attributionDestination: ['https://d.test', 'https://c.test'],
+      randomizedTriggerRate: 0.4,
+      reportId: 'ac908546-2609-49d9-95b0-b796f9774da6',
+      scheduledReportTime: 789n,
+      sourceDebugKey: null,
+      sourceType: SourceType.navigation,
+      sourceEventId: 1n,
+      triggerData: 2n,
+      triggerDebugKey: null,
+      triggerSummaryBucket: null,
+    }),
+    expectedWarnings: [
+      {
+        msg: 'although order is semantically irrelevant, list is expected to be sorted',
+        path: ['attribution_destination'],
+      },
+    ],
+  },
 
   {
     name: 'invalid-scheduled-report-time-type',

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1606,15 +1606,16 @@ function reportDestination(ctx: Context, j: Json): Maybe<string | string[]> {
       array(ctx, j, suitableSiteNoExtraneous, {
         minLength: 2,
         maxLength: 3,
-      }).peek((v) => {
+      }).filter((v) => {
         for (let i = 1; i < v.length; ++i) {
           if (v[i]! < v[i - 1]!) {
-            ctx.warning(
-              'although order is semantically irrelevant, list is expected to be sorted'
+            ctx.error(
+              'although order is semantically irrelevant, list must be sorted'
             )
-            break
+            return false
           }
         }
+        return true
       }),
   })
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1603,7 +1603,19 @@ function reportDestination(ctx: Context, j: Json): Maybe<string | string[]> {
   return typeSwitch<string | string[]>(ctx, j, {
     string: (ctx, j) => suitableSiteNoExtraneous(ctx, j),
     list: (ctx, j) =>
-      array(ctx, j, suitableSiteNoExtraneous, { minLength: 2, maxLength: 3 }),
+      array(ctx, j, suitableSiteNoExtraneous, {
+        minLength: 2,
+        maxLength: 3,
+      }).peek((v) => {
+        for (let i = 1; i < v.length; ++i) {
+          if (v[i]! < v[i - 1]!) {
+            ctx.warning(
+              'although order is semantically irrelevant, list is expected to be sorted'
+            )
+            break
+          }
+        }
+      }),
   })
 }
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1272.html" title="Last updated on May 7, 2024, 6:24 PM UTC (76b590f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1272/4d166c8...apasel422:76b590f.html" title="Last updated on May 7, 2024, 6:24 PM UTC (76b590f)">Diff</a>