### PR TITLE
Parsing changes for Pre-Attribution Filtering: Attribution Scope

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2736,8 +2736,8 @@ To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a pos
 1. Return |result|.
 
 Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
-to prevent the selection of both sources with and without scopes 
-if |attributionScopeLimit| is set to 1, which would effectively result in two scopes.
+to prevent the selection of both sources with and without scopes which would effectively
+result in |attributionScopeLimit| + 1 scopes.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a

--- a/index.bs
+++ b/index.bs
@@ -845,6 +845,12 @@ An attribution source is a [=struct=] with the following items:
 :: An [=aggregatable debug reporting config=].
 : <dfn>destination limit priority</dfn>
 :: A 64-bit integer.
+: <dfn>attribution scope limit</dfn>
+:: Null or a positive 32-bit integer representing the number of distinct [=attribution source/attribution scopes=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+: <dfn>attribution scopes</dfn>
+:: A [=set=] of [=strings=].
+: <dfn>max event states</dfn>
+:: A positive integer representing the maximum number of [=trigger states=] for [=source type/event=] sources per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
 
 </dl>
 
@@ -985,6 +991,8 @@ An attribution trigger is a [=struct=] with the following items:
 :: A positive integer.
 : <dfn>aggregatable debug reporting config</dfn>
 :: An [=aggregatable debug reporting config=].
+: <dfn>attribution scopes</dfn>
+:: A [=set=] of [=strings=].
 
 </dl>
 
@@ -1155,6 +1163,7 @@ Possible values are:
 <li>"<dfn><code>source-destination-limit-replaced</code></dfn>"
 <li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
+<li>"<dfn><code>source-max-event-states-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
@@ -1413,6 +1422,17 @@ per [=aggregatable debug rate-limit window=]. The second controls the total
 [=aggregatable debug report/required aggregatable budget=] of all [=aggregatable debug reports=]
 with a given ([=aggregatable debug rate-limit record/context site=], [=aggregatable debug rate-limit record/reporting site=])
 per [=aggregatable debug rate-limit window=]. Its value is (2<sup>20</sup>, 65536).
+
+<dfn>Default max event states</dfn> is a positive integer that controls the
+default [=attribution source/max event states=]. Its value is 3.
+
+<dfn>Max length of attribution scope for source</dfn> is a positive integer that controls the
+maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution source/attribution scopes=].
+Its value is 50.
+
+<dfn>Max attribution scopes per source</dfn> is a positive integer that controls the
+maximum [=set/size=] of an [=attribution source=]'s [=attribution source/attribution scopes=].
+Its value is 20.
 
 # Vendor-Specific Values # {#vendor-specific-values}
 
@@ -2401,6 +2421,8 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_report_window</code></dfn>"
 <li>"<dfn><code>aggregation_keys</code></dfn>"
 <li>"<dfn><code>budget</code></dfn>"
+<li>"<dfn><code>attribution_scope_limit</code></dfn>"
+<li>"<dfn><code>attribution_scopes</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>destination</code></dfn>"
@@ -2412,6 +2434,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>expiry</code></dfn>"
 <li>"<dfn><code>filter_data</code></dfn>"
 <li>"<dfn><code>max_event_level_reports</code></dfn>"
+<li>"<dfn><code>max_event_states</code></dfn>"
 <li>"<dfn><code>priority</code></dfn>"
 <li>"<dfn><code>source_event_id</code></dfn>"
 <li>"<dfn><code>start_time</code></dfn>"
