### PR TITLE
Remove erroneous early return

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1433,7 +1433,7 @@ a [=string=] |key|, and a possibly null 64-bit unsigned integer |default|:
 
 1. If |map|[|key|] does not [=map/exists|exist=], return |default|.
 1. If |map|[|key|] is not a [=string=], return an error.
-1. Return the result of applying the
+1. Let |value| be the result of applying the
     <a spec="html">rules for parsing non-negative integers</a> to |map|[|key|].
 1. If |value| is an error, return an error.
 1. If |value| cannot be represented by a 64-bit unsigned integer, return an


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1293.html" title="Last updated on May 21, 2024, 1:39 PM UTC (b9bf97f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1293/758d2dc...apasel422:b9bf97f.html" title="Last updated on May 21, 2024, 1:39 PM UTC (b9bf97f)">Diff</a>