### PR TITLE
Always return explicit debug data type for source registration errors and handle in verbose debug report processing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1070,9 +1070,11 @@ Possible values are:
 
 <ul dfn-for="source debug data type">
 <li>"<dfn><code>source-channel-capacity-limit</code></dfn>"
+<li>"<dfn><code>source-destination-global-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
+<li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
@@ -2480,9 +2482,8 @@ To <dfn>check if an [=attribution source=] exceeds the time-based destination li
 
     </dl>
 
-Note: We do not emit an explicit [=source debug data type=] for "<code>[=destination rate-limit result/hit global limit=]</code>",
-we only emit a [=source debug data type/source-success=] type. For this reason, when both limits are hit, just interpret
-it as "<code>[=destination rate-limit result/hit reporting limit=]</code>" to ensure that the most useful report is sent.
+Note: When both limits are hit, we interpret it as "<code>[=destination rate-limit result/hit reporting limit=]</code>"
+for debug reporting.
 
 To <dfn>check if an [=attribution source=] exceeds the unexpired destination limit</dfn> given an
 [=attribution source=] |source|, run the following steps:
@@ -2525,7 +2526,8 @@ a [=trigger state=] |triggerState|:
 1. Return |fakeReport|.
 
 To <dfn>obtain and deliver a debug report on source registration</dfn> given a
-[=source debug data type=] |dataType| and an [=attribution source=] |source|:
+[=source debug data type=] |dataType|, an [=attribution source=] |source|, and
+an optional [=boolean=] |isNoised| (default false):
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
 1. If |source|'s [=attribution source/debug cookie set=] is false, return.
@@ -2538,8 +2540,17 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
     :: |source|'s [=attribution source/source site=], <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
 1. If |source|'s [=attribution source/debug key=] is not null, [=map/set=] |body|["`source_debug_key`"]
     to |source|'s [=attribution source/debug key=], [=serialize an integer|serialized=].
-
+1. Let |dataTypeToReport| be |dataType|.
 1. If |dataType| is:
+    <dl class="switch">
+        : "<code>[=source debug data type/source-destination-global-rate-limit=]</code>"
+        : "<code>[=source debug data type/source-reporting-origin-limit=]</code>"
+        :: Set |dataTypeToReport| to "<code>[=source debug data type/source-success=]</code>".
+
+    </dl>
+1. If |dataTypeToReport| is "<code>[=source debug data type/source-success=]</code>"
+    and |isNoised| is true, set |dataTypeToReport| to "<code>[=source debug data type/source-noised=]</code>".
+1. If |dataTypeToReport| is:
     <dl class="switch">
     : "<code>[=source debug data type/source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
@@ -2564,7 +2575,7 @@ To <dfn>obtain and deliver a debug report on source registration</dfn> given a
     </dl>
 1. Let |data| be a new [=attribution debug data=] with the items:
     : [=attribution debug data/data type=]
-    :: |dataType|
+    :: |dataTypeToReport|
     : [=attribution debug data/body=]
     :: |body|
 1. Run [=obtain and deliver a debug report=] with « |data| », |source|'s [=attribution source/reporting origin=],
@@ -2618,10 +2629,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-rate-limit=]</code>" and |source|.
     1. Return.
 1. Let |debugDataType| be "<code>[=source debug data type/source-success=]</code>".
-1. Set |debugDataType| to "<code>[=source debug data type/source-noised=]</code>"
-    if |source|'s [=attribution source/randomized response=] is not null.
+1. Let |isNoised| be true if |source|'s [=attribution source/randomized response=]
+    is not null, otherwise false.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
-    1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
+    1. Run [=obtain and deliver a debug report on source registration=] with "<code>[=source debug data type/source-destination-global-rate-limit=]</code>", |source|, and |isNoised|.
     1. Return.
 1. Let |newRateLimitRecords| be a new [=set=].
 1. [=set/iterate|For each=] |destination| in |source|'s [=attribution source/attribution destinations=]:
@@ -2642,7 +2653,9 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: null
     1. If the result of running [=should processing be blocked by reporting-origin limit=] with
         |rateLimitRecord| is <strong>blocked</strong>:
-        1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
+        1. Run [=obtain and deliver a debug report on source registration=] with
+            "<code>[=source debug data type/source-reporting-origin-limit=]</code>", |source|,
+            and |isNoised|.
         1. Return.
     1. [=set/Append=] |rateLimitRecord| to |newRateLimitRecords|.
 1. [=set/iterate|For each=] |record| of |newRateLimitRecords|, [=set/append=] |record| to
@@ -2674,7 +2687,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             : [=attribution rate-limit record/event-level report ID=]
             :: null
         1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
-1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType| and |source|.
+1. Run [=obtain and deliver a debug report on source registration=] with |debugDataType|, |source|,
+    and |isNoised|.
 1. [=set/Append=] |source| to |cache|.
 
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the


### PR DESCRIPTION
This allows for more flexibility for other types of debug reporting.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1301.html" title="Last updated on May 24, 2024, 5:11 PM UTC (b2b0a80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1301/c1d4157...linnan-github:b2b0a80.html" title="Last updated on May 24, 2024, 5:11 PM UTC (b2b0a80)">Diff</a>