@@ -2687,6 +2710,32 @@ non-negative integer |defaultBudget|, and an [=aggregatable debug reporting conf
     with |value|, |budget|, |supportedTypes|, and |defaultConfig|.
 1. Return the [=tuple=] (|budget|, |config|).
 
+To <dfn>parse max event states</dfn> from a [=map=] |map| and
+a possibly null 32-bit positive integer |attributionScopeLimit|:
+1. Let |maxEventStates| be [=default max event states=].
+1. If |map|["<code>[=source-registration JSON key/max_event_states=]</code>"] [=map/exists=], set |maxEventStates| to |map|["<code>[=source-registration JSON key/max_event_states=]</code>"].
+1. If |maxEventStates| is not an integer or is less than or equal to 0, return an error.
+1. If |maxEventStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
+1. If |maxEventStates| is not equal to [=default max event states=] and |attributionScopeLimit| is null, return an error.
+1. Return |maxEventStates|.
+
+To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a possibly null 32-bit positive integer |attributionScopeLimit|:
+1. Let |result| be a new [=set=].
+1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return |result|.
+1. Let |values| be |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"].
+1. If |values| is not a [=list=], return an error.
+1. [=list/iterate|For each=] |value| of |values|:
+    1. If |value| is not a [=string=], return an error.
+    1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.
+    1. [=set/Append=] |value| to |result|.
+1. If |attributionScopeLimit| is null:
+    1. If |result| is not [=set/is empty|empty=], return an error.
+    1. Return |result|.
+1. If |result| [=set/is empty=], return an error.
+1. If |result|'s [=set/size=] is greater than |attributionScopeLimit|, return an error.
+1. If |result|'s [=set/size=] is greater than [=max attribution scopes per source=], return an error.
+1. Return |result|.
+
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
 [=source type=] |sourceType|, a [=moment=] |sourceTime|, and a [=boolean=] |fenced|:
@@ -2756,6 +2805,15 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
     |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
 1. If |triggerSpecs| is an error, return null.
+1. Let |attributionScopeLimit| be null.
+1. If |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"] [=map/exists=]:
+    1. Set |attributionScopeLimit| to |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"].
+    1. If |attributionScopeLimit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return null.
+1. Let |maxEventStates| be the result of running
+    [=parse max event states=] with |value| and |attributionScopeLimit|.
+1. If |maxEventStates| is an error, return null.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes for source=] with |value| and |attributionScopeLimit|.
+1. If |attributionScopes| is an error, return null.
 1. Let |epsilon| be the user agent's [=max settable event-level epsilon=].
 1. Set |epsilon| to |value|["<code>[=source-registration JSON key/event_level_epsilon=]</code>"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
@@ -2822,6 +2880,12 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |aggregatableDebugReportingConfig|
     : [=attribution source/destination limit priority=]
     :: |destinationLimitPriority|
+    : [=attribution source/attribution scopes=]
+    :: |attributionScopes|
+    : [=attribution source/attribution scope limit=]
+    :: |attributionScopeLimit|
+    : [=attribution source/max event states=]
+    :: |maxEventStates|
 1. Return |source|.
 
 Issue: Determine proper charset-handling for the JSON header value.
@@ -3165,6 +3229,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
+1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/max event states=]:
+    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
+    1. Return.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
     [=attribution sources=] |pendingSource| of the [=attribution source cache=] where |pendingSource|'s
     [=attribution source/source origin=] and |source|'s
@@ -3288,6 +3356,7 @@ A <dfn>trigger-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_trigger_data</code></dfn>"
 <li>"<dfn><code>aggregatable_values</code></dfn>"
 <li>"<dfn><code>aggregation_coordinator_origin</code></dfn>"
+<li>"<dfn><code>attribution_scopes</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>deduplication_key</code></dfn>"
@@ -3503,6 +3572,16 @@ To <dfn>parse aggregatable dedup keys</dfn> given a [=map=] |map|:
     1. [=set/Append=] |aggregatableDedupKey| to |aggregatableDedupKeys|.
 1. Return |aggregatableDedupKeys|.
 
+To <dfn>parse attribution scopes for trigger</dfn> from a [=map=] |map|:
+1. Let |result| be a new [=set=].
+1. If |map|["<code>[=trigger-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return |result|.
+1. Let |values| be |map|["<code>[=trigger-registration JSON key/attribution_scopes=]</code>"].
+1. If |values| is not a [=list=], return an error.
+1. [=list/iterate|For each=] |value| of |values|:
+    1. If |value| is not a [=string=], return an error.
+    1. [=set/Append=] |value| to |result|.
+1. Return |result|.
+
 To <dfn noexport>create an attribution trigger</dfn> given a [=byte sequence=]
 |json|, a [=site=] |destination|, a [=suitable origin=] |reportingOrigin|, a [=list=] of [=trigger verification=] |triggerVerifications|,
 a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
@@ -3558,6 +3637,8 @@ a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
     1. Set |aggregatableDebugReportingConfig| to the result of running [=parse an aggregatable debug reporting config=]
         with |value|["<code>[=trigger-registration JSON key/aggregatable_debug_reporting=]</code>"],
         [=allowed aggregatable budget per source=], |supportedTypes|, and |aggregatableDebugReportingConfig|.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes for trigger=] with |value|.
+1. If |attributionScopes| is an error, return null.
 1. Let |trigger| be a new [=attribution trigger=] with the items:
     : [=attribution trigger/attribution destination=]
     :: |destination|
@@ -3595,6 +3676,8 @@ a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
     :: |filteringIdsMaxBytes|
     : [=attribution trigger/aggregatable debug reporting config=]
     :: |aggregatableDebugReportingConfig|
+    : [=attribution trigger/attribution scopes=]
+    :: |attributionScopes|
 1. If |aggregatableSourceRegTimeConfig| is not "<code>[=aggregatable source registration time configuration/exclude=]</code>"
     and the result of running [=check if an aggregatable attribution report should be unconditionally sent=] with |trigger| is true, return null.
 1. Return |trigger|.

--- a/index.bs
+++ b/index.bs
@@ -1163,7 +1163,6 @@ Possible values are:
 <li>"<dfn><code>source-destination-limit-replaced</code></dfn>"
 <li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
