### PR TITLE
Attribution and source processing logic for Attribution scope.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3116,6 +3116,8 @@ and a [=boolean=] |isNoised|:
         : "<code>[=source debug data type/source-reporting-origin-per-site-limit=]</code>"
         :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
             [=serialize an integer|serialized=].
+        : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
+        :: [=map/Set=] |body|["`limit`"] to the |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
 
         </dl>
 1. [=Assert=]: |dataTypeToReport| is not null.

--- a/index.bs
+++ b/index.bs
@@ -3193,7 +3193,7 @@ To <dfn>remove associated event-level reports and rate-limit records</dfn> given
     1. If |report|'s [=event-level report/source identifier=] is not equal to |sourceId|, [=iteration/continue=].
     1. If |report|'s [=event-level report/trigger time=] is less than |minTriggerTime|, [=iteration/continue=].
     1. [=set/Remove=] |report| from the [=event-level report cache=].
-    1. [=list/Remove=] the [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if |entry|'s [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=].
+    1. [=list/Remove=] all [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] where |entry|'s [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=].
 
 To <dfn>remove sources with unselected attribution scopes for destination</dfn> given a [=site=] |destination| and an [=attribution source=] |pendingSource|:
 1. Let |scopeRecords| be a new [=list=].

--- a/index.bs
+++ b/index.bs
@@ -328,6 +328,8 @@ add the property
 Issue: Use/propagate [=navigation params/navigationSourceEligible=] to the
 [=navigation request=]'s [=request/Attribution Reporting eligibility=].
 
+Issue: Enforce [attribution-scope privacy limits](#attribution-scope).
+
 # Network monkeypatches # {#network-monkeypatches}
 
 <pre class="idl">
@@ -1162,6 +1164,7 @@ Possible values are:
 <li>"<dfn><code>source-destination-limit-replaced</code></dfn>"
 <li>"<dfn><code>source-destination-per-day-rate-limit</code></dfn>"
 <li>"<dfn><code>source-destination-rate-limit</code></dfn>"
+<li>"<dfn><code>source-max-event-states-limit</code></dfn>"
 <li>"<dfn><code>source-noised</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-limit</code></dfn>"
 <li>"<dfn><code>source-reporting-origin-per-site-limit</code></dfn>"
@@ -3168,6 +3171,73 @@ To <dfn>delete expired sources</dfn> given a [=moment=] |now|:
     1. If |source|'s [=attribution source/expiry time=] is less than |now|,
         [=set/remove=] |source| from the [=attribution source cache=].
 
+To <dfn>find sources with common destinations and reporting origin</dfn> given an [=attribution source=] |pendingSource|:
+1. Let |matchingSources| be a new [=list=].
+1. [=set/iterate|For each=] |source| of the user agent's [=attribution source cache=]:
+    1. Let |commonDestinations| be the [=set/intersection=] of |source|'s [=attribution source/attribution destinations=] and |pendingSource|'s [=attribution source/attribution destinations=].
+    1. If |commonDestinations| [=set/is empty=], [=iteration/continue=].
+    1. If |source|'s [=attribution source/reporting origin=] and |pendingSource|'s [=attribution source/reporting origin=] are not [=same origin=], [=iteration/continue=].
+    1. [=list/Append=] |source| to |matchingSources|.
+1. Return |matchingSources|.
+
+To <dfn>check if source has incompatible attribution scope fields</dfn> given an [=attribution source=] |source| and an [=attribution source=] |pendingSource|:
+1. If |pendingSource|'s [=attribution source/attribution scopes=] is null:
+    1. Return true if |source|'s [=attribution source/attribution scopes=] is null, false otherwise.
+1. If |source|'s [=attribution source/attribution scopes=] is null, return true.
+1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=] is not equal to |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=], return true.
+1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=] is less than |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=], return true.
+1. Return false.
+
+To <dfn>remove associated event-level reports and rate-limit records</dfn> given an [=attribution source/source identifier=] |sourceId| and a [=moment=] |minTriggerTime|:
+1. [=set/iterate|For each=] [=event-level report=] |report| of the [=event-level report cache=]:
+    1. If |report|'s [=event-level report/source identifier=] is not equal to |sourceId|, [=iteration/continue=].
+    1. If |report|'s [=event-level report/trigger time=] is less than |minTriggerTime|, [=iteration/continue=].
+    1. [=set/Remove=] |report| from the [=event-level report cache=].
+    1. [=list/Remove=] the [=attribution rate-limit records=] |entry| from the [=attribution rate-limit cache=] if |entry|'s [=attribution rate-limit record/entity ID=] is equal to |report|'s [=event-level report/report ID=].
+
+To <dfn>remove sources with unselected attribution scopes for destination</dfn> given a [=site=] |destination| and an [=attribution source=] |pendingSource|:
+1. Let |scopeRecords| be a new [=list=].
+1. Let |scopes| be |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/values=].
+1. [=set/iterate|For each=] |scope| in |scopes|:
+    1. [=list/Append=] the [=tuple=] (|scope|, |pendingSource|) to |scopeRecords|.
+1. [=set/iterate|For each=] |source| of the [=attribution source cache=]:
+    1. If |source|'s [=attribution source/reporting origin=] and |pendingSource|'s [=attribution source/reporting origin=] are not [=same origin=], [=iteration/continue=].
+    1. If |source|'s [=attribution source/attribution destinations=] does not [=set/contain=] |destination|, [=iteration/continue=].
+    1. If |source|'s [=attribution source/attribution scopes=]'s is null, [=iteration/continue=].
+    1. [=set/iterate|For each=] |scope| in |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/values=]:
+        1. [=list/Append=] the [=tuple=] (|scope|, |source|) to |scopeRecords|.
+1. [=list/sort in ascending order|Sort=] |scopeRecords| in ascending order with |a| being less than |b| if any of the following are true:
+      * |a|[1]'s [=attribution source/source time=] is greater than |b|[1]'s [=attribution source/source time=].
+      * |a|[1]'s [=attribution source/source time=] is equal to |b|[1]'s [=attribution source/source time=] and |a|[0] is greater than |b|[0].
+1. Let |selectedScopes| be |scopes|.
+1. Let |sourcesToRemove| be a new [=set=].
+1. [=list/iterate|For each=] |record| of |scopeRecords|:
+    1. If |selectedScopes|'s [=set/size=] is less than |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=], [=set/append=] |record|[0] to |selectedScopes|.
+    1. Otherwise, if |selectedScopes| does not [=set/contain=] |record|[0], [=set/append=] |record|[1] to |sourcesToRemove|.
+1. [=set/iterate|For each=] |source| of the |sourcesToRemove|:
+    1. [=Remove associated event-level reports and rate-limit records=] with |source|'s [=attribution source/source identifier=] and |pendingSource|'s [=attribution source/source time=].
+    1. [=set/Remove=] |source| from the [=attribution source cache=].
+
+To <dfn>remove sources with unselected attribution scopes</dfn> given an [=attribution source=] |pendingSource|:
+1. If |pendingSource|'s [=attribution source/attribution scopes=] is null, return.
+1. [=Assert=]: |pendingSource|'s [=attribution source/attribution destinations=] is [=list/sort in ascending order|sorted=] in
+    ascending order, with |a| being less than |b| if |a|,
+    <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>,
+    is less than |b|, <a href="https://html.spec.whatwg.org/multipage/origin.html#serialization-of-a-site">serialized</a>.
+1. [=set/iterate|For each=] |destination| in |pendingSource|'s [=attribution source/attribution destinations=]:
+    1. [=Remove sources with unselected attribution scopes for destination=] with |destination| and |pendingSource|.
+
+To <dfn>remove or update sources with incompatible attribution scope fields</dfn> given an [=attribution source=] |pendingSource|:
+1. Let |matchingSources| be the result of running [=find sources with common destinations and reporting origin=] with |pendingSource|.
+1. [=list/iterate|For each=] |source| of |matchingSources|:
+    1. If the result of running [=check if source has incompatible attribution scope fields=] with |source| and |pendingSource| is false, [iteration/continue=].
+    1. If |pendingSource|'s [=attribution source/attribution scopes=] is null and |source|'s [=attribution source/attribution scopes=] is not null:
+        1. Set |source|'s [=attribution source/attribution scopes=] to null.
+    1. Otherwise:
+        1. [=Remove associated event-level reports and rate-limit records=] with |source|'s [=attribution source/source identifier=] and |pendingSource|'s [=attribution source/source time=].
+        1. [=set/Remove=] |source| from the [=attribution source cache=].
+1. [=Remove sources with unselected attribution scopes=] with |pendingSource|.
+
 To <dfn>process an attribution source</dfn> given an [=attribution source=] |source|:
 
 1. [=Delete expired sources=] with |source|'s [=attribution source/source time=].
