### PR TITLE
Fix erroneous types in filter-data-too-many-values test case

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -350,7 +350,7 @@ const testCases: TestCase[] = [
     name: 'filter-data-too-many-values',
     json: JSON.stringify({
       destination: 'https://a.test',
-      filter_data: { a: Array.from({ length: 51 }, (_, i) => [`${i}`, []]) },
+      filter_data: { a: Array.from({ length: 51 }, (_, i) => `${i}`) },
     }),
     expectedErrors: [
       {


### PR DESCRIPTION
Previously the values were an array of [string, array], rather than an array of string.