### PR TITLE
Prevent duplicates in event-level-report destination field

### DIFF
--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -348,7 +348,26 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
     expected: Maybe.None,
     expectedErrors: [
       {
-        msg: 'although order is semantically irrelevant, list must be sorted',
+        msg: 'although order is semantically irrelevant, list must be sorted and contain no duplicates',
+        path: ['attribution_destination'],
+      },
+    ],
+  },
+  {
+    name: 'duplicate-destination',
+    json: `{
+      "attribution_destination": ["https://a.test", "https://a.test"],
+      "randomized_trigger_rate": 0.4,
+      "report_id": "ac908546-2609-49d9-95b0-b796f9774da6",
+      "scheduled_report_time": "789",
+      "source_event_id": "1",
+      "source_type": "navigation",
+      "trigger_data": "2"
+    }`,
+    expected: Maybe.None,
+    expectedErrors: [
+      {
+        msg: 'although order is semantically irrelevant, list must be sorted and contain no duplicates',
         path: ['attribution_destination'],
       },
     ],

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1576,9 +1576,9 @@ function reportDestination(ctx: Context, j: Json): Maybe<string | string[]> {
         maxLength: 3,
       }).filter((v) => {
         for (let i = 1; i < v.length; ++i) {
-          if (v[i]! < v[i - 1]!) {
+          if (v[i]! <= v[i - 1]!) {
             ctx.error(
-              'although order is semantically irrelevant, list must be sorted'
+              'although order is semantically irrelevant, list must be sorted and contain no duplicates'
             )
             return false
           }


### PR DESCRIPTION
Since destinations are deduplicated during source registration, they can never appear in the report.