### PR TITLE
Expose common validation/serialization interface for each header

### DIFF
--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -67,12 +67,11 @@ function logIssue(prefix: string, i: Issue): void {
 let config: Maybe<Config> = Maybe.None
 if (options.json_file !== undefined) {
   const json = readFileSync(options.json_file, { encoding: 'utf8' })
-  const [{ errors, warnings }, source] = validateSource(
-    json,
-    vsv.Chromium,
-    options.source_type,
-    /*parseFullFlex=*/ true
-  )
+  const [{ errors, warnings }, source] = validateSource(json, {
+    vsv: vsv.Chromium,
+    sourceType: options.source_type,
+    fullFlex: true,
+  })
   warnings.forEach((i) => logIssue('W', i))
   if (errors.length > 0) {
     errors.forEach((i) => logIssue('E', i))

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2911,31 +2911,19 @@ const testCases: TestCase[] = [
 
 testCases.forEach((tc) =>
   jsontest.run(tc, () => {
-    const result = validateSource(
-      tc.json,
-      { ...vsv.Chromium, ...tc.vsv },
-      tc.sourceType ?? SourceType.navigation,
-      tc.parseFullFlex ?? false,
-      tc.noteInfoGain ?? false,
-      tc.parseScopes ?? false
-    )
+    const opts = {
+      vsv: { ...vsv.Chromium, ...tc.vsv },
+      sourceType: tc.sourceType ?? SourceType.navigation,
+      fullFlex: tc.parseFullFlex,
+      noteInfoGain: tc.noteInfoGain,
+      scopes: tc.parseScopes,
+    }
+
+    const result = validateSource(tc.json, opts)
 
     if (result[1].value !== undefined) {
-      const str = JSON.stringify(
-        serializeSource(
-          result[1].value,
-          tc.parseFullFlex ?? false,
-          tc.parseScopes ?? false
-        )
-      )
-      const [, reparsed] = validateSource(
-        str,
-        { ...vsv.Chromium, ...tc.vsv },
-        tc.sourceType ?? SourceType.navigation,
-        tc.parseFullFlex ?? false,
-        tc.noteInfoGain ?? false,
-        tc.parseScopes ?? false
-      )
+      const str = serializeSource(result[1].value, opts)
+      const [, reparsed] = validateSource(str, opts)
       assert.deepEqual(reparsed, result[1], str)
     }
 

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1728,27 +1728,17 @@ const testCases: jsontest.TestCase<Trigger>[] = [
 
 testCases.forEach((tc) =>
   jsontest.run(tc, () => {
-    const result = validateTrigger(
-      tc.json,
-      { ...vsv.Chromium, ...tc.vsv },
-      tc.parseFullFlex ?? false,
-      tc.parseScopes ?? false
-    )
+    const opts = {
+      vsv: { ...vsv.Chromium, ...tc.vsv },
+      fullFlex: tc.parseFullFlex,
+      scopes: tc.parseScopes,
+    }
+
+    const result = validateTrigger(tc.json, opts)
 
     if (result[1].value !== undefined) {
-      const str = JSON.stringify(
-        serializeTrigger(
-          result[1].value,
-          tc.parseFullFlex ?? false,
-          tc.parseScopes ?? false
-        )
-      )
-      const [, reparsed] = validateTrigger(
-        str,
-        { ...vsv.Chromium, ...tc.vsv },
-        tc.parseFullFlex ?? false,
-        tc.parseScopes ?? false
-      )
+      const str = serializeTrigger(result[1].value, opts)
+      const [, reparsed] = validateTrigger(str, opts)
       assert.deepEqual(reparsed, result[1], str)
     }
 

--- a/ts/src/header-validator/validate-eligible.test.ts
+++ b/ts/src/header-validator/validate-eligible.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { Eligible, validateEligible } from './validate-eligible'
+import { Eligible, validate } from './validate-eligible'
 
 type TestCase = testutil.TestCase & {
   input: string
@@ -114,7 +114,7 @@ const tests: TestCase[] = [
 
 tests.forEach((tc) =>
   testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validateEligible(tc.input)
+    const [validationResult, value] = validate(tc.input)
     if (tc.expected !== undefined) {
       assert.deepEqual(value, tc.expected)
     }

--- a/ts/src/header-validator/validate-eligible.ts
+++ b/ts/src/header-validator/validate-eligible.ts
@@ -37,9 +37,7 @@ function presence(
   return Maybe.some(true)
 }
 
-export function validateEligible(
-  str: string
-): [ValidationResult, Maybe<Eligible>] {
+export function validate(str: string): [ValidationResult, Maybe<Eligible>] {
   return validateDictionary(str, new Context(), (d, ctx) =>
     struct(d, ctx, {
       navigationSource: field(navigationSourceKey, presence),
@@ -57,7 +55,7 @@ export function validateEligible(
   )
 }
 
-export function serializeEligible(e: Eligible): string {
+export function serialize(e: Eligible): string {
   const map: Dictionary = new Map()
   if (e.navigationSource) {
     map.set(navigationSourceKey, [true, new Map()])

--- a/ts/src/header-validator/validate-info.test.ts
+++ b/ts/src/header-validator/validate-info.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { Info, PreferredPlatform, validateInfo } from './validate-info'
+import { Info, PreferredPlatform, validate } from './validate-info'
 
 type TestCase = testutil.TestCase & {
   input: string
@@ -110,7 +110,7 @@ const tests: TestCase[] = [
 
 tests.forEach((tc) =>
   testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validateInfo(tc.input)
+    const [validationResult, value] = validate(tc.input)
     if (tc.expected !== undefined) {
       assert.deepEqual(value, tc.expected)
     }

--- a/ts/src/header-validator/validate-info.ts
+++ b/ts/src/header-validator/validate-info.ts
@@ -1,6 +1,6 @@
 import { Context, ValidationResult } from './context'
 import { Maybe } from './maybe'
-import * as validate from './validate'
+import { enumerated } from './validate'
 import { field, struct, validateDictionary } from './validate-structured'
 import {
   Dictionary,
@@ -31,13 +31,11 @@ function preferredPlatform(
     ctx.error('must be a token')
     return Maybe.None
   }
-  return validate
-    .enumerated(v[0].toString(), ctx, PreferredPlatform)
-    .peek(() => {
-      if (v[1].size !== 0) {
-        ctx.warning('ignoring parameters')
-      }
-    })
+  return enumerated(v[0].toString(), ctx, PreferredPlatform).peek(() => {
+    if (v[1].size !== 0) {
+      ctx.warning('ignoring parameters')
+    }
+  })
 }
 
 function reportHeaderErrors(
@@ -57,7 +55,7 @@ function reportHeaderErrors(
   return Maybe.some(v[0])
 }
 
-export function validateInfo(str: string): [ValidationResult, Maybe<Info>] {
+export function validate(str: string): [ValidationResult, Maybe<Info>] {
   return validateDictionary(str, new Context(), (d, ctx) =>
     struct(d, ctx, {
       preferredPlatform: field('preferred-platform', preferredPlatform),
@@ -66,7 +64,7 @@ export function validateInfo(str: string): [ValidationResult, Maybe<Info>] {
   )
 }
 
-export function serializeInfo(info: Info): string {
+export function serialize(info: Info): string {
   const map: Dictionary = new Map()
   if (info.preferredPlatform !== null) {
     map.set('preferred-platform', [info.preferredPlatform, new Map()])

--- a/ts/src/header-validator/validate-os.test.ts
+++ b/ts/src/header-validator/validate-os.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { OsItem, validateOsRegistration } from './validate-os'
+import { OsItem, validate } from './validate-os'
 
 type TestCase = testutil.TestCase & {
   input: string
@@ -133,7 +133,7 @@ const tests: TestCase[] = [
 
 tests.forEach((tc) =>
   testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validateOsRegistration(tc.input)
+    const [validationResult, value] = validate(tc.input)
     if (tc.expected !== undefined) {
       assert.deepEqual(value, tc.expected)
     }

--- a/ts/src/header-validator/validate-os.ts
+++ b/ts/src/header-validator/validate-os.ts
@@ -1,6 +1,6 @@
 import { Context, ValidationResult } from './context'
 import { Maybe } from './maybe'
-import * as validate from './validate'
+import { ItemErrorAction, array } from './validate'
 import { param } from './validate-structured'
 import {
   InnerList,
@@ -43,9 +43,7 @@ function parseItem(member: InnerList | Item, ctx: Context): Maybe<OsItem> {
   })
 }
 
-export function validateOsRegistration(
-  str: string
-): [ValidationResult, Maybe<OsItem[]>] {
+export function validate(str: string): [ValidationResult, Maybe<OsItem[]>] {
   const ctx = new Context()
 
   let list
@@ -56,16 +54,11 @@ export function validateOsRegistration(
     return [ctx.finish(msg), Maybe.None]
   }
 
-  const items = validate.array(
-    list.entries(),
-    ctx,
-    parseItem,
-    validate.ItemErrorAction.ignore
-  )
+  const items = array(list.entries(), ctx, parseItem, ItemErrorAction.ignore)
   return [ctx.finish(), items]
 }
 
-export function serializeOsRegistration(items: OsItem[]): string {
+export function serialize(items: OsItem[]): string {
   const list: List = []
   for (const item of items) {
     list.push([

--- a/ts/src/header-validator/validator.ts
+++ b/ts/src/header-validator/validator.ts
@@ -1,0 +1,37 @@
+import { ValidationResult } from './context'
+import { Maybe } from './maybe'
+import * as toJson from './to-json'
+import * as json from './validate-json'
+
+export interface Validator<T> {
+  validate(input: string): [ValidationResult, Maybe<T>]
+  serialize(value: T): string
+}
+
+export function source(
+  opts: Readonly<json.SourceOptions>
+): Validator<json.Source> {
+  return {
+    validate: (input) => json.validateSource(input, opts),
+    serialize: (value) => toJson.serializeSource(value, opts),
+  }
+}
+
+export function trigger(
+  opts: Readonly<json.RegistrationOptions>
+): Validator<json.Trigger> {
+  return {
+    validate: (input) => json.validateTrigger(input, opts),
+    serialize: (value) => toJson.serializeTrigger(value, opts),
+  }
+}
+
+export interface Output extends ValidationResult {
+  value?: string
+}
+
+export function validate<T>(input: string, validator: Validator<T>): Output {
+  const [result, value]: [Output, Maybe<T>] = validator.validate(input)
+  value.peek((value) => (result.value = validator.serialize(value)))
+  return result
+}


### PR DESCRIPTION
This makes it easier to guarantee similar operation between the web validator and the command-line one while eliminating redundant logic.

We separate option-construction for the JSON validators from context creation, which is an internal detail of their operation, which enables further encapsulation.