### PR TITLE
Require explicit handling of optional and required fields

### DIFF
--- a/ts/src/header-validator/validate-eligible.ts
+++ b/ts/src/header-validator/validate-eligible.ts
@@ -18,7 +18,14 @@ export type Eligible = {
   trigger: boolean
 }
 
-function presence(v: Item | InnerList, ctx: Context): Maybe<boolean> {
+function presence(
+  v: Item | InnerList | undefined,
+  ctx: Context
+): Maybe<boolean> {
+  if (v === undefined) {
+    return Maybe.some(false)
+  }
+
   if (v[0] !== true) {
     ctx.warning('ignoring dictionary value')
   }
@@ -35,9 +42,9 @@ export function validateEligible(
 ): [ValidationResult, Maybe<Eligible>] {
   return validateDictionary(str, new Context(), (d, ctx) =>
     struct(d, ctx, {
-      navigationSource: field(navigationSourceKey, presence, false),
-      eventSource: field(eventSourceKey, presence, false),
-      trigger: field(triggerKey, presence, false),
+      navigationSource: field(navigationSourceKey, presence),
+      eventSource: field(eventSourceKey, presence),
+      trigger: field(triggerKey, presence),
     }).filter((v) => {
       if (v.navigationSource && (v.eventSource || v.trigger)) {
         ctx.error(

--- a/ts/src/header-validator/validate-info.ts
+++ b/ts/src/header-validator/validate-info.ts
@@ -21,9 +21,12 @@ export type Info = {
 }
 
 function preferredPlatform(
-  v: Item | InnerList,
+  v: Item | InnerList | undefined,
   ctx: Context
-): Maybe<PreferredPlatform> {
+): Maybe<PreferredPlatform | null> {
+  if (v === undefined) {
+    return Maybe.some(null)
+  }
   if (!(v[0] instanceof Token)) {
     ctx.error('must be a token')
     return Maybe.None
@@ -37,7 +40,13 @@ function preferredPlatform(
     })
 }
 
-function reportHeaderErrors(v: Item | InnerList, ctx: Context): Maybe<boolean> {
+function reportHeaderErrors(
+  v: Item | InnerList | undefined,
+  ctx: Context
+): Maybe<boolean> {
+  if (v === undefined) {
+    return Maybe.some(false)
+  }
   if (typeof v[0] !== 'boolean') {
     ctx.error('must be a boolean')
     return Maybe.None
@@ -51,12 +60,8 @@ function reportHeaderErrors(v: Item | InnerList, ctx: Context): Maybe<boolean> {
 export function validateInfo(str: string): [ValidationResult, Maybe<Info>] {
   return validateDictionary(str, new Context(), (d, ctx) =>
     struct(d, ctx, {
-      preferredPlatform: field('preferred-platform', preferredPlatform, null),
-      reportHeaderErrors: field(
-        'report-header-errors',
-        reportHeaderErrors,
-        false
-      ),
+      preferredPlatform: field('preferred-platform', preferredPlatform),
+      reportHeaderErrors: field('report-header-errors', reportHeaderErrors),
     })
   )
 }

--- a/ts/src/header-validator/validate-os.ts
+++ b/ts/src/header-validator/validate-os.ts
@@ -31,17 +31,15 @@ function parseItem(member: InnerList | Item, ctx: Context): Maybe<OsItem> {
 
   return param.struct(member[1], ctx, {
     url: () => Maybe.some(url),
-    debugReporting: param.field(
-      'debug-reporting',
-      (value) => {
-        if (typeof value !== 'boolean') {
-          ctx.warning('ignored, must be a boolean')
-          value = false
-        }
-        return Maybe.some(value)
-      },
-      false
-    ),
+    debugReporting: param.field('debug-reporting', (value) => {
+      if (value === undefined) {
+        value = false
+      } else if (typeof value !== 'boolean') {
+        ctx.warning('ignored, must be a boolean')
+        value = false
+      }
+      return Maybe.some(value)
+    }),
   })
 }
 


### PR DESCRIPTION
This allow us to merge the `field` and `fieldMaybeDefault` functions and makes it harder to accidentally make a field required (or optional).