### PR TITLE
Rename summary window operator to summary operator

### DIFF
--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -76,11 +76,11 @@ In addition to the parameters that were added in Phase 1, we will add one additi
       "end_times": [<int>, ...],
     }
 
-    // Represents an operator that summarizes the triggers within a window
-    // count: number of triggers attributed within a window
-    // value_sum: sum of the value of triggers within a window
+    // Represents an operator that summarizes the triggers attributed to the source.
+    // count: number of triggers attributed
+    // value_sum: sum of the value of triggers
     // Defaults to "count"
-    "summary_window_operator": <one of "count" or "value_sum">,
+    "summary_operator": <one of "count" or "value_sum">,
 
     // Represents a bucketization of the integers from [0, MAX_UINT32], encoded as
     // a list of integers where new buckets begin (excluding 0 which is
@@ -150,7 +150,7 @@ Every trigger registration will match with at most one trigger spec and update i
 * For every trigger spec:
   * Evaluate the `event_trigger_data` on the spec to find a match, using the spec’s `event_reporting_window`
     * The top-level `event_reporting_windows` will act as a default value in case any trigger spec is the missing `event_report_windows` sub-field
-* The first matched spec is chosen for attribution, and we increment its summary value by `value` if the spec's `summary_window_operator` is `value_sum`, or by `1` if it is `count`, saturating in both cases at `MAX_UINT32`.
+* The first matched spec is chosen for attribution, and we increment its summary value by `value` if the spec's `summary_operator` is `value_sum`, or by `1` if it is `count`, saturating in both cases at `MAX_UINT32`.
 
 When the `event_report_window` for a spec completes, we will map its summary value to a bucket, and send an event-level report for every increment in the summary bucket caused by attributed trigger values. Reports will come with one extra field `trigger_summary_bucket`.
 
@@ -223,7 +223,7 @@ It is possible that there are multiple configurations that are equivalent, given
     "event_report_windows": {
       "end_times": [<30 days>]
     },
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1]
   }],
   "max_event_level_reports": 1,
@@ -244,7 +244,7 @@ It is possible that there are multiple configurations that are equivalent, given
     "event_report_windows": {
       "end_times": [<2 days>, <7 days>, <30 days>]
     },
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1, 2, 3]
   }],
   "max_event_level_reports": 3,
@@ -272,7 +272,7 @@ This example configuration supports a developer who wants to optimize for value 
     "event_report_windows": {
       "end_times": [604800, 1209600] // 7 days, 14 days represented in seconds
     },
-    "summary_window_operator": "value_sum",
+    "summary_operator": "value_sum",
     "summary_buckets": [5, 10, 100]
   }],
 }
@@ -333,13 +333,13 @@ This example shows how a developer can configure a source to get a count of trig
       "end_times": [604800] // 7 days represented in seconds
     },
     // This field could be omitted to save bandwidth since the default is "count"
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1, 2, 3, 4]
   }],
 }
 ```
 
-Attributed triggers with `trigger_data` set to 0 are counted and capped at 4. The trigger value is ignored since `summary_window_operator` is set to `count`. Supposing 4 triggers are registered and attributed to the source, the reports would look like this:
+Attributed triggers with `trigger_data` set to 0 are counted and capped at 4. The trigger value is ignored since `summary_operator` is set to `count`. Supposing 4 triggers are registered and attributed to the source, the reports would look like this:
 
 ```jsonc
 // Report 1
@@ -379,7 +379,7 @@ This example configuration supports a developer who wants to learn whether at le
       "end_times": [86400, 172800, 259200, 432000, 604800, 864000]
     },
     // This field could be omitted to save bandwidth since the default is "count"
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1]
   }],
 }

--- a/index.bs
+++ b/index.bs
@@ -680,12 +680,12 @@ Note: The [=report window list/total window=] is conceptually a union of
 [=report windows=], because there are no gaps in time between any of the
 [=report windows|windows=].
 
-<h3 id="summary-windows-operator-header">Summary window operator</h3>
+<h3 id="summary-operator-header">Summary operator</h3>
 
-A <dfn>summary window operator</dfn> summarizes the triggers within a
-[=report window=]. Its value is one of the following:
+A <dfn>summary operator</dfn> summarizes the triggers attributed to an
+[=attribution source=]. Its value is one of the following:
 
-<dl dfn-for="summary window operator">
+<dl dfn-for="summary operator">
 : "<dfn><code>count</code></dfn>"
 :: Number of triggers attributed.
 : "<dfn><code>value_sum</code></dfn>"
@@ -2419,7 +2419,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>source_event_id</code></dfn>"
 <li>"<dfn><code>start_time</code></dfn>"
 <li>"<dfn><code>summary_buckets</code></dfn>"
-<li>"<dfn><code>summary_window_operator</code></dfn>"
+<li>"<dfn><code>summary_operator</code></dfn>"
 <li>"<dfn><code>trigger_data</code></dfn>"
 <li>"<dfn><code>trigger_data_matching</code></dfn>"
 <li>"<dfn><code>trigger_specs</code></dfn>"
@@ -2564,15 +2564,15 @@ non-normative behavior described in the
 <a href="https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md">Flexible event-level configurations</a>
 proposal.
 
-To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
+To <dfn>parse summary operator</dfn> given a [=map=] |map|:
 