@@ -3196,6 +3266,10 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
+1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
+    1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
+    1. Return.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all
     [=attribution sources=] |pendingSource| of the [=attribution source cache=] where |pendingSource|'s
     [=attribution source/source origin=] and |source|'s
@@ -3226,6 +3300,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     [=set/append=] "<code>[=source debug data type/source-destination-limit-replaced=]</code>"
     to |debugDataTypes|.
 1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
+1. [=Remove or update sources with incompatible attribution scope fields=] with |source|.
 1. Let |isNoised| be true if |source|'s [=attribution source/randomized response=]
     is not null, otherwise false.
 1. If |destinationRateLimitResult| is "<code>[=destination rate-limit result/hit global limit=]</code>":
@@ -4176,6 +4251,11 @@ and an optional [=attribution source=]
 1. Run [=obtain and deliver an aggregatable debug report on trigger registration=]
     with |dataSet|, |trigger|, and |sourceToAttribute|.
 
+To <dfn>check if an [=attribution source=] and [=attribution trigger=] have matching attribution scopes</dfn> given an [=attribution source=] |source| and an [=attribution trigger=] |trigger|:
+
+1. If |trigger|'s [=attribution trigger/attribution scopes=] [=set/is empty=], return true.
+1. Return whether the [=set/intersection=] of |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/values=] and |trigger|'s [=attribution trigger/attribution scopes=] is not [=set/is empty|empty=].
+
 To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
 
 1. Let |matchingSources| be a new [=list=].
