### PR TITLE
Set aggregatable report version explicitly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3801,7 +3801,7 @@ of running the following steps:
     : "`scheduled_report_time`"
     :: |report|'s [=aggregatable report/report time=] in seconds since the UNIX epoch, [=serialize an integer|serialized=]
     : "`version`"
-    :: A [=string=], API version.
+    :: "`0.1`"
 
 1. If |report|'s [=aggregatable report/debug mode=] is <strong>enabled</strong>,
     [=map/set=] |sharedInfo|["`debug_mode`"] to "`enabled`".

--- a/index.bs
+++ b/index.bs
@@ -3802,6 +3802,8 @@ of running the following steps:
     :: |report|'s [=aggregatable report/report time=] in seconds since the UNIX epoch, [=serialize an integer|serialized=]
     : "`version`"
     :: "`0.1`"
+    
+    Note: The "`version`" value needs to be bumped if the <a href="https://github.com/privacysandbox/aggregation-service">aggregation service</a> upgrades.
 
 1. If |report|'s [=aggregatable report/debug mode=] is <strong>enabled</strong>,
     [=map/set=] |sharedInfo|["`debug_mode`"] to "`enabled`".


### PR DESCRIPTION
The version should be explicit to match the aggregation service.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1305.html" title="Last updated on May 28, 2024, 4:16 PM UTC (946845d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1305/b2f438e...linnan-github:946845d.html" title="Last updated on May 28, 2024, 4:16 PM UTC (946845d)">Diff</a>