-<li>"<dfn><code>source-max-event-states-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"

--- a/index.bs
+++ b/index.bs
@@ -2736,7 +2736,7 @@ To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a pos
 1. Return |result|.
 
 Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
-to prevent the selection of both buckets with and without scopes 
+to prevent the selection of both sources with and without scopes 
 if |attributionScopeLimit| is set to 1, which would effectively result in two scopes.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]

--- a/index.bs
+++ b/index.bs
@@ -2735,6 +2735,10 @@ To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a pos
 1. If |result|'s [=set/size=] is greater than [=max attribution scopes per source=], return an error.
 1. Return |result|.
 
+Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
+to prevent the selection of both buckets with and without scopes 
+if |attributionScopeLimit| is set to 1, which would effectively result in two scopes.
+
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
 [=source type=] |sourceType|, a [=moment=] |sourceTime|, and a [=boolean=] |fenced|:

--- a/index.bs
+++ b/index.bs
@@ -3229,10 +3229,6 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
-1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/max event states=]:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
-    1. Return.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
     [=attribution sources=] |pendingSource| of the [=attribution source cache=] where |pendingSource|'s
     [=attribution source/source origin=] and |source|'s

--- a/index.bs
+++ b/index.bs
@@ -2736,7 +2736,7 @@ To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a pos
 1. Return |result|.
 
 Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
-to prevent the selection of both sources with and without scopes which would effectively
+to prevent the selection of both sources with and without scopes, which would effectively
 result in |attributionScopeLimit| + 1 scopes.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -19,6 +19,10 @@ export const maxLengthPerAggregationKeyIdentifier: number = 25
 
 export const maxLengthPerTriggerContextID: number = 64
 
+export const maxAttributionScopesPerSource: number = 20
+
+export const maxLengthPerAttributionScope: number = 50
+
 export const minReportWindow: number = 1 * SECONDS_PER_HOUR
 
 export const validSourceExpiryRange: Readonly<[min: number, max: number]> = [
@@ -96,3 +100,5 @@ export const triggerAggregatableDebugTypes: Readonly<[string, ...string[]]> = [
   'trigger-unknown-error',
   'unspecified',
 ]
+
+export const defaultMaxEventStates: number = 3

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2649,7 +2649,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['max_event_states'],
-        msg: 'non-default if attribution_scope_limit is not set',
+        msg: 'non-default (3) if attribution_scope_limit is not set',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2623,7 +2623,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scopes'],
-        msg: 'length must be in the range [1, 3]',
+        msg: 'must be non-empty if attribution_scope_limit is set',
       },
     ],
   },
@@ -2636,7 +2636,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scopes'],
-        msg: 'length must be in the range [0, 0]',
+        msg: 'must be empty if attribution_scope_limit is not set',
       },
     ],
   },
@@ -2649,7 +2649,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['max_event_states'],
-        msg: 'non-default max_event_states when attribution_scope_limit is not set',
+        msg: 'non-default if attribution_scope_limit is not set',
       },
     ],
   },
@@ -2705,7 +2705,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scopes'],
-        msg: 'length must be in the range [1, 1]',
+        msg: 'size must be less than or equal to attribution_scope_limit (1) if attribution_scope_limit is set',
       },
     ],
   },
@@ -2719,10 +2719,6 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scopes', 0],
-        msg: 'must be a string',
-      },
-      {
-        path: ['attribution_scopes', 1],
         msg: 'must be a string',
       },
     ],
@@ -2758,7 +2754,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scopes'],
-        msg: 'length must be in the range [1, 20]',
+        msg: 'size must be less than or equal to max number of attribution scopes (20) if attribution_scope_limit is set',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2649,7 +2649,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['max_event_states'],
-        msg: 'non-default (3) if attribution_scope_limit is not set',
+        msg: 'must be default (3) if attribution_scope_limit is not set',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2714,7 +2714,7 @@ const testCases: TestCase[] = [
     json: `{
       "destination": "https://a.test",
       "attribution_scope_limit": 2,
-      "attribution_scopes": [1, 2]
+      "attribution_scopes": [1]
     }`,
     expectedErrors: [
       {

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2623,7 +2623,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scope_limit'],
-        msg: 'attribution scopes size must be in the range [1, 3]',
+        msg: 'attribution_scope_limit must be great or equal to the number of attribution scopes 3',
       },
     ],
   },
@@ -2649,7 +2649,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scope_limit'],
-        msg: 'must be set if max_event_states is set',
+        msg: 'must be set if non-default max_event_states value is set',
       },
     ],
   },
@@ -2705,7 +2705,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scope_limit'],
-        msg: 'attribution scopes size must be in the range [1, 1]',
+        msg: 'attribution_scope_limit must be great or equal to the number of attribution scopes 1',
       },
     ],
   },
