### PR TITLE
Remove Maybe.flatten function

### DIFF
--- a/ts/src/header-validator/maybe.ts
+++ b/ts/src/header-validator/maybe.ts
@@ -1,14 +1,8 @@
-export type Maybeable<T> = T | Maybe<T>
-
 export class Maybe<T> {
   static readonly None = new Maybe<never>()
 
   static some<T>(this: void, t: T): Maybe<T> {
     return new Maybe(t)
-  }
-
-  static flatten<T>(this: void, t: Maybeable<T>): Maybe<T> {
-    return t instanceof Maybe ? t : Maybe.some(t)
   }
 
   private constructor(private readonly t?: T) {}
@@ -21,10 +15,17 @@ export class Maybe<T> {
   }
 
   map<U, C extends unknown[]>(
-    f: (t: T, ...args: C) => Maybeable<U>,
+    f: (t: T, ...args: C) => U,
     ...args: C
   ): Maybe<U> {
-    return this.t === undefined ? Maybe.None : Maybe.flatten(f(this.t, ...args))
+    return this.t === undefined ? Maybe.None : new Maybe<U>(f(this.t, ...args))
+  }
+
+  flatMap<U, C extends unknown[]>(
+    f: (t: T, ...args: C) => Maybe<U>,
+    ...args: C
+  ): Maybe<U> {
+    return this.t === undefined ? Maybe.None : f(this.t, ...args)
   }
 
   peek<C extends unknown[]>(f: (t: T, ...args: C) => void, ...args: C): this {


### PR DESCRIPTION
It was unsound because it could be called with a Maybe<T> but its type parameter T instantiated with Maybe<T>, resulting in an apparent return type of Maybe<Maybe<T>>, but the instanceof check would cause the original Maybe<T> to be returned.

For example, the following code logs "number" despite y's type indicating that its value should be another Maybe:

```ts
const x = Maybe.some(5)
const y: Maybe<Maybe<number>> = Maybe.flatten<Maybe<number>>(x)
console.log(typeof y.value)
```