-1. Let |value| be "<code>[=summary window operator/count=]</code>".
-1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] [=map/exists=]:
-    1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] is not a [=string=], return an
+1. Let |value| be "<code>[=summary operator/count=]</code>".
+1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] [=map/exists=]:
+    1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] is not a [=string=], return an
         error.
-    1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] is not a
-        [=summary window operator=], return an error.
-    1. Set |value| to |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"].
+    1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] is not a
+        [=summary operator=], return an error.
+    1. Set |value| to |map|["<code>[=source-registration JSON key/summary_operator=]</code>"].
 1. Return |value|.
 
 To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxEventLevelReports|:
@@ -2672,7 +2672,7 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. Set |i| to |i| + 1.
 1. Return |specs|.
 
-Issue: Invoke [=parse summary buckets=] and [=parse summary window operator=]
+Issue: Invoke [=parse summary buckets=] and [=parse summary operator=]
 from this algorithm.
 
 To <dfn>parse a source aggregatable debug reporting config</dfn> given |value|, a

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -5,7 +5,7 @@ import { Maybe } from './maybe'
 import { serializeSource } from './to-json'
 import {
   Source,
-  SummaryWindowOperator,
+  SummaryOperator,
   TriggerDataMatching,
   validateSource,
 } from './validate-json'
@@ -72,7 +72,7 @@ const testCases: TestCase[] = [
             endTimes: [3601],
           },
           summaryBuckets: [1, 2],
-          summaryWindowOperator: SummaryWindowOperator.count,
+          summaryOperator: SummaryOperator.count,
           triggerData: new Set([0, 1, 2, 3, 4, 5, 6, 7]),
         },
       ],
@@ -2357,35 +2357,35 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'summary-window-operator-wrong-type',
+    name: 'summary-operator-wrong-type',
     json: `{
       "destination": "https://a.test",
       "trigger_specs": [{
         "trigger_data": [3],
-        "summary_window_operator": 4
+        "summary_operator": 4
       }]
     }`,
     parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'summary_window_operator'],
+        path: ['trigger_specs', 0, 'summary_operator'],
         msg: 'must be a string',
       },
     ],
   },
   {
-    name: 'summary-window-operator-wrong-value',
+    name: 'summary-operator-wrong-value',
     json: `{
       "destination": "https://a.test",
       "trigger_specs": [{
         "trigger_data": [3],
-        "summary_window_operator": "VALUE_SUM"
+        "summary_operator": "VALUE_SUM"
       }]
     }`,
     parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'summary_window_operator'],
+        path: ['trigger_specs', 0, 'summary_operator'],
         msg: 'must be one of the following (case-sensitive): count, value_sum',
       },
     ],

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -105,7 +105,7 @@ function serializeTriggerData(d: Set<number>): TriggerData {
 export type TriggerSpec = EventReportWindows &
   TriggerData & {
     summary_buckets: number[]
-    summary_window_operator: string
+    summary_operator: string
   }
 
 function serializeTriggerSpec(ts: parsed.TriggerSpec): TriggerSpec {
@@ -114,7 +114,7 @@ function serializeTriggerSpec(ts: parsed.TriggerSpec): TriggerSpec {
     ...serializeTriggerData(ts.triggerData),
 
     summary_buckets: Array.from(ts.summaryBuckets),
-    summary_window_operator: ts.summaryWindowOperator,
+    summary_operator: ts.summaryOperator,
   }
 }
 

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -759,7 +759,7 @@ function channelCapacity(s: Source, ctx: SourceContext): void {
   }
 }
 
-export enum SummaryWindowOperator {
+export enum SummaryOperator {
   count = 'count',
   value_sum = 'value_sum',
 }
@@ -767,7 +767,7 @@ export enum SummaryWindowOperator {
 export type TriggerSpec = {
   eventReportWindows: EventReportWindows
   summaryBuckets: number[]
-  summaryWindowOperator: SummaryWindowOperator
+  summaryOperator: SummaryOperator
   triggerData: Set<number>
 }
 
@@ -887,10 +887,10 @@ function triggerSpec(
       deps.maxEventLevelReports
     ),
 
-    summaryWindowOperator: field(
-      'summary_window_operator',
-      withDefault(enumerated, SummaryWindowOperator.count),
-      SummaryWindowOperator
+    summaryOperator: field(
+      'summary_operator',
+      withDefault(enumerated, SummaryOperator.count),
+      SummaryOperator
     ),
 
     triggerData: field('trigger_data', required(triggerDataSet)),
@@ -954,7 +954,7 @@ function triggerSpecsFromTriggerData(
         summaryBuckets: makeDefaultSummaryBuckets(
           deps.maxEventLevelReports.value
         ),
-        summaryWindowOperator: SummaryWindowOperator.count,
+        summaryOperator: SummaryOperator.count,
         triggerData: triggerData,
       },
     ]
@@ -974,7 +974,7 @@ function defaultTriggerSpecs(
           { length: maxEventLevelReports },
           (_, i) => i + 1
         ),
-        summaryWindowOperator: SummaryWindowOperator.count,
+        summaryOperator: SummaryOperator.count,
         triggerData: new Set(
           Array.from(
             {


### PR DESCRIPTION
Fixes #1343


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1346.html" title="Last updated on Jun 24, 2024, 6:04 PM UTC (190d031)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1346/ae7d42b...apasel422:190d031.html" title="Last updated on Jun 24, 2024, 6:04 PM UTC (190d031)">Diff</a>