@@ -2751,7 +2751,6 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-many',
     json: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
       "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
     }`,
     expectedErrors: [

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -49,7 +49,10 @@ const testCases: TestCase[] = [
           "types": ["source-success"],
           "value": 123
         } ]
-      }
+      },
+      "attribution_scope_limit": 3,
+      "attribution_scopes": ["1"],
+      "max_event_states": 4
     }`,
     sourceType: SourceType.navigation,
     expected: Maybe.some({
@@ -90,6 +93,9 @@ const testCases: TestCase[] = [
         aggregationCoordinatorOrigin:
           'https://publickeyservice.msmt.aws.privacysandboxservices.com',
       },
+      attributionScopeLimit: 3,
+      attributionScopes: new Set<string>('1'),
+      maxEventStates: 4,
     }),
   },
 
@@ -1367,7 +1373,12 @@ const testCases: TestCase[] = [
   },
   {
     name: 'trigger-state-cardinality-invalid',
-    json: `{"destination": "https://a.test"}`,
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 3,
+      "attribution_scopes": ["1"],
+      "max_event_states": 2
+    }`,
     sourceType: SourceType.event,
     vsv: {
       maxEventLevelChannelCapacityPerSource: {
@@ -1381,6 +1392,10 @@ const testCases: TestCase[] = [
       {
         path: [],
         msg: 'number of possible output states (3) exceeds max cardinality (2)',
+      },
+      {
+        path: [],
+        msg: 'number of possible output states (3) exceeds max event states (2)',
       },
     ],
   },
@@ -2541,6 +2556,222 @@ const testCases: TestCase[] = [
       {
         path: [],
         msg: 'max_event_level_reports > 0 but event-level attribution will always fail because trigger_specs is empty',
+      },
+    ],
+  },
+
+  // Attribution Scope
+  {
+    name: 'attribution-scope-limit-negative',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": -1
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be in the range [1, 4294967295]',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scope-limit-zero',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 0
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be in the range [1, 4294967295]',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scope-limit-not-integer',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1.5
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be an integer',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scope-limit-exceeds-max',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 4294967296
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be in the range [1, 4294967295]',
+      },
+    ],
+  },
+  {
+    name: 'empty-attribution-scopes-with-limit',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 3,
+      "attribution_scopes": []
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'attribution scopes size must be in the range [1, 3]',
+      },
+    ],
+  },
+  {
+    name: 'missing-attribution-scope-limit-attribution-scopes',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scopes": ["1", "2"]
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be set if attribution_scopes is set',
+      },
+    ],
+  },
+  {
+    name: 'missing-attribution-scope-limit-max-event-states',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_states": 5
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be set if max_event_states is set',
+      },
+    ],
+  },
+  {
+    name: 'max-event-states-negative',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "max_event_states": -1
+    }`,
+    expectedErrors: [
+      {
+        path: ['max_event_states'],
+        msg: 'must be in the range [1, Infinity]',
+      },
+    ],
+  },
+  {
+    name: 'max-event-states-zero',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "max_event_states": 0
+    }`,
+    expectedErrors: [
+      {
+        path: ['max_event_states'],
+        msg: 'must be in the range [1, Infinity]',
+      },
+    ],
+  },
+  {
+    name: 'max-event-states-not-integer',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "max_event_states": 1.5
+    }`,
+    expectedErrors: [
+      {
+        path: ['max_event_states'],
+        msg: 'must be an integer',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-size-exceeds-attribution-scope-limit',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "attribution_scopes": ["1", "2"]
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'attribution scopes size must be in the range [1, 1]',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scope-not-string',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scopes": [1, 2]
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes', 0],
+        msg: 'must be a string',
+      },
+      {
+        path: ['attribution_scopes', 1],
+        msg: 'must be a string',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-empty-list',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scopes": []
+    }`,
+  },
+  {
+    name: 'attribution-scopes-not-list',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "attribution_scopes": 1
+    }`,
+    expectedErrors: [
+      {
+        msg: 'must be a list',
+        path: ['attribution_scopes'],
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-too-many',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes'],
+        msg: 'length must be in the range [0, 20]',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-too-long',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scope_limit": 1,
+      "attribution_scopes": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes', 0],
+        msg: 'exceeds max length per attribution scope (51 > 50)',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2623,7 +2623,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scope_limit'],
-        msg: 'attribution_scope_limit must be great or equal to the number of attribution scopes 3',
+        msg: 'attribution_scope_limit must be greater than or equal to the number of attribution scopes 3',
       },
     ],
   },
