### PR TITLE
Add non-normative note for event-level reports deletion for unexpired destination limit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2890,6 +2890,15 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
         and |report|'s [=event-level report/trigger time=] is greater than or equal to |now|:
         1. [=set/Append=] |report|'s [=event-level report/report ID=] to |deletedEventLevelReports|.
         1. [=set/Remove=] |report| from the [=event-level report cache=].
+
+    Note: The privacy concern on leaking browsing history of destinations
+    deactivated for unexpired destination limit from [=event-level reports=]
+    whose [=event-level report/trigger time=] is earlier than |now| is mitigated
+    by the presence of [=obtain a fake report|fake reports=]. [=Event-level reports=]
+    whose [=event-level report/trigger time=] is greater than or equal to |now|
+    must be deleted to avoid exposing whether an [=attribution source=] has
+    [=attribution source/randomized response=].
+
 1. Let |deletedAggregatableReports| be a new [=set=].
 1. [=set/iterate|For each=] [=aggregatable attribution report=] |report| of the [=aggregatable attribution report cache=]:
     1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable attribution report/source identifier=]:

--- a/index.bs
+++ b/index.bs
@@ -2896,7 +2896,7 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
     whose [=event-level report/trigger time=] is earlier than |now| is mitigated
     by the presence of [=obtain a fake report|fake reports=]. [=Event-level reports=]
     whose [=event-level report/trigger time=] is greater than or equal to |now|
-    must be deleted to avoid exposing whether an [=attribution source=] has
+    must be deleted to avoid exposing whether an [=attribution source=] has a
     [=attribution source/randomized response=].
 
 1. Let |deletedAggregatableReports| be a new [=set=].

--- a/index.bs
+++ b/index.bs
@@ -2891,13 +2891,12 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
         1. [=set/Append=] |report|'s [=event-level report/report ID=] to |deletedEventLevelReports|.
         1. [=set/Remove=] |report| from the [=event-level report cache=].
 
-    Note: The privacy concern on leaking browsing history of destinations
-    deactivated for unexpired destination limit from [=event-level reports=]
-    whose [=event-level report/trigger time=] is earlier than |now| is mitigated
-    by the presence of [=obtain a fake report|fake reports=]. [=Event-level reports=]
-    whose [=event-level report/trigger time=] is greater than or equal to |now|
-    must be deleted to avoid exposing whether an [=attribution source=] has a
-    [=attribution source/randomized response=].
+    Note: Leaking browsing history of destinations deactivated for unexpired
+    destination limit from [=event-level reports=] whose [=event-level report/trigger time=]
+    is earlier than |now| is mitigated by the presence of [=obtain a fake report|fake reports=].
+    [=Event-level reports=] whose [=event-level report/trigger time=] is greater
+    than or equal to |now| must be deleted to avoid exposing whether an
+    [=attribution source=] has a [=attribution source/randomized response=].
 
 1. Let |deletedAggregatableReports| be a new [=set=].
 1. [=set/iterate|For each=] [=aggregatable attribution report=] |report| of the [=aggregatable attribution report cache=]:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1351.html" title="Last updated on Jul 1, 2024, 5:37 PM UTC (f40ddfd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1351/bacfb84...linnan-github:f40ddfd.html" title="Last updated on Jul 1, 2024, 5:37 PM UTC (f40ddfd)">Diff</a>