@@ -4189,7 +4269,12 @@ To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
       * |a|'s [=attribution source/priority=] is less than |b|'s [=attribution source/priority=].
       * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
          [=attribution source/source time=] is less than |b|'s [=attribution source/source time=].
+      * the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |a| and |trigger| is false
+        and the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |b| and |trigger| is true
+1. If |matchingSources| is not [=list/is empty|empty=] and the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |matchingSources|[0] and |trigger| is false, return a new [=list=].
 1. Return |matchingSources|.
+
+Note: Sources with matching attribution scopes from the trigger will be prioritized. If no source matches attribution scopes from the trigger, an empty list will be returned.
 
 To <dfn>check if an [=attribution trigger=] contains aggregatable data</dfn> given an [=attribution trigger=] |trigger|,
 run the following steps:
@@ -5281,3 +5366,13 @@ Possible mitigations:
     presence from the reporting origin. Compared to the previous mitigation, the
     proxy server could itself handle the [=event-level report/trigger priority=]
     functionality, at the cost of increased complexity in the proxy.
+
+## Attribution scope ## {#attribution-scope}
+
+*This section is non-normative.*
+
+It is possible for an adversary to register multiple [=source type/navigation=] sources in response to a single navigation, and use these multiple sources, each with a different non-empty [=attribution source/attribution scopes=] value, to gain additional information about a user based on which attribution scope is chosen. To prevent this abuse the number of unique attribution scope sets per reporting origin per navigation needs to be limited.
+
+Proposed mitigation:
+
+Limit to 1 unique non-empty attribution scope set per reporting origin per navigation. Extraneous sources will be dropped.

--- a/index.bs
+++ b/index.bs
@@ -3269,7 +3269,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
 1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