@@ -2705,7 +2705,7 @@ const testCases: TestCase[] = [
     expectedErrors: [
       {
         path: ['attribution_scope_limit'],
-        msg: 'attribution_scope_limit must be great or equal to the number of attribution scopes 1',
+        msg: 'attribution_scope_limit must be greater than or equal to the number of attribution scopes 1',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2622,8 +2622,8 @@ const testCases: TestCase[] = [
     }`,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
-        msg: 'attribution_scope_limit must be greater than or equal to the number of attribution scopes 3',
+        path: ['attribution_scopes'],
+        msg: 'length must be in the range [1, 3]',
       },
     ],
   },
@@ -2635,8 +2635,8 @@ const testCases: TestCase[] = [
     }`,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
-        msg: 'must be set if attribution_scopes is set',
+        path: ['attribution_scopes'],
+        msg: 'length must be in the range [0, 0]',
       },
     ],
   },
@@ -2648,8 +2648,8 @@ const testCases: TestCase[] = [
     }`,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
-        msg: 'must be set if non-default max_event_states value is set',
+        path: ['max_event_states'],
+        msg: 'non-default max_event_states when attribution_scope_limit is not set',
       },
     ],
   },
@@ -2704,8 +2704,8 @@ const testCases: TestCase[] = [
     }`,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
-        msg: 'attribution_scope_limit must be greater than or equal to the number of attribution scopes 1',
+        path: ['attribution_scopes'],
+        msg: 'length must be in the range [1, 1]',
       },
     ],
   },
@@ -2713,6 +2713,7 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-not-string',
     json: `{
       "destination": "https://a.test",
+      "attribution_scope_limit": 2,
       "attribution_scopes": [1, 2]
     }`,
     expectedErrors: [
@@ -2751,12 +2752,13 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-many',
     json: `{
       "destination": "https://a.test",
+      "attribution_scope_limit": 21,
       "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
     }`,
     expectedErrors: [
       {
         path: ['attribution_scopes'],
-        msg: 'length must be in the range [0, 20]',
+        msg: 'length must be in the range [1, 20]',
       },
     ],
   },

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -182,6 +182,9 @@ export type Source = CommonDebug &
     source_event_id: string
     trigger_data_matching: string
     aggregatable_debug_reporting?: SourceAggregatableDebugReportingConfig
+    attribution_scopes: string[]
+    attribution_scope_limit?: number
+    max_event_states: number
   }
 
 export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
@@ -217,6 +220,9 @@ export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
       s.aggregatableDebugReporting,
       (v) => serializeSourceAggregatableDebugReportingConfig(v)
     ),
+    attribution_scopes: Array.from(s.attributionScopes),
+    ...ifNotNull('attribution_scope_limit', s.attributionScopeLimit, (v) => v),
+    max_event_states: s.maxEventStates,
   }
 }
 
@@ -347,6 +353,7 @@ export type Trigger = CommonDebug &
     event_trigger_data: EventTriggerDatum[]
     trigger_context_id?: string
     aggregatable_debug_reporting?: AggregatableDebugReportingConfig
+    attribution_scopes: string[]
   }
 
 export function serializeTrigger(
@@ -389,5 +396,6 @@ export function serializeTrigger(
       t.aggregatableDebugReporting,
       (v) => serializeAggregatableDebugReportingConfig(v)
     ),
+    attribution_scopes: Array.from(t.attributionScopes),
   }
 }

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1631,7 +1631,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   // Attribution Scope
   {
     name: 'attribution-scope-not-string',
-    json: `{"attribution_scopes": [1, 2]}`,
+    json: `{"attribution_scopes": [1]}`,
     expectedErrors: [
       {
         path: ['attribution_scopes', 0],

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -50,7 +50,8 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           "key_piece": "0x5",
           "value": 123
         }]
-      }
+      },
+      "attribution_scopes": ["1"]
     }`,
     expected: Maybe.some({
       aggregatableDedupKeys: [
@@ -150,6 +151,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           map: new Map([['g', new Set()]]),
         },
       ],
+      attributionScopes: new Set('1'),
     }),
   },
   {
@@ -1622,6 +1624,40 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'duplicate type: unspecified',
+      },
+    ],
+  },
+
+  // Attribution Scope
+  {
+    name: 'attribution-scope-not-string',
+    json: `{"attribution_scopes": [1, 2]}`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes', 0],
+        msg: 'must be a string',
+      },
+      {
+        path: ['attribution_scopes', 1],
+        msg: 'must be a string',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-empty-list',
+    json: `{
+      "attribution_scopes": []
+    }`,
+  },
+  {
+    name: 'attribution-scopes-not-list',
+    json: `{
+      "attribution_scopes": 1
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes'],
+        msg: 'must be a list',
       },
     ],
   },

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1637,10 +1637,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         path: ['attribution_scopes', 0],
         msg: 'must be a string',
       },
