### PR TITLE
Information gain computation logic for Attribution Scope.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3285,7 +3285,6 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
 1. If |source|'s [=attribution source/attribution scopes=] is not null and |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
     1. Return.

--- a/index.bs
+++ b/index.bs
@@ -1168,6 +1168,7 @@ Possible values are:
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
+<li>"<dfn><code>source-scopes-channel-capacity-limit</code></dfn>"
 <li>"<dfn><code>source-storage-limit</code></dfn>"
 <li>"<dfn><code>source-success</code></dfn>"
 <li>"<dfn><code>source-trigger-state-cardinality-limit</code></dfn>"
@@ -1443,6 +1444,10 @@ many [=aggregatable attribution reports=] can be in the [=aggregatable attributi
 
 <dfn>Max event-level channel capacity per source</dfn> is a [=map=] that
 controls how many bits of information can be exposed associated with a single [=attribution source=].
+The keys are «[=source type/navigation=], [=source type/event=]». The values are non-negative doubles.
+
+<dfn>Max event-level attribution scopes channel capacity per source</dfn> is a [=map=] that
+controls how many bits of information can be exposed due to attribution scopes for a single [=attribution source=].
 The keys are «[=source type/navigation=], [=source type/event=]». The values are non-negative doubles.
 
 <dfn>Max aggregatable reports per source</dfn> is a [=tuple=] consisting of two
@@ -2341,30 +2346,30 @@ To <dfn>obtain a set of possible trigger states</dfn> given a [=randomized respo
         with repetition.
 1. Return |possibleValues|.
 
-To <dfn>obtain a randomized source response pick rate</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
-
-1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |config|.
-1. Let |numPossibleValues| be the [=set/size=] of |possibleValues|.
-1. Return |numPossibleValues| / (|numPossibleValues| - 1 + e<sup>|epsilon|</sup>).
+To <dfn>obtain a randomized source response pick rate</dfn> given a positive integer |states| and a double |epsilon|:
+1. Return |states| / (|states| - 1 + e<sup>|epsilon|</sup>).
 
 To <dfn>obtain a randomized source response</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
 
 1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |config|.
-1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |config| and |epsilon|.
+1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |possibleValues|'s [=set/size=] and |epsilon|.
 1. Return the result of [=obtaining a randomized response=] with null, |possibleValues|, and
     |pickRate|.
 
 <h3 algorithm id="computing-channel-capacity">Computing channel capacity</h3>
 
-To <dfn>compute the channel capacity of a source</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
-1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
+To <dfn>compute the channel capacity of a source</dfn> given a positive integer |states| and a double |epsilon|:
 1. If |states| is 1, return 0.
 1. If |states| is greater than the user agent's [=max trigger-state cardinality=], return an error.
+1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |states| and |epsilon|.
 1. Let |p| be |pickRate| * (|states| - 1) / |states|.
 1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
 
 Note: This algorithm computes the channel capacity [[CHAN]] of a q-ary symmetric channel [[Q-SC]].
+
+To <dfn>compute the scopes channel capacity of a source</dfn> given a positive integer |numTriggerStates|, a positive integer |attributionScopeLimit|, and a positive integer |maxEventStates|:
+1. Let |totalStates| be |numTriggerStates| + |maxEventStates| * (|attributionScopeLimit| - 1).
+1. Return log2(|totalStates|).
 
 <h3 algorithm id="parsing-source-registration">Parsing source-registration JSON</h3>
 
@@ -3082,29 +3087,33 @@ a [=boolean=] |isNoised|, and a [=boolean=] |destinationLimitReplaced|:
     : "<code>[=source debug data type/source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
-         [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-storage-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
-        [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
-    ::
-        1. Let |sourceType| be |source|'s [=attribution source/source type=].
-        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
-    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
-        [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
-        [=serialize an integer|serialized=].
-    : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
-    ::
-        1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
-        1. [=map/Set=] |body|["`limit`"] to |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
+        : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
+             [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
+             [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-storage-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
+        ::
+            1. Let |sourceType| be |source|'s [=attribution source/source type=].
+            1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
+        : "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>"
+        ::
+            1. Let |sourceType| be |source|'s [=attribution source/source type=].
+            1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level attribution scopes channel capacity per source=][|sourceType|].
+        : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
+            [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
+        ::
+            1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
+            1. [=map/Set=] |body|["`limit`"] to |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
 
     </dl>
 
@@ -3251,7 +3260,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     :: |source|'s [=trigger specs=]
 
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
-1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
+1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |states| and |epsilon|.
 1. If |channelCapacity| is an error:
     1. Run [=obtain and deliver debug reports on source registration=] with
         "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" and |source|.
@@ -3261,6 +3271,13 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Run [=obtain and deliver debug reports on source registration=] with
         "<code>[=source debug data type/source-channel-capacity-limit=]</code>" and |source|.
     1. Return.
+1. If |source|'s [=attribution source/attribution scopes=] is not null:
+    1. Let |attributionScopes| be [=attribution source/attribution scopes=].
+    1. Let |scopesChannelCapacity| be the result of [=computing the scopes channel capacity of a source=] with |states|, |attributionScopes|'s [=attribution scopes/limit=], and |attributionScopes|'s [=attribution scopes/max event states=].
+    1. If |scopesChannelCapacity| is greater than [=max event-level attribution scopes channel capacity per source=][|sourceType|]:
+        1. Run [=obtain and deliver debug reports on source registration=] with
+            « "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" » and |source|.
+        1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
     [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
 1. Set |source|'s [=attribution source/randomized trigger rate=] to the result of

--- a/index.bs
+++ b/index.bs
@@ -3102,6 +3102,7 @@ a [=boolean=] |isNoised|, and a [=boolean=] |destinationLimitReplaced|:
             1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
         : "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>"
         ::
+            1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
             1. Let |sourceType| be |source|'s [=attribution source/source type=].
             1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level attribution scopes channel capacity per source=][|sourceType|].
         : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"

--- a/index.bs
+++ b/index.bs
@@ -3259,9 +3259,9 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     :: |source|'s [=trigger specs=]
 
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
-1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |randomizedResponseConfig|.
-1. Let |states| be |possibleValues|'s [=set/size=].
-1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |states| and |epsilon|.
+1. Let |possibleTriggerStates| be the result of [=obtaining a set of possible trigger states=] with |randomizedResponseConfig|.
+1. Let |numPossibleTriggerStates| be |possibleTriggerStates|'s [=set/size=].
+1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |numPossibleTriggerStates| and |epsilon|.
 1. If |channelCapacity| is an error:
     1. Run [=obtain and deliver debug reports on source registration=] with
         "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" and |source|.
@@ -3273,18 +3273,18 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Return.
 1. If |source|'s [=attribution source/attribution scopes=] is not null:
     1. Let |attributionScopes| be [=attribution source/attribution scopes=].
-    1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |attributionScopes|'s [=attribution scopes/max event states=]:
+    1. If |sourceType| is "<code>[=source type/event=]</code>" and |numPossibleTriggerStates| is greater than |attributionScopes|'s [=attribution scopes/max event states=]:
         1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
         1. Return.
-    1. Let |scopesChannelCapacity| be the result of [=computing the scopes channel capacity of a source=] with |states|, |attributionScopes|'s [=attribution scopes/limit=], and |attributionScopes|'s [=attribution scopes/max event states=].
+    1. Let |scopesChannelCapacity| be the result of [=computing the scopes channel capacity of a source=] with |numPossibleTriggerStates|, |attributionScopes|'s [=attribution scopes/limit=], and |attributionScopes|'s [=attribution scopes/max event states=].
     1. If |scopesChannelCapacity| is greater than [=max event-level attribution scopes channel capacity per source=][|sourceType|]:
         1. Run [=obtain and deliver debug reports on source registration=] with
             « "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" » and |source|.
         1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
-    [=obtaining a randomized source response=] with |possibleValues| and |epsilon|.
+    [=obtaining a randomized source response=] with |possibleTriggerStates| and |epsilon|.
 1. Set |source|'s [=attribution source/randomized trigger rate=] to the result of
-    [=obtaining a randomized source response pick rate=] with |states| and |epsilon|.
+    [=obtaining a randomized source response pick rate=] with |numPossibleTriggerStates| and |epsilon|.
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.

--- a/index.bs
+++ b/index.bs
@@ -3085,34 +3085,34 @@ a [=boolean=] |isNoised|, and a [=boolean=] |destinationLimitReplaced|:
     : "<code>[=source debug data type/source-destination-limit=]</code>"
     :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations covered by unexpired sources=],
         [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
-             [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
-             [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-storage-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
-            [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
-        ::
-            1. Let |sourceType| be |source|'s [=attribution source/source type=].
-            1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
-        : "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>"
-        ::
-            1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
-            1. Let |sourceType| be |source|'s [=attribution source/source type=].
-            1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level attribution scopes channel capacity per source=][|sourceType|].
-        : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
-            [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
-            [=serialize an integer|serialized=].
-        : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
-        ::
-            1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
-            1. [=map/Set=] |body|["`limit`"] to |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
+    : "<code>[=source debug data type/source-destination-rate-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per rate-limit window=][1],
+         [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-destination-per-day-rate-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max destinations per source reporting site per day=],
+         [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-storage-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max pending sources per source origin=],
+        [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-channel-capacity-limit=]</code>"
+    ::
+        1. Let |sourceType| be |source|'s [=attribution source/source type=].
+        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level channel capacity per source=][|sourceType|].
+    : "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>"
+    ::
+        1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
+        1. Let |sourceType| be |source|'s [=attribution source/source type=].
+        1. [=map/Set=] |body|["`limit`"] to the user agent's [=max event-level attribution scopes channel capacity per source=][|sourceType|].
+    : "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max trigger-state cardinality=],
+        [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
+    :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
+        [=serialize an integer|serialized=].
+    : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
+    ::
+        1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
+        1. [=map/Set=] |body|["`limit`"] to |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
 
     </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -2349,10 +2349,8 @@ To <dfn>obtain a set of possible trigger states</dfn> given a [=randomized respo
 To <dfn>obtain a randomized source response pick rate</dfn> given a positive integer |states| and a double |epsilon|:
 1. Return |states| / (|states| - 1 + e<sup>|epsilon|</sup>).
 
-To <dfn>obtain a randomized source response</dfn> given a positive integer |states| and a [=randomized response output configuration=] |config| and a double |epsilon|:
-
-1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |config|.
-1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |states| and |epsilon|.
+To <dfn>obtain a randomized source response</dfn> given a [=set=] of possible trigger states |possibleValues| and a double |epsilon|:
+1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |possibleValues|'s [=set/size=] and |epsilon|.
 1. Return the result of [=obtaining a randomized response=] with null, |possibleValues|, and
     |pickRate|.
 
@@ -3261,7 +3259,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     :: |source|'s [=trigger specs=]
 
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
+1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |randomizedResponseConfig|.
+1. Let |states| be |possibleValues|'s [=set/size=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |states| and |epsilon|.
 1. If |channelCapacity| is an error:
     1. Run [=obtain and deliver debug reports on source registration=] with
@@ -3283,9 +3282,9 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
             « "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" » and |source|.
         1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
-    [=obtaining a randomized source response=] with |states|, |randomizedResponseConfig| and |epsilon|.
+    [=obtaining a randomized source response=] with |possibleValues| and |epsilon|.
 1. Set |source|'s [=attribution source/randomized trigger rate=] to the result of
-    [=obtaining a randomized source response pick rate=] with |randomizedResponseConfig| and |epsilon|.
+    [=obtaining a randomized source response pick rate=] with |states| and |epsilon|.
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.

--- a/index.bs
+++ b/index.bs
@@ -2349,10 +2349,10 @@ To <dfn>obtain a set of possible trigger states</dfn> given a [=randomized respo
 To <dfn>obtain a randomized source response pick rate</dfn> given a positive integer |states| and a double |epsilon|:
 1. Return |states| / (|states| - 1 + e<sup>|epsilon|</sup>).
 
-To <dfn>obtain a randomized source response</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
+To <dfn>obtain a randomized source response</dfn> given a positive integer |states| and a [=randomized response output configuration=] |config| and a double |epsilon|:
 
 1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |config|.
-1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |possibleValues|'s [=set/size=] and |epsilon|.
+1. Let |pickRate| be the result of [=obtaining a randomized source response pick rate=] with |states| and |epsilon|.
 1. Return the result of [=obtaining a randomized response=] with null, |possibleValues|, and
     |pickRate|.
 
@@ -3274,21 +3274,21 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Return.
 1. If |source|'s [=attribution source/attribution scopes=] is not null:
     1. Let |attributionScopes| be [=attribution source/attribution scopes=].
+    1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |attributionScopes|'s [=attribution scopes/max event states=]:
+        1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
+        1. Return.
     1. Let |scopesChannelCapacity| be the result of [=computing the scopes channel capacity of a source=] with |states|, |attributionScopes|'s [=attribution scopes/limit=], and |attributionScopes|'s [=attribution scopes/max event states=].
     1. If |scopesChannelCapacity| is greater than [=max event-level attribution scopes channel capacity per source=][|sourceType|]:
         1. Run [=obtain and deliver debug reports on source registration=] with
             « "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" » and |source|.
         1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
-    [=obtaining a randomized source response=] with |randomizedResponseConfig| and |epsilon|.
+    [=obtaining a randomized source response=] with |states|, |randomizedResponseConfig| and |epsilon|.
 1. Set |source|'s [=attribution source/randomized trigger rate=] to the result of
     [=obtaining a randomized source response pick rate=] with |randomizedResponseConfig| and |epsilon|.
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
-1. If |source|'s [=attribution source/attribution scopes=] is not null and |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
-    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
-    1. Return.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
     [=attribution sources=] |pendingSource| of the [=attribution source cache=] where |pendingSource|'s
     [=attribution source/source origin=] and |source|'s

--- a/index.bs
+++ b/index.bs
@@ -3279,7 +3279,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Let |scopesChannelCapacity| be the result of [=computing the scopes channel capacity of a source=] with |numPossibleTriggerStates|, |attributionScopes|'s [=attribution scopes/limit=], and |attributionScopes|'s [=attribution scopes/max event states=].
     1. If |scopesChannelCapacity| is greater than [=max event-level attribution scopes channel capacity per source=][|sourceType|]:
         1. Run [=obtain and deliver debug reports on source registration=] with
-            « "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" » and |source|.
+            "<code>[=source debug data type/source-scopes-channel-capacity-limit=]</code>" and |source|.
         1. Return.
 1. Set |source|'s [=attribution source/randomized response=] to the result of
     [=obtaining a randomized source response=] with |possibleTriggerStates| and |epsilon|.

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -70,6 +70,7 @@ export const sourceAggregatableDebugTypes: Readonly<[string, ...string[]]> = [
   'source-noised',
   'source-reporting-origin-limit',
   'source-reporting-origin-per-site-limit',
+  'source-scopes-channel-capacity-limit',
   'source-storage-limit',
   'source-success',
   'source-trigger-state-cardinality-limit',

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -114,6 +114,14 @@ if (options.json_file !== undefined) {
   if (options.windows.value.length !== options.buckets.value.length) {
     throw new Error('windows and buckets must have same length')
   }
+  if (
+    (options.attribution_scope_limit === undefined) !==
+    (options.max_event_states === undefined)
+  ) {
+    throw new Error(
+      'attribution_scope_limit and max_event_states must be set / unset at the same time'
+    )
+  }
   const attributionScopes: AttributionScopes | null =
     options.attribution_scope_limit === undefined ||
     options.max_event_states === undefined

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -21,7 +21,7 @@ function commaSeparatedInts(str: string): Wrapped<number[]> {
 interface Arguments {
   max_event_level_reports: number
   attribution_scope_limit?: number
-  max_event_states: number
+  max_event_states?: number
   epsilon: number
   source_type: SourceType
   windows?: Wrapped<number[]>
@@ -44,6 +44,7 @@ const options = parse<Arguments>({
     alias: 's',
     type: Number,
     defaultValue: constants.defaultMaxEventStates,
+    optional: true,
   },
   epsilon: {
     alias: 'e',
@@ -114,7 +115,8 @@ if (options.json_file !== undefined) {
     throw new Error('windows and buckets must have same length')
   }
   const attributionScopes: AttributionScopes | null =
-    options.attribution_scope_limit === undefined
+    options.attribution_scope_limit === undefined ||
+    options.max_event_states === undefined
       ? null
       : {
           limit: options.attribution_scope_limit,

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -8,7 +8,6 @@ import { AttributionScopes } from '../header-validator/source'
 import { SourceType, parseSourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, PerTriggerDataConfig } from './privacy'
-import * as constants from '../constants'
 
 // Workaround for `parse` not handling top-level array types without `multiple`
 // `OptionDef` configuration.
@@ -43,7 +42,6 @@ const options = parse<Arguments>({
   max_event_states: {
     alias: 's',
     type: Number,
-    defaultValue: constants.defaultMaxEventStates,
     optional: true,
   },
   epsilon: {

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -4,9 +4,11 @@ import { readFileSync } from 'fs'
 import { Issue } from '../header-validator/context'
 import { Maybe } from '../header-validator/maybe'
 import { validateSource } from '../header-validator/validate-source'
+import { AttributionScopes } from '../header-validator/source'
 import { SourceType, parseSourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, PerTriggerDataConfig } from './privacy'
+import * as constants from '../constants'
 
 // Workaround for `parse` not handling top-level array types without `multiple`
 // `OptionDef` configuration.
@@ -18,6 +20,8 @@ function commaSeparatedInts(str: string): Wrapped<number[]> {
 
 interface Arguments {
   max_event_level_reports: number
+  attribution_scope_limit?: number
+  max_event_states: number
   epsilon: number
   source_type: SourceType
   windows?: Wrapped<number[]>
@@ -30,6 +34,16 @@ const options = parse<Arguments>({
     alias: 'm',
     type: Number,
     defaultValue: 20,
+  },
+  attribution_scope_limit: {
+    alias: 'a',
+    type: Number,
+    optional: true,
+  },
+  max_event_states: {
+    alias: 's',
+    type: Number,
+    defaultValue: constants.defaultMaxEventStates,
   },
   epsilon: {
     alias: 'e',
@@ -82,6 +96,7 @@ if (options.json_file !== undefined) {
     (source) =>
       new Config(
         source.maxEventLevelReports,
+        source.attributionScopes,
         source.triggerSpecs.flatMap((spec) =>
           new Array<PerTriggerDataConfig>(spec.triggerData.size).fill(
             new PerTriggerDataConfig(
@@ -98,9 +113,18 @@ if (options.json_file !== undefined) {
   if (options.windows.value.length !== options.buckets.value.length) {
     throw new Error('windows and buckets must have same length')
   }
+  const attributionScopes: AttributionScopes | null =
+    options.attribution_scope_limit === undefined
+      ? null
+      : {
+          limit: options.attribution_scope_limit,
+          values: new Set<string>(),
+          maxEventStates: options.max_event_states,
+        }
   config = Maybe.some(
     new Config(
       options.max_event_level_reports,
+      attributionScopes,
       options.windows.value.map(
         (w: number, i: number) =>
           new PerTriggerDataConfig(w, options.buckets!.value[i]!)

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -3011,6 +3011,88 @@ const testCases: TestCase[] = [
       },
     ],
   },
+  {
+    name: 'channel-capacity-attribution-scope-event',
+    input: `{
+      "destination": "https://a.test",
+      "attribution_scopes": {
+        "limit": 11,
+        "values": ["1"],
+        "max_event_states": 15
+      }
+    }`,
+    sourceType: SourceType.event,
+    noteInfoGain: true,
+    vsv: {
+      maxEventLevelAttributionScopesChannelCapacityPerSource: {
+        [SourceType.event]: 6.5,
+        [SourceType.navigation]: 11.55,
+      },
+      maxSettableEventLevelEpsilon: 14,
+    },
+    parseScopes: true,
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'information gain for attribution scope: 7.26 exceeds max event-level attribution scope information gain per event source (6.50)',
+      },
+    ],
+    expectedNotes: [
+      {
+        msg: 'information gain: 1.58',
+        path: [],
+      },
+      {
+        path: [],
+        msg: 'number of possible output states: 3',
+      },
+      {
+        path: [],
+        msg: 'randomized trigger rate: 0.0000025',
+      },
+    ],
+  },
+  {
+    name: 'channel-capacity-attribution-scope-navigation',
+    input: `{
+      "destination": "https://a.test",
+      "attribution_scopes": {
+        "limit": 21,
+        "values": ["1"],
+        "max_event_states": 20
+      }
+    }`,
+    sourceType: SourceType.navigation,
+    noteInfoGain: true,
+    vsv: {
+      maxEventLevelAttributionScopesChannelCapacityPerSource: {
+        [SourceType.event]: 6.5,
+        [SourceType.navigation]: 11.55,
+      },
+      maxSettableEventLevelEpsilon: 14,
+    },
+    parseScopes: true,
+    expectedErrors: [
+      {
+        path: [],
+        msg: 'information gain for attribution scope: 11.70 exceeds max event-level attribution scope information gain per navigation source (11.55)',
+      },
+    ],
+    expectedNotes: [
+      {
+        msg: 'information gain: 11.46',
+        path: [],
+      },
+      {
+        path: [],
+        msg: 'number of possible output states: 2925',
+      },
+      {
+        path: [],
+        msg: 'randomized trigger rate: 0.0024263',
+      },
+    ],
+  },
 ]
 
 testCases.forEach((tc) =>

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -325,6 +325,7 @@ function channelCapacity(s: Source, ctx: Context): void {
 
   const config = new privacy.Config(
     s.maxEventLevelReports,
+    s.attributionScopes,
     perTriggerDataConfigs
   )
 
@@ -353,9 +354,7 @@ function channelCapacity(s: Source, ctx: Context): void {
 
   const maxInfoGain =
     ctx.opts.vsv.maxEventLevelChannelCapacityPerSource[ctx.opts.sourceType]
-  const infoGainMsg = `information gain${
-    s.attributionScopes !== null ? ' for attribution scope' : ''
-  }: ${out.infoGain.toFixed(2)}`
+  const infoGainMsg = `information gain: ${out.infoGain.toFixed(2)}`
 
   if (out.infoGain > maxInfoGain) {
     ctx.error(
@@ -365,6 +364,24 @@ function channelCapacity(s: Source, ctx: Context): void {
     )
   } else if (ctx.opts.noteInfoGain) {
     ctx.note(infoGainMsg)
+  }
+
+  if (out.attributionScopesInfoGain !== undefined) {
+    const attributionScopesInfoGainMsg = `information gain for attribution scope: ${out.attributionScopesInfoGain.toFixed(2)}`
+    const maxAttributionScopeInfoGain =
+      ctx.opts.vsv.maxEventLevelAttributionScopesChannelCapacityPerSource[
+        ctx.opts.sourceType
+      ]
+
+    if (out.attributionScopesInfoGain > maxAttributionScopeInfoGain) {
+      ctx.error(
+        `${attributionScopesInfoGainMsg} exceeds max event-level attribution scope information gain per ${
+          ctx.opts.sourceType
+        } source (${maxAttributionScopeInfoGain.toFixed(2)})`
+      )
+    } else if (ctx.opts.noteInfoGain) {
+      ctx.note(attributionScopesInfoGainMsg)
+    }
   }
 
   if (ctx.opts.noteInfoGain) {

--- a/ts/src/vendor-specific-values.ts
+++ b/ts/src/vendor-specific-values.ts
@@ -4,6 +4,10 @@ export type VendorSpecificValues = {
   // The first value is the default if a trigger doesn't specify one.
   aggregationCoordinatorOrigins: [string, ...string[]]
   maxEventLevelChannelCapacityPerSource: Record<SourceType, number>
+  maxEventLevelAttributionScopesChannelCapacityPerSource: Record<
+    SourceType,
+    number
+  >
   maxSettableEventLevelEpsilon: number
   maxTriggerStateCardinality: number
 }
@@ -16,6 +20,10 @@ export const Chromium: Readonly<VendorSpecificValues> = {
   maxEventLevelChannelCapacityPerSource: {
     [SourceType.event]: 6.5,
     [SourceType.navigation]: 11.5,
+  },
+  maxEventLevelAttributionScopesChannelCapacityPerSource: {
+    [SourceType.event]: 6.5,
+    [SourceType.navigation]: 11.55,
   },
   maxSettableEventLevelEpsilon: 14,
   maxTriggerStateCardinality: 2 ** 32 - 1,

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -110,7 +110,7 @@ Additional fields: `limit`
 
 #### `source-scopes-channel-capacity-limit`
 
-A source is rejected due to the [attribution scope channel-capacity limit][].
+The source was rejected due to the [attribution scope channel-capacity limit][].
 
 Additional fields: `limit`
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -49,6 +49,12 @@ The source was rejected due to the [destination limit][].
 
 Additional fields: `limit`
 
+#### `source-max-event-states-limit`
+
+A source is rejected due to the [event state limit][].
+
+Additional fields: `limit`
+
 #### `source-noised`
 
 The source was successfully registered, but it will not be attributable by any
@@ -144,7 +150,7 @@ Additionally:
   the following fields:
    * `source_event_id`: The source registration's `source_event_id`.
    * `source_site`: The top-level site on which the source registration
-     occurred.
+      occurred.
    * `source_debug_key`: The source registration's `debug_key`, but omitted if
      the source registration did not contain a valid `debug_key` or
      [cookie-based debugging][] was prohibited.

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -49,12 +49,6 @@ The source was rejected due to the [destination limit][].
 
 Additional fields: `limit`
 
-#### `source-max-event-states-limit`
-
-A source is rejected due to the [event state limit][].
-
-Additional fields: `limit`
-
 #### `source-noised`
 
 The source was successfully registered, but it will not be attributable by any
@@ -108,6 +102,12 @@ The source was rejected due to the [channel-capacity limit][].
 
 Additional fields: `limit`
 
+#### `source-scopes-channel-capacity-limit`
+
+A source is rejected due to the [attribution scope channel-capacity limit][].
+
+Additional fields: `limit`
+
 #### `source-trigger-state-cardinality-limit`
 
 The source was rejected due to the [trigger-state cardinality limit][].
@@ -142,12 +142,12 @@ Additionally:
   will also contain a string-typed `limit` field.
 * If the trigger was attributed to a source, then the `body` will also contain
   the following fields:
-   * `source_event_id`: The source registration's `source_event_id`.
-   * `source_site`: The top-level site on which the source registration
-      occurred.
-   * `source_debug_key`: The source registration's `debug_key`, but omitted if
-     the source registration did not contain a valid `debug_key` or
-     [cookie-based debugging][] was prohibited.
+  * `source_event_id`: The source registration's `source_event_id`.
+  * `source_site`: The top-level site on which the source registration
+    occurred.
+  * `source_debug_key`: The source registration's `debug_key`, but omitted if
+    the source registration did not contain a valid `debug_key` or
+    [cookie-based debugging][] was prohibited.
 
 #### `trigger-no-matching-source`
 
@@ -264,13 +264,13 @@ The trigger was rejected due to an internal error.
 [attribution source registrations]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#registering-attribution-sources
 [attribution trigger registrations]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#triggering-attribution
 [channel-capacity limit]: https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source
+[attribution scope channel-capacity limit]: https://wicg.github.io/attribution-reporting-api/#max-event-level-attribution-scope-channel-capacity-per-source
 [cookie-based debugging]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-transitional-debugging-reports
 [destination limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources
 [destinations per source and reporting site per day rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources
 [destinations per source and reporting site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [destinations per source site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [event-level report body]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#attribution-reports
-[event states limit]: https://wicg.github.io/attribution-reporting-api/#attribution-scopes-max-event-states
 [filter data]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-attribution-filters
 [insufficient budget]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#contribution-bounding-and-budgeting
 [max aggregatable reports]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#hide-the-true-number-of-attribution-reports

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -142,12 +142,12 @@ Additionally:
   will also contain a string-typed `limit` field.
 * If the trigger was attributed to a source, then the `body` will also contain
   the following fields:
-  * `source_event_id`: The source registration's `source_event_id`.
-  * `source_site`: The top-level site on which the source registration
-    occurred.
-  * `source_debug_key`: The source registration's `debug_key`, but omitted if
-    the source registration did not contain a valid `debug_key` or
-    [cookie-based debugging][] was prohibited.
+   * `source_event_id`: The source registration's `source_event_id`.
+   * `source_site`: The top-level site on which the source registration
+     occurred.
+   * `source_debug_key`: The source registration's `debug_key`, but omitted if
+     the source registration did not contain a valid `debug_key` or
+     [cookie-based debugging][] was prohibited.
 
 #### `trigger-no-matching-source`
 
@@ -261,16 +261,17 @@ The trigger was rejected due to an internal error.
 [aggregatable storage limit]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#storage-limits
 [aggregatable trigger algorithm]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#attribution-trigger-registration
 [attributed reporting origin limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits
+[attribution scope channel-capacity limit]: https://wicg.github.io/attribution-reporting-api/#max-event-level-attribution-scope-channel-capacity-per-source
 [attribution source registrations]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#registering-attribution-sources
 [attribution trigger registrations]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#triggering-attribution
 [channel-capacity limit]: https://wicg.github.io/attribution-reporting-api/#max-event-level-channel-capacity-per-source
-[attribution scope channel-capacity limit]: https://wicg.github.io/attribution-reporting-api/#max-event-level-attribution-scope-channel-capacity-per-source
 [cookie-based debugging]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-transitional-debugging-reports
 [destination limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources
 [destinations per source and reporting site per day rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-covered-by-unexpired-sources
 [destinations per source and reporting site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [destinations per source site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [event-level report body]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#attribution-reports
+[event states limit]: https://wicg.github.io/attribution-reporting-api/#attribution-scopes-max-event-states
 [filter data]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-attribution-filters
 [insufficient budget]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#contribution-bounding-and-budgeting
 [max aggregatable reports]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#hide-the-true-number-of-attribution-reports


### PR DESCRIPTION
The current attribution logic in the Attribution Reporting API may not be ideal for use-cases where an ad-tech needs more fine grain control over the attribution granularity (i.e. campaign, product, conversion ID, etc.) before a source is chosen for attribution. Currently available features such as top-level filters are not fully sufficient for this use-case because they happen after a source has been selected (i.e. after attribution). We can optionally support this use-case by allowing callers of the API to specify predefined attribution scopes that will be considered for filtering before attributing a source, in order to more efficiently extract utility out of the API.

This PR covers the information gain computation logic:
Given event report configuration `(c, b, w)` definition:
- the maximum number `c` of conversions per impression
- the number `b` of bits per conversion
- the number `w` of reporting windows

To accommodate our default configuration navigation=(3,3,3) and event=(1,1,1), we propose introduction of a new information gain limit of 11.55 for attribution scope attack vector (for navigation sources) specifically because the upper bound doesn’t include source noise considerations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/feifeiji89/attribution-reporting-api/pull/1364.html" title="Last updated on Aug 15, 2024, 4:25 PM UTC (cdd2ffe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1364/1dbcd91...feifeiji89:cdd2ffe.html" title="Last updated on Aug 15, 2024, 4:25 PM UTC (cdd2ffe)">Diff</a>