### PR TITLE
Rename attribution debug reports to verbose debug reports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1136,7 +1136,7 @@ A <dfn>verbose debug data</dfn> is a [=struct=] with the following items:
 
 </dl>
 
-An verbose debug report is a [=struct=] with the following items:
+A verbose debug report is a [=struct=] with the following items:
 
 <dl dfn-for="verbose debug report">
 : <dfn>data</dfn>
@@ -1687,7 +1687,7 @@ To <dfn>obtain and deliver a verbose debug report</dfn> given a [=list=] of [=ve
 a [=suitable origin=] |reportingOrigin|, and a [=boolean=] |fenced|:
 
 1. If |fenced| is true, return.
-1. Let |debugReport| be an [=verbose debug report=] with the items:
+1. Let |debugReport| be a [=verbose debug report=] with the items:
     : [=verbose debug report/data=]
     :: |data|
     : [=verbose debug report/reporting origin=]
@@ -4111,7 +4111,7 @@ To <dfn>attempt to deliver a debug report</dfn> given an [=attribution report=] 
 
 <h3 id="issue-verbose-debug-report-request">Issuing a verbose debug request</h3>
 
-To <dfn>attempt to deliver a verbose debug report</dfn> given an [=verbose debug report=] |report|:
+To <dfn>attempt to deliver a verbose debug report</dfn> given a [=verbose debug report=] |report|:
 
 1. The user-agent MAY ignore the report; if so, return.
 1. Let |url| be the result of executing [=generate a verbose debug report URL=] on |report|.


### PR DESCRIPTION
This allows for supporting other types of debug reports.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1303.html" title="Last updated on May 28, 2024, 2:41 PM UTC (5157c36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1303/a01e250...linnan-github:5157c36.html" title="Last updated on May 28, 2024, 2:41 PM UTC (5157c36)">Diff</a>