-1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
+1. If |source|'s [=attribution source/attribution scopes=] is not null and |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
     1. Return.
 1. Let |pendingSourcesForSourceOrigin| be the [=set=] of all

--- a/index.bs
+++ b/index.bs
@@ -3117,7 +3117,9 @@ and a [=boolean=] |isNoised|:
         :: [=map/Set=] |body|["`limit`"] to the user agent's [=max source reporting origins per source reporting site=],
             [=serialize an integer|serialized=].
         : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
-        :: [=map/Set=] |body|["`limit`"] to the |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
+        ::
+            1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
+            1. [=map/Set=] |body|["`limit`"] to the |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
 
         </dl>
 1. [=Assert=]: |dataTypeToReport| is not null.

--- a/index.bs
+++ b/index.bs
@@ -3230,8 +3230,8 @@ To <dfn>remove sources with unselected attribution scopes</dfn> given an [=attri
 To <dfn>remove or update sources with incompatible attribution scope fields</dfn> given an [=attribution source=] |pendingSource|:
 1. Let |matchingSources| be the result of running [=find sources with common destinations and reporting origin=] with |pendingSource|.
 1. [=list/iterate|For each=] |source| of |matchingSources|:
-    1. If the result of running [=check if source has incompatible attribution scope fields=] with |source| and |pendingSource| is false, [iteration/continue=].
-    1. If |pendingSource|'s [=attribution source/attribution scopes=] is null and |source|'s [=attribution source/attribution scopes=] is not null:
+    1. If the result of running [=check if source has incompatible attribution scope fields=] with |source| and |pendingSource| is false, [=iteration/continue=].
+    1. If |pendingSource|'s [=attribution source/attribution scopes=] is null:
         1. Set |source|'s [=attribution source/attribution scopes=] to null.
     1. Otherwise:
         1. [=Remove associated event-level reports and rate-limit records=] with |source|'s [=attribution source/source identifier=] and |pendingSource|'s [=attribution source/source time=].

--- a/index.bs
+++ b/index.bs
@@ -3119,7 +3119,7 @@ and a [=boolean=] |isNoised|:
         : "<code>[=source debug data type/source-max-event-states-limit=]</code>"
         ::
             1. [=Assert=]: |source|'s [=attribution source/attribution scopes=] is not null.
-            1. [=map/Set=] |body|["`limit`"] to the |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
+            1. [=map/Set=] |body|["`limit`"] to |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=].
 
         </dl>
 1. [=Assert=]: |dataTypeToReport| is not null.

--- a/index.bs
+++ b/index.bs
@@ -3180,13 +3180,13 @@ To <dfn>find sources with common destinations and reporting origin</dfn> given a
     1. [=list/Append=] |source| to |matchingSources|.
 1. Return |matchingSources|.
 
-To <dfn>check if source has incompatible attribution scope fields</dfn> given an [=attribution source=] |source| and an [=attribution source=] |pendingSource|:
+To <dfn>check if source has compatible attribution scope fields</dfn> given an [=attribution source=] |source| and an [=attribution source=] |pendingSource|:
 1. If |pendingSource|'s [=attribution source/attribution scopes=] is null:
-    1. Return false if |source|'s [=attribution source/attribution scopes=] is null, true otherwise.
-1. If |source|'s [=attribution source/attribution scopes=] is null, return true.
-1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=] is not equal to |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=], return true.
-1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=] is less than |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=], return true.
-1. Return false.
+    1. Return true if |source|'s [=attribution source/attribution scopes=] is null, false otherwise.
+1. If |source|'s [=attribution source/attribution scopes=] is null, return false.
+1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=] is not equal to |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=], return false.
+1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=] is less than |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=], return false.
+1. Return true.
 
 To <dfn>remove associated event-level reports and rate-limit records</dfn> given an [=attribution source/source identifier=] |sourceId| and a [=moment=] |minTriggerTime|:
 1. [=set/iterate|For each=] [=event-level report=] |report| of the [=event-level report cache=]:
