### PR TITLE
Round-trip all registrations during testing

### DIFF
--- a/ts/src/header-validator/util.test.ts
+++ b/ts/src/header-validator/util.test.ts
@@ -1,24 +1,35 @@
 import { strict as assert } from 'assert'
 import test from 'node:test'
 import * as context from './context'
+import { Maybe } from './maybe'
+import { Validator } from './validator'
 
-export type TestCase = {
+export type TestCase<T> = {
+  name?: string
+  input: string
   expectedWarnings?: context.Issue[]
   expectedErrors?: context.Issue[]
   expectedNotes?: context.Issue[]
+  expected?: Maybe<T>
 }
 
-export function run(
-  tc: TestCase,
-  name: string,
-  f: () => context.ValidationResult
-): void {
-  void test(name, () => {
-    const result = f()
+export function run<T>(tc: TestCase<T>, validator: Validator<T>): void {
+  void test(tc.name ?? tc.input, () => {
+    const [result, value] = validator.validate(tc.input)
     assert.deepEqual(result, {
       errors: tc.expectedErrors ?? [],
       warnings: tc.expectedWarnings ?? [],
       notes: tc.expectedNotes ?? [],
     })
+
+    if (tc.expected !== undefined) {
+      assert.deepEqual(value, tc.expected)
+    }
+
+    if (value.value !== undefined) {
+      const str = validator.serialize(value.value)
+      const [, reparsed] = validator.validate(str)
+      assert.deepEqual(reparsed, value, str)
+    }
   })
 }

--- a/ts/src/header-validator/validate-eligible.test.ts
+++ b/ts/src/header-validator/validate-eligible.test.ts
@@ -1,14 +1,8 @@
-import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { Eligible, validate } from './validate-eligible'
+import * as eligible from './validate-eligible'
 
-type TestCase = testutil.TestCase & {
-  input: string
-  expected?: Maybe<Eligible>
-}
-
-const tests: TestCase[] = [
+const tests: testutil.TestCase<eligible.Eligible>[] = [
   // Valid
   {
     input: '',
@@ -112,12 +106,4 @@ const tests: TestCase[] = [
   },
 ]
 
-tests.forEach((tc) =>
-  testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validate(tc.input)
-    if (tc.expected !== undefined) {
-      assert.deepEqual(value, tc.expected)
-    }
-    return validationResult
-  })
-)
+tests.forEach((tc) => testutil.run(tc, eligible))

--- a/ts/src/header-validator/validate-info.test.ts
+++ b/ts/src/header-validator/validate-info.test.ts
@@ -1,21 +1,15 @@
-import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { Info, PreferredPlatform, validate } from './validate-info'
+import * as info from './validate-info'
 
-type TestCase = testutil.TestCase & {
-  input: string
-  expected?: Maybe<Info>
-}
-
-const tests: TestCase[] = [
+const tests: testutil.TestCase<info.Info>[] = [
   {
     input: 'preferred-platform=os',
   },
   {
     input: 'preferred-platform=web',
     expected: Maybe.some({
-      preferredPlatform: PreferredPlatform.web,
+      preferredPlatform: info.PreferredPlatform.web,
       reportHeaderErrors: false,
     }),
   },
@@ -32,7 +26,7 @@ const tests: TestCase[] = [
   {
     input: 'preferred-platform=os,report-header-errors=?0',
     expected: Maybe.some({
-      preferredPlatform: PreferredPlatform.os,
+      preferredPlatform: info.PreferredPlatform.os,
       reportHeaderErrors: false,
     }),
   },
@@ -108,12 +102,4 @@ const tests: TestCase[] = [
   },
 ]
 
-tests.forEach((tc) =>
-  testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validate(tc.input)
-    if (tc.expected !== undefined) {
-      assert.deepEqual(value, tc.expected)
-    }
-    return validationResult
-  })
-)
+tests.forEach((tc) => testutil.run(tc, info))

--- a/ts/src/header-validator/validate-info.ts
+++ b/ts/src/header-validator/validate-info.ts
@@ -67,7 +67,10 @@ export function validate(str: string): [ValidationResult, Maybe<Info>] {
 export function serialize(info: Info): string {
   const map: Dictionary = new Map()
   if (info.preferredPlatform !== null) {
-    map.set('preferred-platform', [info.preferredPlatform, new Map()])
+    map.set('preferred-platform', [
+      new Token(info.preferredPlatform),
+      new Map(),
+    ])
   }
   map.set('report-header-errors', [info.reportHeaderErrors, new Map()])
   return serializeDictionary(map)

--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -1,27 +1,8 @@
-import { strict as assert } from 'assert'
-import * as context from './context'
-import { Maybe } from './maybe'
 import * as testutil from './util.test'
 import * as vsv from '../vendor-specific-values'
 
-export type TestCase<T> = testutil.TestCase & {
-  name: string
-  json: string
+export type TestCase<T> = testutil.TestCase<T> & {
   vsv?: Readonly<Partial<vsv.VendorSpecificValues>>
   parseFullFlex?: boolean
   parseScopes?: boolean
-  expected?: Maybe<T>
-}
-
-export function run<T>(
-  tc: TestCase<T>,
-  f: () => [context.ValidationResult, Maybe<T>]
-): void {
-  testutil.run(tc, tc.name, () => {
-    const [validationResult, value] = f()
-    if (tc.expected !== undefined) {
-      assert.deepEqual(value, tc.expected)
-    }
-    return validationResult
-  })
 }

--- a/ts/src/header-validator/validate-os.test.ts
+++ b/ts/src/header-validator/validate-os.test.ts
@@ -1,14 +1,8 @@
-import { strict as assert } from 'assert'
 import * as testutil from './util.test'
 import { Maybe } from './maybe'
-import { OsItem, validate } from './validate-os'
+import * as os from './validate-os'
 
-type TestCase = testutil.TestCase & {
-  input: string
-  expected?: Maybe<OsItem[]>
-}
-
-const tests: TestCase[] = [
+const tests: testutil.TestCase<os.OsItem[]>[] = [
   // Valid
   { input: '"https://a.test/"' },
   { input: '"http://localhost/"' },
@@ -131,12 +125,4 @@ const tests: TestCase[] = [
   },
 ]
 
-tests.forEach((tc) =>
-  testutil.run(tc, /*name=*/ tc.input, () => {
-    const [validationResult, value] = validate(tc.input)
-    if (tc.expected !== undefined) {
-      assert.deepEqual(value, tc.expected)
-    }
-    return validationResult
-  })
-)
+tests.forEach((tc) => testutil.run(tc, os))


### PR DESCRIPTION
And fix a newly identified bug in the serialization of the Attribution-Reporting-Info header in which the preferred platform was emitted as a string instead of a token.