### PR TITLE
Move parsed source/trigger types to separate files

### DIFF
--- a/ts/src/header-validator/aggregatable-contributions.test.ts
+++ b/ts/src/header-validator/aggregatable-contributions.test.ts
@@ -2,12 +2,11 @@ import { strict as assert } from 'assert'
 import test from 'node:test'
 import { SourceType } from '../source-type'
 import { createAggregatableContributions } from './aggregatable-contributions'
+import { AggregationKeys, FilterData } from './source'
 import {
   AggregatableTriggerDatum,
   AggregatableValuesConfiguration,
-  AggregationKeys,
-  FilterData,
-} from './validate-json'
+} from './trigger'
 
 const sourceTime = 1
 const triggerTime = sourceTime + 5

--- a/ts/src/header-validator/aggregatable-contributions.ts
+++ b/ts/src/header-validator/aggregatable-contributions.ts
@@ -1,12 +1,11 @@
 import { SourceType } from '../source-type'
 import * as filters from './filters'
+import { AggregationKeys, FilterData } from './source'
 import {
   AggregatableTriggerDatum,
   AggregatableValues,
   AggregatableValuesConfiguration,
-  AggregationKeys,
-  FilterData,
-} from './validate-json'
+} from './trigger'
 
 export type AggregatableContribution = {
   key: bigint

--- a/ts/src/header-validator/filters.test.ts
+++ b/ts/src/header-validator/filters.test.ts
@@ -2,7 +2,8 @@ import { strict as assert } from 'assert'
 import test from 'node:test'
 import { SourceType } from '../source-type'
 import * as filters from './filters'
-import { FilterData, FilterConfig } from './validate-json'
+import { FilterData } from './source'
+import { FilterConfig } from './trigger'
 
 type TestCase = {
   name: string

--- a/ts/src/header-validator/filters.ts
+++ b/ts/src/header-validator/filters.ts
@@ -1,5 +1,6 @@
 import { SourceType } from '../source-type'
-import { FilterData, FilterConfig, FilterPair } from './validate-json'
+import { FilterData } from './source'
+import { FilterConfig, FilterPair } from './trigger'
 
 // https://wicg.github.io/attribution-reporting-api/#does-filter-data-match
 function matchFilterValues(a: Set<string>, b: Set<string>): boolean {

--- a/ts/src/header-validator/reg.ts
+++ b/ts/src/header-validator/reg.ts
@@ -1,0 +1,26 @@
+export type CommonDebug = {
+  debugKey: bigint | null
+  debugReporting: boolean
+}
+
+export type Priority = {
+  priority: bigint
+}
+
+export type KeyPiece = {
+  keyPiece: bigint
+}
+
+export type AggregatableDebugReportingData = KeyPiece & {
+  types: Set<string>
+  value: number
+}
+
+export type AggregationCoordinatorOrigin = {
+  aggregationCoordinatorOrigin: string
+}
+
+export type AggregatableDebugReportingConfig = KeyPiece &
+  AggregationCoordinatorOrigin & {
+    debugData: AggregatableDebugReportingData[]
+  }

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2,13 +2,9 @@ import { strict as assert } from 'assert'
 import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
+import { Source, SummaryOperator, TriggerDataMatching } from './source'
 import { serializeSource } from './to-json'
-import {
-  Source,
-  SummaryOperator,
-  TriggerDataMatching,
-  validateSource,
-} from './validate-json'
+import { validateSource } from './validate-json'
 import * as jsontest from './validate-json.test'
 
 type TestCase = jsontest.TestCase<Source> & {

--- a/ts/src/header-validator/source.ts
+++ b/ts/src/header-validator/source.ts
@@ -1,0 +1,53 @@
+import * as reg from './reg'
+
+export type EventReportWindows = {
+  startTime: number
+  endTimes: number[]
+}
+
+export type FilterData = Map<string, Set<string>>
+
+export type AggregationKeys = Map<string, bigint>
+
+export enum SummaryOperator {
+  count = 'count',
+  value_sum = 'value_sum',
+}
+
+export type TriggerSpec = {
+  eventReportWindows: EventReportWindows
+  summaryBuckets: number[]
+  summaryOperator: SummaryOperator
+  triggerData: Set<number>
+}
+
+export type SourceAggregatableDebugReportingConfig =
+  reg.AggregatableDebugReportingConfig & {
+    budget: number
+  }
+
+export enum TriggerDataMatching {
+  exact = 'exact',
+  modulus = 'modulus',
+}
+
+export type Source = reg.CommonDebug &
+  reg.Priority & {
+    aggregatableReportWindow: number
+    aggregationKeys: AggregationKeys
+    destination: Set<string>
+    expiry: number
+    filterData: FilterData
+    maxEventLevelReports: number
+    sourceEventId: bigint
+
+    triggerSpecs: TriggerSpec[]
+    triggerDataMatching: TriggerDataMatching
+
+    eventLevelEpsilon: number
+    aggregatableDebugReporting: SourceAggregatableDebugReportingConfig | null
+    destinationLimitPriority: bigint
+    attributionScopes: Set<string>
+    attributionScopeLimit: number | null
+    maxEventStates: number
+  }

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -1,4 +1,6 @@
-import * as parsed from './validate-json'
+import * as reg from './reg'
+import * as source from './source'
+import * as trigger from './trigger'
 
 type MaybeHasField<K extends string, V> = {
   [key in K]?: V
@@ -21,7 +23,7 @@ type CommonDebug = {
   debug_reporting: boolean
 }
 
-function serializeCommonDebug(c: parsed.CommonDebug): CommonDebug {
+function serializeCommonDebug(c: reg.CommonDebug): CommonDebug {
   return {
     ...ifNotNull('debug_key', c.debugKey, (v) => v.toString()),
     debug_reporting: c.debugReporting,
@@ -32,7 +34,7 @@ type Priority = {
   priority: string
 }
 
-function serializePriority(p: parsed.Priority): Priority {
+function serializePriority(p: reg.Priority): Priority {
   return { priority: p.priority.toString() }
 }
 
@@ -40,7 +42,7 @@ type KeyPiece = {
   key_piece: string
 }
 
-function serializeKeyPiece(p: parsed.KeyPiece): KeyPiece {
+function serializeKeyPiece(p: reg.KeyPiece): KeyPiece {
   return { key_piece: `0x${p.keyPiece.toString(16)}` }
 }
 
@@ -50,7 +52,7 @@ type AggregatableDebugReportingData = KeyPiece & {
 }
 
 function serializeAggregatableDebugReportingData(
-  d: parsed.AggregatableDebugReportingData
+  d: reg.AggregatableDebugReportingData
 ): AggregatableDebugReportingData {
   return {
     ...serializeKeyPiece(d),
@@ -66,7 +68,7 @@ type AggregatableDebugReportingConfig = KeyPiece & {
 }
 
 function serializeAggregatableDebugReportingConfig(
-  d: parsed.AggregatableDebugReportingConfig
+  d: reg.AggregatableDebugReportingConfig
 ): AggregatableDebugReportingConfig {
   return {
     ...serializeKeyPiece(d),
@@ -84,7 +86,7 @@ type EventReportWindows = {
 }
 
 function serializeEventReportWindows(
-  e: parsed.EventReportWindows
+  e: source.EventReportWindows
 ): EventReportWindows {
   return {
     event_report_windows: {
@@ -108,7 +110,7 @@ type TriggerSpec = EventReportWindows &
     summary_operator: string
   }
 
-function serializeTriggerSpec(ts: parsed.TriggerSpec): TriggerSpec {
+function serializeTriggerSpec(ts: source.TriggerSpec): TriggerSpec {
   return {
     ...serializeEventReportWindows(ts.eventReportWindows),
     ...serializeTriggerData(ts.triggerData),
@@ -124,7 +126,7 @@ type SourceAggregatableDebugReportingConfig =
   }
 
 function serializeSourceAggregatableDebugReportingConfig(
-  d: parsed.SourceAggregatableDebugReportingConfig
+  d: source.SourceAggregatableDebugReportingConfig
 ): SourceAggregatableDebugReportingConfig {
   return {
     ...serializeAggregatableDebugReportingConfig(d),
@@ -145,7 +147,7 @@ type FullFlexSource = {
 }
 
 function serializeFlexSource(
-  s: parsed.Source,
+  s: source.Source,
   fullFlex: boolean
 ): NotFullFlexSource | FullFlexSource {
   if (fullFlex) {
@@ -193,7 +195,7 @@ export interface Options {
 }
 
 export function serializeSource(
-  s: parsed.Source,
+  s: source.Source,
   opts: Readonly<Options>
 ): string {
   const scopeFields = opts.scopes
@@ -250,7 +252,7 @@ type FilterConfig = {
   [key: string]: number | string[]
 }
 
-function serializeFilterConfig(fc: parsed.FilterConfig): FilterConfig {
+function serializeFilterConfig(fc: trigger.FilterConfig): FilterConfig {
   const obj: FilterConfig = Object.fromEntries(
     Array.from(fc.map.entries(), ([key, vals]) => [key, Array.from(vals)])
   )
@@ -267,7 +269,7 @@ type FilterPair = {
   not_filters: FilterConfig[]
 }
 
-function serializeFilterPair(fp: parsed.FilterPair): FilterPair {
+function serializeFilterPair(fp: trigger.FilterPair): FilterPair {
   return {
     filters: Array.from(fp.positive, serializeFilterConfig),
     not_filters: Array.from(fp.negative, serializeFilterConfig),
@@ -278,7 +280,7 @@ type DedupKey = {
   deduplication_key?: string
 }
 
-function serializeDedupKey(fp: parsed.DedupKey): DedupKey {
+function serializeDedupKey(fp: trigger.DedupKey): DedupKey {
   return ifNotNull('deduplication_key', fp.dedupKey, (v) => v.toString())
 }
 
@@ -290,7 +292,7 @@ type EventTriggerDatum = FilterPair &
   }
 
 function serializeEventTriggerDatum(
-  d: parsed.EventTriggerDatum,
+  d: trigger.EventTriggerDatum,
   fullFlex: boolean
 ): EventTriggerDatum {
   const obj: EventTriggerDatum = {
@@ -311,7 +313,7 @@ function serializeEventTriggerDatum(
 type AggregatableDedupKey = FilterPair & DedupKey
 
 function serializeAggregatableDedupKey(
-  d: parsed.AggregatableDedupKey
+  d: trigger.AggregatableDedupKey
 ): AggregatableDedupKey {
   return {
     ...serializeFilterPair(d),
@@ -325,7 +327,7 @@ type AggregatableTriggerDatum = FilterPair &
   }
 
 function serializeAggregatableTriggerDatum(
-  d: parsed.AggregatableTriggerDatum
+  d: trigger.AggregatableTriggerDatum
 ): AggregatableTriggerDatum {
   return {
     ...serializeFilterPair(d),
@@ -347,7 +349,7 @@ type AggregatableValuesConfiguration = FilterPair & {
 }
 
 function serializeAggregatableValuesConfiguration(
-  c: parsed.AggregatableValuesConfiguration
+  c: trigger.AggregatableValuesConfiguration
 ): AggregatableValuesConfiguration {
   const values: AggregatableValues = {}
   for (const [key, value] of c.values.entries()) {
@@ -377,7 +379,7 @@ type Trigger = CommonDebug &
   }
 
 export function serializeTrigger(
-  t: parsed.Trigger,
+  t: trigger.Trigger,
   opts: Readonly<Options>
 ): string {
   const scopeFields = opts.scopes

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -2,11 +2,8 @@ import { strict as assert } from 'assert'
 import * as vsv from '../vendor-specific-values'
 import { Maybe } from './maybe'
 import { serializeTrigger } from './to-json'
-import {
-  AggregatableSourceRegistrationTime,
-  Trigger,
-  validateTrigger,
-} from './validate-json'
+import { AggregatableSourceRegistrationTime, Trigger } from './trigger'
+import { validateTrigger } from './validate-json'
 import * as jsontest from './validate-json.test'
 
 const testCases: jsontest.TestCase<Trigger>[] = [

--- a/ts/src/header-validator/trigger.ts
+++ b/ts/src/header-validator/trigger.ts
@@ -1,0 +1,59 @@
+import * as reg from './reg'
+
+export type FilterConfig = {
+  lookbackWindow: number | null
+  map: Map<string, Set<string>>
+}
+
+export type FilterPair = {
+  positive: FilterConfig[]
+  negative: FilterConfig[]
+}
+
+export type DedupKey = {
+  dedupKey: bigint | null
+}
+
+export type AggregatableTriggerDatum = FilterPair &
+  reg.KeyPiece & {
+    sourceKeys: Set<string>
+  }
+
+export type AggregatableValuesValue = {
+  value: number
+  filteringId: bigint
+}
+
+export type AggregatableValues = Map<string, AggregatableValuesValue>
+
+export type AggregatableValuesConfiguration = FilterPair & {
+  values: AggregatableValues
+}
+
+export type EventTriggerDatum = FilterPair &
+  reg.Priority &
+  DedupKey & {
+    triggerData: bigint
+    value: number
+  }
+
+export type AggregatableDedupKey = FilterPair & DedupKey
+
+export enum AggregatableSourceRegistrationTime {
+  exclude = 'exclude',
+  include = 'include',
+}
+
+export type Trigger = reg.CommonDebug &
+  FilterPair &
+  reg.AggregationCoordinatorOrigin & {
+    aggregatableDedupKeys: AggregatableDedupKey[]
+    aggregatableTriggerData: AggregatableTriggerDatum[]
+    aggregatableSourceRegistrationTime: AggregatableSourceRegistrationTime
+    aggregatableFilteringIdMaxBytes: number
+    aggregatableValuesConfigurations: AggregatableValuesConfiguration[]
+    eventTriggerData: EventTriggerDatum[]
+    triggerContextID: string | null
+    aggregatableDebugReporting: reg.AggregatableDebugReportingConfig | null
+    attributionScopes: Set<string>
+  }

--- a/ts/src/header-validator/validator.ts
+++ b/ts/src/header-validator/validator.ts
@@ -1,5 +1,7 @@
 import { ValidationResult } from './context'
 import { Maybe } from './maybe'
+import { Source } from './source'
+import { Trigger } from './trigger'
 import * as toJson from './to-json'
 import * as json from './validate-json'
 
@@ -8,9 +10,7 @@ export interface Validator<T> {
   serialize(value: T): string
 }
 
-export function source(
-  opts: Readonly<json.SourceOptions>
-): Validator<json.Source> {
+export function source(opts: Readonly<json.SourceOptions>): Validator<Source> {
   return {
     validate: (input) => json.validateSource(input, opts),
     serialize: (value) => toJson.serializeSource(value, opts),
@@ -19,7 +19,7 @@ export function source(
 
 export function trigger(
   opts: Readonly<json.RegistrationOptions>
-): Validator<json.Trigger> {
+): Validator<Trigger> {
   return {
     validate: (input) => json.validateTrigger(input, opts),
     serialize: (value) => toJson.serializeTrigger(value, opts),


### PR DESCRIPTION
This will make it easier to split source/trigger parsing into separate files, and removes unnecessary dependencies on parsing.