### PR TITLE
Clarify source debug data types that are not reported implicitly for verbose debug reports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3056,9 +3056,12 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 Note: Because a fake report does not have a "real" effective destination, we need to subtract from the
 privacy budget of all possible destinations.
 
-Note: The limits that are not reported as <code>[=source debug data type/source-success=]</code> should be
-checked before any limits that are reported implicitly as <code>[=source debug data type/source-success=]</code>
-to prevent side-channel leakage of cross-origin data. Furthermore, the [=verbose debug data=]
+Note: The limits that are not reported as <code>[=source debug data type/source-success=]</code>
+in [=verbose debug reports=] should be checked before any limits that are reported implicitly as
+<code>[=source debug data type/source-success=]</code> (including
+<code>[=source debug data type/source-destination-global-rate-limit=]</code> and
+<code>[=source debug data type/source-reporting-origin-limit =]</code>) to
+prevent side-channel leakage of cross-origin data. Furthermore, the [=verbose debug data=]
 should be fully determined regardless of the result of checks on implicitly reported limits.
 
 # Triggering Algorithms # {#trigger-algorithms}

--- a/index.bs
+++ b/index.bs
@@ -3060,7 +3060,7 @@ Note: The limits that are not reported as <code>[=source debug data type/source-
 in [=verbose debug reports=] should be checked before any limits that are reported implicitly as
 <code>[=source debug data type/source-success=]</code> (including
 <code>[=source debug data type/source-destination-global-rate-limit=]</code> and
-<code>[=source debug data type/source-reporting-origin-limit =]</code>) to
+<code>[=source debug data type/source-reporting-origin-limit=]</code>) to
 prevent side-channel leakage of cross-origin data. Furthermore, the [=verbose debug data=]
 should be fully determined regardless of the result of checks on implicitly reported limits.
 

--- a/index.bs
+++ b/index.bs
@@ -3058,7 +3058,7 @@ privacy budget of all possible destinations.
 
 Note: The limits that are not reported as <code>[=source debug data type/source-success=]</code>
 in [=verbose debug reports=] should be checked before any limits that are reported implicitly as
-<code>[=source debug data type/source-success=]</code> (including
+<code>[=source debug data type/source-success=]</code> (
 <code>[=source debug data type/source-destination-global-rate-limit=]</code> and
 <code>[=source debug data type/source-reporting-origin-limit=]</code>) to
 prevent side-channel leakage of cross-origin data. Furthermore, the [=verbose debug data=]


### PR DESCRIPTION
This is easier to check the order when new limits were added.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1325.html" title="Last updated on Jun 7, 2024, 1:25 PM UTC (290d16d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1325/f765a4a...linnan-github:290d16d.html" title="Last updated on Jun 7, 2024, 1:25 PM UTC (290d16d)">Diff</a>