### PR TITLE
Allow max attribution rate limit when replacing an event report

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3943,6 +3943,25 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|,
     |trigger|'s [=attribution trigger/trigger time=], |trigger|'s [=attribution trigger/debug key=],
     |matchedConfig|'s [=event-level trigger configuration/priority=], and |specEntry|.
+1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
+    is false:
+     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+         ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
+1. If the result of running [=maybe replace event-level report=] with |sourceToAttribute| and |report| is:
+    <dl class="switch">
+    : "<code>[=event-level-report-replacement result/add-new-report=]</code>"
+    ::
+         1. Do nothing.
+    : "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>"
+    ::
+         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+             ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
+    : "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>"
+    ::
+         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+             ("<code>[=trigger debug data type/trigger-event-low-priority=]</code>", |report|)).
+
+    </dl>
 1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
     : [=attribution rate-limit record/scope=]
     :: "<code>[=rate-limit scope/event-attribution=]</code>"
@@ -3960,29 +3979,11 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
-1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
-    is false:
-     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-         ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
-1. If the result of running [=maybe replace event-level report=] with |sourceToAttribute| and |report| is:
-    <dl class="switch">
-    : "<code>[=event-level-report-replacement result/add-new-report=]</code>"
-    ::
-         1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
-             [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
-         1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:
-             1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-                 ("<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", null)).
-    : "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>"
-    ::
-         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-             ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
-    : "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>"
-    ::
-         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-             ("<code>[=trigger debug data type/trigger-event-low-priority=]</code>", |report|)).
-
-    </dl>
+1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
+    [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
+1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+        ("<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", null)).
 1. Let |triggeringStatus| be "<code>[=triggering status/attributed=]</code>".
 1. Let |debugData| be null.
 1. If |sourceToAttribute|'s [=attribution source/randomized response=] is:


### PR DESCRIPTION
Resolves issue https://github.com/WICG/attribution-reporting-api/issues/1309

In step 15 of https://wicg.github.io/attribution-reporting-api/#trigger-event-level-attribution, we exit early if the number of persisted attribution rate limit records is equal to the max allowed; which means we reach step 17, replacing event-level reports, only if the number of persisted attribution rate limit records is less than the max allowed, even though we keep the number of attribution rate limit records in line with the number of reports by removing attribution rate limit records (step 12 of https://wicg.github.io/attribution-reporting-api/#maybe-replace-event-level-report).

Since having (max-1) persisted attribution rate limit records results in report replacements unlimited by max attributions per rate-limit window, it seems arbitrary to limit such report replacements when we keep max persisted attribution rate limit records.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giladbarkan-github/attribution-reporting-api/pull/1326.html" title="Last updated on Jul 2, 2024, 8:55 PM UTC (0e9ed97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1326/312deee...giladbarkan-github:0e9ed97.html" title="Last updated on Jul 2, 2024, 8:55 PM UTC (0e9ed97)">Diff</a>