-      {
-        path: ['attribution_scopes', 1],
-        msg: 'must be a string',
-      },
     ],
   },
   {

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -788,7 +788,7 @@ function validateAttributionScopeFields(
       ctx,
       1,
       s.attributionScopeLimit,
-      `attribution_scope_limit must be great or equal to the number of attribution scopes ${s.attributionScopeLimit}`
+      `attribution_scope_limit must be greater than or equal to the number of attribution scopes ${s.attributionScopeLimit}`
     )
   })
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1393,7 +1393,7 @@ function maxEventStates(
         n !== constants.defaultMaxEventStates
       ) {
         ctx.error(
-          `non-default (${constants.defaultMaxEventStates}) if attribution_scope_limit is not set`
+          `must be default (${constants.defaultMaxEventStates}) if attribution_scope_limit is not set`
         )
         return false
       }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1392,7 +1392,9 @@ function maxEventStates(
         attributionScopeLimit.value === null &&
         n !== constants.defaultMaxEventStates
       ) {
-        ctx.error('non-default if attribution_scope_limit is not set')
+        ctx.error(
+          `non-default (${constants.defaultMaxEventStates}) if attribution_scope_limit is not set`
+        )
         return false
       }
       return true

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1160,7 +1160,7 @@ function source(j: Json, ctx: SourceContext): Maybe<Source> {
                   attributionScopeLimitVal.value !== null ? 1 : 0,
                   Math.min(
                     constants.maxAttributionScopesPerSource,
-                    attributionScopeLimitVal.value || 0
+                    attributionScopeLimitVal.value ?? 0
                   ),
                   constants.maxLengthPerAttributionScope
                 ),

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1180,7 +1180,6 @@ function source(j: Json, ctx: SourceContext): Maybe<Source> {
         })
       })
       .filter(isTriggerDataMatchingValidForSpecs, ctx)
-      // .filter(validateAttributionScopeFields, ctx)
       .peek(channelCapacity, ctx)
       .peek(warnInconsistentMaxEventLevelReportsAndTriggerSpecs, ctx)
   )

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -778,7 +778,7 @@ function validateAttributionScopeFields(
         return false
       }
       if (s.maxEventStates !== constants.defaultMaxEventStates) {
-        ctx.error('must be set if max_event_states is set')
+        ctx.error('must be set if non-default max_event_states value is set')
         return false
       }
       return true
@@ -788,7 +788,7 @@ function validateAttributionScopeFields(
       ctx,
       1,
       s.attributionScopeLimit,
-      `attribution scopes size must be in the range [1, ${s.attributionScopeLimit}]`
+      `attribution_scope_limit must be great or equal to the number of attribution scopes ${s.attributionScopeLimit}`
     )
   })
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -767,32 +767,6 @@ function channelCapacity(s: Source, ctx: SourceContext): void {
   }
 }
 
