### PR TITLE
Rename integer regex

### DIFF
--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -387,7 +387,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be an integer (must match /^-?[0-9]+$/)',
+        msg: 'string must represent an integer (must match /^-?[0-9]+$/)',
         path: ['scheduled_report_time'],
       },
     ],
@@ -426,7 +426,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
         path: ['source_event_id'],
       },
     ],
@@ -465,7 +465,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
         path: ['trigger_data'],
       },
     ],
@@ -584,7 +584,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
         path: ['source_debug_key'],
       },
     ],
@@ -625,7 +625,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
         path: ['trigger_debug_key'],
       },
     ],

--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -387,7 +387,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be an int64 (must match /^-?[0-9]+$/)',
+        msg: 'must be an integer (must match /^-?[0-9]+$/)',
         path: ['scheduled_report_time'],
       },
     ],
@@ -426,7 +426,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
         path: ['source_event_id'],
       },
     ],
@@ -465,7 +465,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
         path: ['trigger_data'],
       },
     ],
@@ -584,7 +584,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
         path: ['source_debug_key'],
       },
     ],
@@ -625,7 +625,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
         path: ['trigger_debug_key'],
       },
     ],

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -480,7 +480,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['source_event_id'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -507,7 +507,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['debug_key'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -534,7 +534,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['priority'],
-        msg: 'must be an int64 (must match /^-?[0-9]+$/)',
+        msg: 'must be an integer (must match /^-?[0-9]+$/)',
       },
     ],
   },
@@ -595,7 +595,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregatable_report_window'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -608,7 +608,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregatable_report_window'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -700,7 +700,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['event_report_window'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -713,7 +713,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['event_report_window'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -759,7 +759,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['expiry'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -772,7 +772,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['expiry'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -480,7 +480,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['source_event_id'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -507,7 +507,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['debug_key'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -534,7 +534,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['priority'],
-        msg: 'must be an integer (must match /^-?[0-9]+$/)',
+        msg: 'string must represent an integer (must match /^-?[0-9]+$/)',
       },
     ],
   },
@@ -595,7 +595,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregatable_report_window'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -608,7 +608,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['aggregatable_report_window'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -700,7 +700,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['event_report_window'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -713,7 +713,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['event_report_window'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -759,7 +759,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['expiry'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -772,7 +772,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['expiry'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -490,7 +490,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['debug_key'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -535,7 +535,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_deduplication_keys', 0, 'deduplication_key'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -694,7 +694,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'trigger_data'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -719,7 +719,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'priority'],
-        msg: 'must be an integer (must match /^-?[0-9]+$/)',
+        msg: 'string must represent an integer (must match /^-?[0-9]+$/)',
       },
     ],
   },
@@ -744,7 +744,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'deduplication_key'],
-        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
+        msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -490,7 +490,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['debug_key'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -535,7 +535,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['aggregatable_deduplication_keys', 0, 'deduplication_key'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -694,7 +694,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'trigger_data'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },
@@ -719,7 +719,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'priority'],
-        msg: 'must be an int64 (must match /^-?[0-9]+$/)',
+        msg: 'must be an integer (must match /^-?[0-9]+$/)',
       },
     ],
   },
@@ -744,7 +744,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     expectedErrors: [
       {
         path: ['event_trigger_data', 0, 'deduplication_key'],
-        msg: 'must be a uint64 (must match /^[0-9]+$/)',
+        msg: 'must be a non-negative integer (must match /^[0-9]+$/)',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -251,7 +251,12 @@ function matchesPattern(
 function uint64(ctx: Context, j: Json): Maybe<bigint> {
   return string(ctx, j)
     .filter((s) =>
-      matchesPattern(ctx, s, uintRegex, 'must be a non-negative integer')
+      matchesPattern(
+        ctx,
+        s,
+        uintRegex,
+        'string must represent a non-negative integer'
+      )
     )
     .map(BigInt)
     .filter((n) =>
@@ -305,7 +310,9 @@ function positiveInteger(ctx: Context, j: Json): Maybe<number> {
 
 function int64(ctx: Context, j: Json): Maybe<bigint> {
   return string(ctx, j)
-    .filter((s) => matchesPattern(ctx, s, intRegex, 'must be an integer'))
+    .filter((s) =>
+      matchesPattern(ctx, s, intRegex, 'string must represent an integer')
+    )
     .map(BigInt)
     .filter((n) =>
       isInRange(

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -12,8 +12,8 @@ const { None, some } = Maybe
 export type JsonDict = { [key: string]: Json }
 export type Json = null | boolean | number | string | Json[] | JsonDict
 
-const uint64Regex = /^[0-9]+$/
-const int64Regex = /^-?[0-9]+$/
+const uintRegex = /^[0-9]+$/
+const intRegex = /^-?[0-9]+$/
 const hex128Regex = /^0[xX][0-9A-Fa-f]{1,32}$/
 
 const UINT32_MAX: number = 2 ** 32 - 1
@@ -250,7 +250,9 @@ function matchesPattern(
 
 function uint64(ctx: Context, j: Json): Maybe<bigint> {
   return string(ctx, j)
-    .filter((s) => matchesPattern(ctx, s, uint64Regex, 'must be a uint64'))
+    .filter((s) =>
+      matchesPattern(ctx, s, uintRegex, 'must be a non-negative integer')
+    )
     .map(BigInt)
     .filter((n) =>
       isInRange(
@@ -303,7 +305,7 @@ function positiveInteger(ctx: Context, j: Json): Maybe<number> {
 
 function int64(ctx: Context, j: Json): Maybe<bigint> {
   return string(ctx, j)
-    .filter((s) => matchesPattern(ctx, s, int64Regex, 'must be an int64'))
+    .filter((s) => matchesPattern(ctx, s, intRegex, 'must be an integer'))
     .map(BigInt)
     .filter((n) =>
       isInRange(


### PR DESCRIPTION
The regex are not validating the sizes of the integers. Renaming to make this clearer.