@@ -3230,7 +3230,7 @@ To <dfn>remove sources with unselected attribution scopes</dfn> given an [=attri
 To <dfn>remove or update sources with incompatible attribution scope fields</dfn> given an [=attribution source=] |pendingSource|:
 1. Let |matchingSources| be the result of running [=find sources with common destinations and reporting origin=] with |pendingSource|.
 1. [=list/iterate|For each=] |source| of |matchingSources|:
-    1. If the result of running [=check if source has incompatible attribution scope fields=] with |source| and |pendingSource| is false, [=iteration/continue=].
+    1. If the result of running [=check if source has compatible attribution scope fields=] with |source| and |pendingSource| is true, [=iteration/continue=].
     1. If |pendingSource|'s [=attribution source/attribution scopes=] is null:
         1. Set |source|'s [=attribution source/attribution scopes=] to null.
     1. Otherwise:
@@ -3248,7 +3248,6 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     : [=randomized response output configuration/trigger specs=]
     :: |source|'s [=trigger specs=]
 
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
 1. If |channelCapacity| is an error:
@@ -3267,6 +3266,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
 1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
     1. Return.

--- a/index.bs
+++ b/index.bs
@@ -3182,7 +3182,7 @@ To <dfn>find sources with common destinations and reporting origin</dfn> given a
 
 To <dfn>check if source has incompatible attribution scope fields</dfn> given an [=attribution source=] |source| and an [=attribution source=] |pendingSource|:
 1. If |pendingSource|'s [=attribution source/attribution scopes=] is null:
-    1. Return true if |source|'s [=attribution source/attribution scopes=] is null, false otherwise.
+    1. Return false if |source|'s [=attribution source/attribution scopes=] is null, true otherwise.
 1. If |source|'s [=attribution source/attribution scopes=] is null, return true.
 1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=] is not equal to |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=], return true.
 1. If |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=] is less than |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/limit=], return true.
@@ -3248,6 +3248,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     : [=randomized response output configuration/trigger specs=]
     :: |source|'s [=trigger specs=]
 
+1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
 1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
 1. If |channelCapacity| is an error:
