### PR TITLE
Share struct/field logic for JSON and structured headers

### DIFF
--- a/ts/src/header-validator/validate-info.ts
+++ b/ts/src/header-validator/validate-info.ts
@@ -1,74 +1,62 @@
 import { Context, ValidationResult } from './context'
 import { Maybe } from './maybe'
+import { field, struct, validateDictionary } from './validate-structured'
 import {
   Dictionary,
+  InnerList,
+  Item,
   Token,
-  parseDictionary,
   serializeDictionary,
 } from 'structured-headers'
 
+export type PreferredPlatform = null | 'os' | 'web'
+
 export type Info = {
-  preferredPlatform: null | 'os' | 'web'
+  preferredPlatform: PreferredPlatform
   reportHeaderErrors: boolean
 }
 
+function preferredPlatform(
+  ctx: Context,
+  v: Item | InnerList
+): Maybe<PreferredPlatform> {
+  if (!(v[0] instanceof Token)) {
+    ctx.error('must be a token')
+    return Maybe.None
+  }
+  const token = v[0].toString()
+  if (token !== 'os' && token !== 'web') {
+    ctx.error('must be one of the following (case-sensitive): os, web')
+    return Maybe.None
+  }
+  if (v[1].size !== 0) {
+    ctx.warning('ignoring parameters')
+  }
+  return Maybe.some(token)
+}
+
+function reportHeaderErrors(ctx: Context, v: Item | InnerList): Maybe<boolean> {
+  if (typeof v[0] !== 'boolean') {
+    ctx.error('must be a boolean')
+    return Maybe.None
+  }
+  if (v[1].size !== 0) {
+    ctx.warning('ignoring parameters')
+  }
+  return Maybe.some(v[0])
+}
+
 export function validateInfo(str: string): [ValidationResult, Maybe<Info>] {
-  const ctx = new Context()
-
-  let dict
-  try {
-    dict = parseDictionary(str)
-  } catch (err) {
-    const msg = err instanceof Error ? err.toString() : 'unknown error'
-    return [ctx.finish(msg), Maybe.None]
-  }
-
-  let ok = true
-  let preferredPlatform = null
-  let reportHeaderErrors = false
-
-  for (const [key, value] of dict) {
-    ctx.scope(key, () => {
-      switch (key) {
-        case 'preferred-platform':
-          if (!(value[0] instanceof Token)) {
-            ctx.error('must be a token')
-            ok = false
-            return
-          }
-          const token = value[0].toString()
-          if (token !== 'os' && token !== 'web') {
-            ctx.error('must be one of the following (case-sensitive): os, web')
-            ok = false
-            return
-          }
-          if (value[1].size !== 0) {
-            ctx.warning('ignoring parameters')
-          }
-          preferredPlatform = token
-          break
-        case 'report-header-errors':
-          if (typeof value[0] !== 'boolean') {
-            ctx.error('must be a boolean')
-            ok = false
-            return
-          }
-          if (value[1].size !== 0) {
-            ctx.warning('ignoring parameters')
-          }
-          reportHeaderErrors = value[0]
-          break
-        default:
-          ctx.warning('unknown dictionary key')
-          break
-      }
+  return validateDictionary(new Context(), str, (ctx, d) =>
+    struct(ctx, d, {
+      preferredPlatform: field('preferred-platform', preferredPlatform, null),
+      reportHeaderErrors: field(
+        'report-header-errors',
+        reportHeaderErrors,
+        false
+      ),
     })
-  }
-
-  return [
-    ctx.finish(),
-    ok ? Maybe.some({ preferredPlatform, reportHeaderErrors }) : Maybe.None,
-  ]
+  )
 }
 
 export function serializeInfo(info: Info): string {

--- a/ts/src/header-validator/validate-structured.ts
+++ b/ts/src/header-validator/validate-structured.ts
@@ -1,0 +1,37 @@
+import { Context, ValidationResult } from './context'
+import { Maybe } from './maybe'
+import { CtxFunc } from './validate'
+import * as validate from './validate'
+import {
+  Dictionary,
+  InnerList,
+  Item,
+  parseDictionary,
+} from 'structured-headers'
+
+export const { field, struct } = validate.make<Dictionary, Item | InnerList>(
+  /*getAndDelete=*/ (d, name) => {
+    const v = d.get(name)
+    d.delete(name)
+    return v
+  },
+  /*unknownKeys=*/ (d) => d.keys(),
+  /*warnUnknownMsg=*/ 'unknown dictionary key'
+)
+
+export function validateDictionary<T extends Object, C extends Context>(
+  ctx: C,
+  str: string,
+  f: CtxFunc<C, Dictionary, Maybe<T>>
+): [ValidationResult, Maybe<T>] {
+  let d
+  try {
+    d = parseDictionary(str)
+  } catch (err) {
+    const msg = err instanceof Error ? err.toString() : 'unknown error'
+    return [ctx.finish(msg), Maybe.None]
+  }
+
+  const v = f(ctx, d)
+  return [ctx.finish(), v]
+}

--- a/ts/src/header-validator/validate.ts
+++ b/ts/src/header-validator/validate.ts
@@ -1,0 +1,134 @@
+import { Context } from './context'
+import { Maybe, Maybeable } from './maybe'
+
+export type CtxFunc<C extends Context, I, O> = (ctx: C, i: I) => O
+
+export type StructFields<T extends object, D, C extends Context = Context> = {
+  [K in keyof T]-?: CtxFunc<C, D, Maybe<T[K]>>
+}
+
+type StructFunc<D> = <T extends object, C extends Context>(
+  ctx: C,
+  d: D,
+  fields: StructFields<T, D, C>,
+  warnUnknown?: boolean
+) => Maybe<T>
+
+function struct<D>(
+  unknownKeys: (d: D) => Iterable<string>,
+  warnUnknownMsg: string
+): StructFunc<D> {
+  return <T extends object, C extends Context>(
+    ctx: C,
+    d: D,
+    fields: StructFields<T, D, C>,
+    warnUnknown = true
+  ) => {
+    const t: Partial<T> = {}
+
+    let ok = true
+    for (const prop in fields) {
+      let itemOk = false
+      fields[prop](ctx, d).peek((v) => {
+        itemOk = true
+        t[prop] = v
+      })
+      ok = ok && itemOk
+    }
+
+    if (warnUnknown) {
+      for (const key of unknownKeys(d)) {
+        ctx.scope(key, () => ctx.warning(warnUnknownMsg))
+      }
+    }
+
+    return ok ? Maybe.some(t as T) : Maybe.None
+  }
+}
+
+type GetAndDeleteFunc<D, V> = (d: D, name: string) => V | undefined
+
+type FieldFunc<D, V> = <T, C extends Context>(
+  name: string,
+  f: CtxFunc<C, V, Maybe<T>>,
+  valueIfAbsent?: Maybeable<T>
+) => CtxFunc<C, D, Maybe<T>>
+
+function field<D, V>(getAndDelete: GetAndDeleteFunc<D, V>): FieldFunc<D, V> {
+  return <T, C extends Context>(
+      name: string,
+      f: CtxFunc<C, V, Maybe<T>>,
+      valueIfAbsent?: Maybeable<T>
+    ) =>
+    (ctx: C, d: D): Maybe<T> =>
+      ctx.scope(name, () => {
+        const v = getAndDelete(d, name)
+        if (v === undefined) {
+          if (valueIfAbsent === undefined) {
+            ctx.error('required')
+            return Maybe.None
+          }
+          return Maybe.flatten(valueIfAbsent)
+        }
+        return f(ctx, v)
+      })
+}
+
+export type Exclusive<T, V, C extends Context> = {
+  [key: string]: CtxFunc<C, V, Maybe<T>>
+}
+
+type ExclusiveFunc<D, V> = <T, C extends Context>(
+  x: Exclusive<T, V, C>,
+  valueIfAbsent: Maybeable<T>
+) => CtxFunc<C, D, Maybe<T>>
+
+function exclusive<D, V>(
+  getAndDelete: GetAndDeleteFunc<D, V>
+): ExclusiveFunc<D, V> {
+  return <T, C extends Context>(
+      x: Exclusive<T, V, C>,
+      valueIfAbsent: Maybeable<T>
+    ) =>
+    (ctx: C, d: D): Maybe<T> => {
+      const found: string[] = []
+      let v: Maybe<T> = Maybe.None
+
+      for (const [key, f] of Object.entries(x)) {
+        const j = getAndDelete(d, key)
+        if (j !== undefined) {
+          found.push(key)
+          v = ctx.scope(key, () => f(ctx, j))
+        }
+      }
+
+      if (found.length === 1) {
+        return v
+      }
+
+      if (found.length > 1) {
+        ctx.error(`mutually exclusive fields: ${found.join(', ')}`)
+        return Maybe.None
+      }
+
+      return Maybe.flatten(valueIfAbsent)
+    }
+}
+
+type Funcs<D, V> = {
+  exclusive: ExclusiveFunc<D, V>
+  field: FieldFunc<D, V>
+  struct: StructFunc<D>
+}
+
+export function make<D, V>(
+  getAndDelete: GetAndDeleteFunc<D, V>,
+  unknownKeys: (d: D) => Iterable<string>,
+  warnUnknownMsg: string
+): Funcs<D, V> {
+  return {
+    exclusive: exclusive(getAndDelete),
+    field: field(getAndDelete),
+    struct: struct(unknownKeys, warnUnknownMsg),
+  }
+}


### PR DESCRIPTION
This allows the structured header validators to parse values into well-typed objects without ad-hoc logic.

`validate.ts` is effectively a module parameterized over a map type (`object` for JSON, `Map` for structured headers) and a value type (the `Json` type union for JSON, `Item | InnerList` for structured headers).