-function validateAttributionScopeFields(
-  s: Source,
-  ctx: SourceContext
-): boolean {
-  return ctx.scope('attribution_scope_limit', () => {
-    if (s.attributionScopeLimit === null) {
-      if (s.attributionScopes.size !== 0) {
-        ctx.error('must be set if attribution_scopes is set')
-        return false
-      }
-      if (s.maxEventStates !== constants.defaultMaxEventStates) {
-        ctx.error('must be set if non-default max_event_states value is set')
-        return false
-      }
-      return true
-    }
-    return isInRange(
-      s.attributionScopes.size,
-      ctx,
-      1,
-      s.attributionScopeLimit,
-      `attribution_scope_limit must be greater than or equal to the number of attribution scopes ${s.attributionScopeLimit}`
-    )
-  })
-}
-
 export enum SummaryWindowOperator {
   count = 'count',
   value_sum = 'value_sum',
@@ -1092,113 +1066,124 @@ export type Source = CommonDebug &
   }
 
 function source(j: Json, ctx: SourceContext): Maybe<Source> {
-  return object(j, ctx)
-    .flatMap((j) => {
-      const expiryVal = field(
-        'expiry',
-        withDefault(expiry, constants.validSourceExpiryRange[1])
-      )(j, ctx)
+  return (
+    object(j, ctx)
+      .flatMap((j) => {
+        const expiryVal = field(
+          'expiry',
+          withDefault(expiry, constants.validSourceExpiryRange[1])
+        )(j, ctx)
 
-      const eventReportWindowsVal = exclusive(
-        {
-          event_report_window: (j) => eventReportWindow(j, ctx, expiryVal),
-          event_report_windows: (j) => eventReportWindows(j, ctx, expiryVal),
-        },
-        expiryVal.map(defaultEventReportWindows, ctx)
-      )(j, ctx)
+        const eventReportWindowsVal = exclusive(
+          {
+            event_report_window: (j) => eventReportWindow(j, ctx, expiryVal),
+            event_report_windows: (j) => eventReportWindows(j, ctx, expiryVal),
+          },
+          expiryVal.map(defaultEventReportWindows, ctx)
+        )(j, ctx)
 
-      const maxEventLevelReportsVal = field(
-        'max_event_level_reports',
-        maxEventLevelReports
-      )(j, ctx)
+        const maxEventLevelReportsVal = field(
+          'max_event_level_reports',
+          maxEventLevelReports
+        )(j, ctx)
 
-      const defaultTriggerSpecsVal = defaultTriggerSpecs(
-        ctx,
-        eventReportWindowsVal,
-        maxEventLevelReportsVal
-      )
+        const defaultTriggerSpecsVal = defaultTriggerSpecs(
+          ctx,
+          eventReportWindowsVal,
+          maxEventLevelReportsVal
+        )
 
-      const triggerSpecsDeps = {
-        expiry: expiryVal,
-        eventReportWindows: eventReportWindowsVal,
-        maxEventLevelReports: maxEventLevelReportsVal,
-      }
+        const triggerSpecsDeps = {
+          expiry: expiryVal,
+          eventReportWindows: eventReportWindowsVal,
+          maxEventLevelReports: maxEventLevelReportsVal,
+        }
 
-      const triggerSpecsVal = exclusive(
-        {
-          trigger_data: (j) =>
-            triggerSpecsFromTriggerData(j, ctx, triggerSpecsDeps),
-          ...(ctx.parseFullFlex
-            ? {
-                trigger_specs: (j) => triggerSpecs(j, ctx, triggerSpecsDeps),
-              }
-            : {}),
-        },
-        defaultTriggerSpecsVal
-      )(j, ctx)
+        const triggerSpecsVal = exclusive(
+          {
+            trigger_data: (j) =>
+              triggerSpecsFromTriggerData(j, ctx, triggerSpecsDeps),
+            ...(ctx.parseFullFlex
+              ? {
+                  trigger_specs: (j) => triggerSpecs(j, ctx, triggerSpecsDeps),
+                }
+              : {}),
+          },
+          defaultTriggerSpecsVal
+        )(j, ctx)
 
-      return struct(j, ctx, {
-        aggregatableReportWindow: field('aggregatable_report_window', (j) =>
-          j === undefined ? expiryVal : singleReportWindow(j, ctx, expiryVal)
-        ),
-        aggregationKeys: field(
-          'aggregation_keys',
-          withDefault(aggregationKeys, new Map())
-        ),
-        destination: field('destination', required(destination)),
-        eventLevelEpsilon: field(
-          'event_level_epsilon',
-          withDefault(eventLevelEpsilon, ctx.vsv.maxSettableEventLevelEpsilon)
-        ),
-        expiry: () => expiryVal,
-        filterData: field('filter_data', withDefault(filterData, new Map())),
-        maxEventLevelReports: () => maxEventLevelReportsVal,
-        sourceEventId: field('source_event_id', withDefault(uint64, 0n)),
-        triggerSpecs: () => triggerSpecsVal,
-        aggregatableDebugReporting: field(
-          'aggregatable_debug_reporting',
-          withDefault(sourceAggregatableDebugReportingConfig, null)
-        ),
-
-        triggerDataMatching: field(
-          'trigger_data_matching',
-          withDefault(enumerated, TriggerDataMatching.modulus),
-          TriggerDataMatching
-        ),
-        destinationLimitPriority: field(
-          'destination_limit_priority',
-          withDefault(int64, 0n)
-        ),
-        attributionScopeLimit: field(
+        const attributionScopeLimitVal = field(
           'attribution_scope_limit',
           withDefault(positiveUint32, null)
-        ),
-        attributionScopes: field(
-          'attribution_scopes',
-          withDefault(
-            (j) =>
-              attributionScopes(
-                ctx,
-                j,
-                constants.maxAttributionScopesPerSource,
-                constants.maxLengthPerAttributionScope
-              ),
-            new Set<string>()
-          )
-        ),
-        maxEventStates: field(
-          'max_event_states',
-          withDefault(maxEventStates, constants.defaultMaxEventStates)
-        ),
+        )(j, ctx)
 
-        ...commonDebugFields,
-        ...priorityField,
+        return struct(j, ctx, {
+          aggregatableReportWindow: field('aggregatable_report_window', (j) =>
+            j === undefined ? expiryVal : singleReportWindow(j, ctx, expiryVal)
+          ),
+          aggregationKeys: field(
+            'aggregation_keys',
+            withDefault(aggregationKeys, new Map())
+          ),
+          destination: field('destination', required(destination)),
+          eventLevelEpsilon: field(
+            'event_level_epsilon',
+            withDefault(eventLevelEpsilon, ctx.vsv.maxSettableEventLevelEpsilon)
+          ),
+          expiry: () => expiryVal,
+          filterData: field('filter_data', withDefault(filterData, new Map())),
+          maxEventLevelReports: () => maxEventLevelReportsVal,
+          sourceEventId: field('source_event_id', withDefault(uint64, 0n)),
+          triggerSpecs: () => triggerSpecsVal,
+          aggregatableDebugReporting: field(
+            'aggregatable_debug_reporting',
+            withDefault(sourceAggregatableDebugReportingConfig, null)
+          ),
+
+          triggerDataMatching: field(
+            'trigger_data_matching',
+            withDefault(enumerated, TriggerDataMatching.modulus),
+            TriggerDataMatching
+          ),
+          destinationLimitPriority: field(
+            'destination_limit_priority',
+            withDefault(int64, 0n)
+          ),
+          attributionScopeLimit: () => attributionScopeLimitVal,
+          attributionScopes: field(
+            'attribution_scopes',
+            withDefault(
+              (j) =>
+                attributionScopes(
+                  ctx,
+                  j,
+                  attributionScopeLimitVal.value !== null ? 1 : 0,
+                  Math.min(
+                    constants.maxAttributionScopesPerSource,
+                    attributionScopeLimitVal.value || 0
+                  ),
+                  constants.maxLengthPerAttributionScope
+                ),
+              new Set<string>()
+            )
+          ),
+          maxEventStates: field(
+            'max_event_states',
+            withDefault(
+              (j) => maxEventStates(j, ctx, attributionScopeLimitVal),
+              constants.defaultMaxEventStates
+            )
+          ),
+
+          ...commonDebugFields,
+          ...priorityField,
+        })
       })
-    })
-    .filter(isTriggerDataMatchingValidForSpecs, ctx)
-    .filter(validateAttributionScopeFields, ctx)
-    .peek(channelCapacity, ctx)
-    .peek(warnInconsistentMaxEventLevelReportsAndTriggerSpecs, ctx)
+      .filter(isTriggerDataMatchingValidForSpecs, ctx)
+      // .filter(validateAttributionScopeFields, ctx)
+      .peek(channelCapacity, ctx)
+      .peek(warnInconsistentMaxEventLevelReportsAndTriggerSpecs, ctx)
+  )
 }
 
 function sourceKeys(j: Json, ctx: Context): Maybe<Set<string>> {
@@ -1400,15 +1385,32 @@ function positiveUint32(j: Json, ctx: Context): Maybe<number> {
     .filter(isInRange, ctx, 1, UINT32_MAX)
 }
 
-function maxEventStates(j: Json, ctx: SourceContext): Maybe<number> {
+function maxEventStates(
+  j: Json,
+  ctx: SourceContext,
+  attributionScopeLimit: Maybe<number | null>
+): Maybe<number> {
   return number(j, ctx)
     .filter(isInteger, ctx)
     .filter(isInRange, ctx, 1, ctx.vsv.maxTriggerStateCardinality)
+    .filter((n) => {
+      if (
+        attributionScopeLimit.value === null &&
+        n !== constants.defaultMaxEventStates
+      ) {
+        ctx.error(
+          'non-default max_event_states when attribution_scope_limit is not set'
+        )
+        return false
+      }
+      return true
+    })
 }
 
 function attributionScopes(
   ctx: RegistrationContext,
   j: Json,
+  minAttributionScopes: number,
   maxAttributionScopes: number,
   maxLengthPerAttributionScope: number
 ): Maybe<Set<string>> {
@@ -1427,6 +1429,7 @@ function attributionScopes(
     ctx,
     (j) => string(j, ctx).filter(attributionScopeStringLength),
     {
+      minLength: minAttributionScopes,
       maxLength: maxAttributionScopes,
     }
   )
@@ -1609,7 +1612,7 @@ function trigger(j: Json, ctx: RegistrationContext): Maybe<Trigger> {
         attributionScopes: field(
           'attribution_scopes',
           withDefault(
-            (j) => attributionScopes(ctx, j, Infinity, Infinity),
+            (j) => attributionScopes(ctx, j, 0, Infinity, Infinity),
             new Set<string>()
           )
         ),


### PR DESCRIPTION
The current attribution logic in the Attribution Reporting API may not be ideal for use-cases where an ad-tech needs more fine grain control over the attribution granularity (i.e. campaign, product, conversion ID, etc.) before a source is chosen for attribution. Currently available features such as top-level filters are not fully sufficient for this use-case because they happen after a source has been selected (i.e. after attribution). We can optionally support this use-case by allowing callers of the API to specify predefined attribution scopes that will be considered for filtering before attributing a source, in order to more efficiently extract utility out of the API.

This PR covers the parsing logic for the new API surface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/feifeiji89/attribution-reporting-api/pull/1352.html" title="Last updated on Jul 8, 2024, 4:14 PM UTC (3841d5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1352/bacfb84...feifeiji89:3841d5f.html" title="Last updated on Jul 8, 2024, 4:14 PM UTC (3841d5f)">Diff</a>