### PR TITLE
Revert "Prevent coalescing for web source/trigger headers"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1913,11 +1913,6 @@ a [=header value=] or null |webTriggerHeader|, a [=header value=] or null
 
      </dl>
 
-To <dfn>get non-coalesced headers</dfn> given a [=response/header list=] |headers|
-and a [=header name=] header:
-1. Return the [=header value|values=] of all [=header|headers=] in |headers| whose [=header name|name=]
-    is a [=byte-case-insensitive=] match for |header|, in order.
-
 To <dfn export>process an attribution eligible response</dfn> given a [=suitable origin=]
 |contextOrigin|, an [=eligibility=] |eligibility|, a [=boolean=] |fenced|,
 a possibly null [=trigger verification metadata=] |triggerVerificationMetadata|, and a [=response=] |response|:
@@ -1939,16 +1934,12 @@ a possibly null [=trigger verification metadata=] |triggerVerificationMetadata|,
     "<code>[=eligibility/event-source-or-trigger=]</code>".
 1. Let |reportingOrigin| be |response|'s [=response/URL=]'s [=url/origin=].
 1. If |reportingOrigin| is not [=check if an origin is suitable|suitable=], return.
-1. Let |sourceHeaders| be the result of [=get non-coalesced headers=] with |response|'s
-    [=response/header list=] and "`Attribution-Reporting-Register-Source`".
-1. If |sourceHeaders|'s [=list/size=] is greater than 1, return.
-1. Let |sourceHeader| be null.
-1. If |sourceHeaders|'s [=list/size=] is equal to 1, set |sourceHeader| to |sourceHeaders|[0].
-1. Let |triggerHeaders| be the result of [=get non-coalesced headers=] with |response|'s
-    [=response/header list=] and "`Attribution-Reporting-Register-Trigger`".
-1. If |triggerHeaders|'s [=list/size=] is greater than 1, return.
-1. Let |triggerHeader| be null.
-1. If |triggerHeaders|'s [=list/size=] is equal to 1, set |triggerHeader| to |triggerHeaders|[0].
+1. Let |sourceHeader| be the result of [=header list/get|getting=]
+    "`Attribution-Reporting-Register-Source`" from |response|'s
+    [=response/header list=].
+1. Let |triggerHeader| be the result of [=header list/get|getting=]
+    "`Attribution-Reporting-Register-Trigger`" from |response|'s
+    [=response/header list=].
 1. Let |osSourceHeader| be the result of [=header list/get|getting=]
     "`Attribution-Reporting-Register-OS-Source`" from |response|'s
     [=response/header list=].


### PR DESCRIPTION
Reverts WICG/attribution-reporting-api#1212 given issues discussed in https://github.com/WICG/attribution-reporting-api/issues/1202#issuecomment-2121954047.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1294.html" title="Last updated on May 21, 2024, 5:02 PM UTC (cb29b53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1294/9e8cf9f...cb29b53.html" title="Last updated on May 21, 2024, 5:02 PM UTC (cb29b53)">Diff</a>