### PR TITLE
Remove warning about trigger-data sanitization

### DIFF
--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -698,20 +698,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       },
     ],
   },
-  {
-    name: 'trigger-data-sanitized',
-    json: `{"event_trigger_data": [{"trigger_data": "10"}]}`,
-    expectedWarnings: [
-      {
-        path: ['event_trigger_data', 0, 'trigger_data'],
-        msg: 'will be sanitized to 0 if trigger is attributed to event source',
-      },
-      {
-        path: ['event_trigger_data', 0, 'trigger_data'],
-        msg: 'will be sanitized to 2 if trigger is attributed to navigation source',
-      },
-    ],
-  },
 
   {
     name: 'priority-wrong-type',

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -267,22 +267,6 @@ function uint64(ctx: Context, j: Json): Maybe<bigint> {
     )
 }
 
-function triggerData(ctx: Context, j: Json): Maybe<bigint> {
-  return uint64(ctx, j).peek((n) => {
-    Object.entries(constants.defaultTriggerDataCardinality).forEach(
-      ([t, c]) => {
-        if (n >= c) {
-          ctx.warning(
-            `will be sanitized to ${
-              n % c
-            } if trigger is attributed to ${t} source`
-          )
-        }
-      }
-    )
-  })
-}
-
 function number(ctx: Context, j: Json): Maybe<number> {
   return typeSwitch(ctx, j, { number: (_ctx, j) => some(j) })
 }
@@ -1354,7 +1338,7 @@ function eventTriggerData(
 ): Maybe<EventTriggerDatum[]> {
   return array(ctx, j, (ctx, j) =>
     struct(ctx, j, {
-      triggerData: field('trigger_data', triggerData, 0n),
+      triggerData: field('trigger_data', uint64, 0n),
 
       value: ctx.parseFullFlex
         ? field('value', eventTriggerValue, 1)


### PR DESCRIPTION
It is no longer possible to know how trigger data will be modified, if at all, as it depends on the source's trigger_data_matching and trigger_data fields.