@@ -3266,7 +3267,6 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. Set |source|'s [=attribution source/number of event-level reports=] to 0 if
     |source|'s [=attribution source/randomized response=] is null,
     [=attribution source/randomized response=]'s [=list/size=] otherwise.
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] obtained with |randomizedResponseConfig|.
 1. If |sourceType| is "<code>[=source type/event=]</code>" and |states| is greater than |source|'s [=attribution source/attribution scopes=]'s [=attribution scopes/max event states=]:
     1. Run [=obtain and deliver debug reports on source registration=] with "<code>[=source debug data type/source-max-event-states-limit=]</code>" and |source|.
     1. Return.

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -66,6 +66,7 @@ export const sourceAggregatableDebugTypes: Readonly<[string, ...string[]]> = [
   'source-destination-global-rate-limit',
   'source-destination-limit',
   'source-destination-rate-limit',
+  'source-max-event-states-limit',
   'source-noised',
   'source-reporting-origin-limit',
   'source-reporting-origin-per-site-limit',

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -144,7 +144,7 @@ Additionally:
   the following fields:
    * `source_event_id`: The source registration's `source_event_id`.
    * `source_site`: The top-level site on which the source registration
-     occurred.
+      occurred.
    * `source_debug_key`: The source registration's `debug_key`, but omitted if
      the source registration did not contain a valid `debug_key` or
      [cookie-based debugging][] was prohibited.

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -51,9 +51,10 @@ Additional fields: `limit`
 
 #### `source-max-event-states-limit`
 
-A source is rejected due to [max event states][].
+A source is rejected due to the [event state limit][].
 
 Additional fields: `limit`
+
 #### `source-noised`
 
 The source was successfully registered, but it will not be attributable by any

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -49,6 +49,11 @@ The source was rejected due to the [destination limit][].
 
 Additional fields: `limit`
 
+#### `source-max-event-states-limit`
+
+A source is rejected due to [max event states][].
+
+Additional fields: `limit`
 #### `source-noised`
 
 The source was successfully registered, but it will not be attributable by any
@@ -136,12 +141,12 @@ Additionally:
   will also contain a string-typed `limit` field.
 * If the trigger was attributed to a source, then the `body` will also contain
   the following fields:
-   * `source_event_id`: The source registration's `source_event_id`.
-   * `source_site`: The top-level site on which the source registration
-      occurred.
-   * `source_debug_key`: The source registration's `debug_key`, but omitted if
-     the source registration did not contain a valid `debug_key` or
-     [cookie-based debugging][] was prohibited.
+  * `source_event_id`: The source registration's `source_event_id`.
+  * `source_site`: The top-level site on which the source registration
+    occurred.
+  * `source_debug_key`: The source registration's `debug_key`, but omitted if
+    the source registration did not contain a valid `debug_key` or
+    [cookie-based debugging][] was prohibited.
 
 #### `trigger-no-matching-source`
 
@@ -268,6 +273,7 @@ The trigger was rejected due to an internal error.
 [insufficient budget]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#contribution-bounding-and-budgeting
 [max aggregatable reports]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#hide-the-true-number-of-attribution-reports
 [max attributions rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits
+[max event states]: https://wicg.github.io/attribution-reporting-api/#attribution-scopes-max-event-states
 [noise]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#data-limits-and-noise
 [reporting origins per source and reporting site limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits
 [reporting origins per source and reporting site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -142,12 +142,12 @@ Additionally:
   will also contain a string-typed `limit` field.
 * If the trigger was attributed to a source, then the `body` will also contain
   the following fields:
-  * `source_event_id`: The source registration's `source_event_id`.
-  * `source_site`: The top-level site on which the source registration
-    occurred.
-  * `source_debug_key`: The source registration's `debug_key`, but omitted if
-    the source registration did not contain a valid `debug_key` or
-    [cookie-based debugging][] was prohibited.
+   * `source_event_id`: The source registration's `source_event_id`.
+   * `source_site`: The top-level site on which the source registration
+     occurred.
+   * `source_debug_key`: The source registration's `debug_key`, but omitted if
+     the source registration did not contain a valid `debug_key` or
+     [cookie-based debugging][] was prohibited.
 
 #### `trigger-no-matching-source`
 

--- a/verbose_debugging_reports.md
+++ b/verbose_debugging_reports.md
@@ -270,11 +270,11 @@ The trigger was rejected due to an internal error.
 [destinations per source and reporting site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [destinations per source site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#limiting-the-number-of-unique-destinations-per-source-site
 [event-level report body]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#attribution-reports
+[event states limit]: https://wicg.github.io/attribution-reporting-api/#attribution-scopes-max-event-states
 [filter data]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#optional-attribution-filters
 [insufficient budget]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#contribution-bounding-and-budgeting
 [max aggregatable reports]: https://github.com/WICG/attribution-reporting-api/blob/main/AGGREGATE.md#hide-the-true-number-of-attribution-reports
 [max attributions rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-cooldown--rate-limits
-[max event states]: https://wicg.github.io/attribution-reporting-api/#attribution-scopes-max-event-states
 [noise]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#data-limits-and-noise
 [reporting origins per source and reporting site limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits
 [reporting origins per source and reporting site rate limit]: https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#reporting-origin-limits


### PR DESCRIPTION
The current attribution logic in the Attribution Reporting API may not be ideal for use-cases where an ad-tech needs more fine grain control over the attribution granularity (i.e. campaign, product, conversion ID, etc.) before a source is chosen for attribution. Currently available features such as top-level filters are not fully sufficient for this use-case because they happen after a source has been selected (i.e. after attribution). We can optionally support this use-case by allowing callers of the API to specify predefined attribution scopes that will be considered for filtering before attributing a source, in order to more efficiently extract utility out of the API.

This PR covers the attribution and source processing logic.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/feifeiji89/attribution-reporting-api/pull/1365.html" title="Last updated on Aug 13, 2024, 6:53 PM UTC (ec6d054)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1365/d22686c...feifeiji89:ec6d054.html" title="Last updated on Aug 13, 2024, 6:53 PM UTC (ec6d054)">Diff</a>