### PR TITLE
Use never instead of any with Maybe.None

### DIFF
--- a/ts/src/header-validator/maybe.ts
+++ b/ts/src/header-validator/maybe.ts
@@ -1,7 +1,7 @@
 export type Maybeable<T> = T | Maybe<T>
 
 export class Maybe<T> {
-  static readonly None: Maybe<any> = new Maybe()
+  static readonly None = new Maybe<never>()
 
   static some<T>(t: T): Maybe<T> {
     return new Maybe(t)


### PR DESCRIPTION
Although any was safe due to the underlying field being readonly, never enables more precise type-checking, as such a value can never exist.