### PR TITLE
Compare suitable scopes case-insensitively

### DIFF
--- a/ts/src/header-validator/event_level_report.test.ts
+++ b/ts/src/header-validator/event_level_report.test.ts
@@ -356,7 +356,7 @@ const testCases: jsontest.TestCase<EventLevelReport>[] = [
   {
     name: 'duplicate-destination',
     json: `{
-      "attribution_destination": ["https://a.test", "https://a.test"],
+      "attribution_destination": ["https://a.test", "https://A.test"],
       "randomized_trigger_rate": 0.4,
       "report_id": "ac908546-2609-49d9-95b0-b796f9774da6",
       "scheduled_report_time": "789",

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -107,7 +107,7 @@ const testCases: TestCase[] = [
   },
   {
     name: 'destination-url-components',
-    json: `{"destination": ["https://a.test/b?c=d#e", "https://x.y.test", "https://sub.a.test/z"]}`,
+    json: `{"destination": ["https://a.test/b?c=d#e", "https://x.Y.test", "https://sub.A.test/z"]}`,
     expectedWarnings: [
       {
         path: ['destination', 0],

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -270,7 +270,7 @@ function suitableScope(
   }
 
   const scoped = scope(url)
-  if (s !== scoped) {
+  if (url.toString() !== new URL(scoped).toString()) {
     if (rejectExtraComponents) {
       ctx.error(
         `must not contain URL components other than ${label} (${scoped})`


### PR DESCRIPTION
By round-tripping through the URL parser and serializer.

Without this, spurious issues are generated.