### PR TITLE
Split source/trigger validation into separate files

### DIFF
--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs'
 
 import { Issue } from '../header-validator/context'
 import { Maybe } from '../header-validator/maybe'
-import { validateSource } from '../header-validator/validate-json'
+import { validateSource } from '../header-validator/validate-source'
 import { SourceType, parseSourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, PerTriggerDataConfig } from './privacy'

--- a/ts/src/header-validator/filters-index.ts
+++ b/ts/src/header-validator/filters-index.ts
@@ -2,7 +2,9 @@ import { SourceType } from '../source-type'
 import { Context } from './context'
 import * as filters from './filters'
 import { makeLi } from './issue-utils'
-import { validateJSON, filterPair, filterData } from './validate-json'
+import { validateJSON } from './validate-json'
+import { filterData } from './validate-source'
+import { filterPair } from './validate-trigger'
 
 const form = document.querySelector<HTMLFormElement>('form')!
 const sourceAgeInput = form.elements.namedItem(

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -4,6 +4,8 @@ import { makeLi } from './issue-utils'
 import * as eligible from './validate-eligible'
 import * as info from './validate-info'
 import * as os from './validate-os'
+import * as source from './validate-source'
+import * as trigger from './validate-trigger'
 import * as validator from './validator'
 
 const form = document.querySelector<HTMLFormElement>('form')!
@@ -39,7 +41,7 @@ function validate(): void {
       sourceTypeFieldset.disabled = false
       flexCheckbox.disabled = false
       scopesCheckbox.disabled = false
-      v = validator.source({
+      v = source.validator({
         vsv: vsv.Chromium,
         sourceType: sourceType(),
         fullFlex: flexCheckbox.checked,
@@ -50,7 +52,7 @@ function validate(): void {
     case 'trigger':
       flexCheckbox.disabled = false
       scopesCheckbox.disabled = false
-      v = validator.trigger({
+      v = trigger.validator({
         vsv: vsv.Chromium,
         fullFlex: flexCheckbox.checked,
         scopes: scopesCheckbox.checked,

--- a/ts/src/header-validator/main.ts
+++ b/ts/src/header-validator/main.ts
@@ -1,7 +1,9 @@
 import { parse } from 'ts-command-line-args'
 import { readFileSync } from 'fs'
 
-import * as validator from './validator'
+import { validate } from './validator'
+import * as source from './validate-source'
+import * as trigger from './validate-trigger'
 import { SourceType, parseSourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 
@@ -92,15 +94,15 @@ if (options.file !== undefined) {
   })
 }
 
-const out = validator.validate<unknown>(
+const out = validate<unknown>(
   options.input!,
   options.sourceType === undefined
-    ? validator.trigger({
+    ? trigger.validator({
         vsv: vsv.Chromium,
         fullFlex: options.fullFlex,
         scopes: options.scopes,
       })
-    : validator.source({
+    : source.validator({
         vsv: vsv.Chromium,
         fullFlex: options.fullFlex,
         sourceType: options.sourceType,

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -4,7 +4,7 @@ import { Maybe } from './maybe'
 import { Source, SummaryOperator, TriggerDataMatching } from './source'
 import * as testutil from './util.test'
 import * as jsontest from './validate-json.test'
-import * as validator from './validator'
+import * as source from './validate-source'
 
 type TestCase = jsontest.TestCase<Source> & {
   sourceType?: SourceType
@@ -2907,7 +2907,7 @@ const testCases: TestCase[] = [
 testCases.forEach((tc) =>
   testutil.run(
     tc,
-    validator.source({
+    source.validator({
       vsv: { ...vsv.Chromium, ...tc.vsv },
       sourceType: tc.sourceType ?? SourceType.navigation,
       fullFlex: tc.parseFullFlex,

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -3,7 +3,7 @@ import { Maybe } from './maybe'
 import { AggregatableSourceRegistrationTime, Trigger } from './trigger'
 import * as testutil from './util.test'
 import * as jsontest from './validate-json.test'
-import * as validator from './validator'
+import * as trigger from './validate-trigger'
 
 const testCases: jsontest.TestCase<Trigger>[] = [
   // no errors or warnings
@@ -1725,7 +1725,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
 testCases.forEach((tc) =>
   testutil.run(
     tc,
-    validator.trigger({
+    trigger.validator({
       vsv: { ...vsv.Chromium, ...tc.vsv },
       fullFlex: tc.parseFullFlex,
       scopes: tc.parseScopes,

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -1,5 +1,4 @@
 import * as constants from '../constants'
-import { SourceType } from '../source-type'
 import { VendorSpecificValues } from '../vendor-specific-values'
 import { Context, ValidationResult } from './context'
 import { Maybe } from './maybe'
@@ -12,44 +11,18 @@ import {
   Priority,
 } from './reg'
 import {
-  AggregationKeys,
-  EventReportWindows,
-  FilterData,
-  Source,
-  SourceAggregatableDebugReportingConfig,
-  SummaryOperator,
-  TriggerDataMatching,
-  TriggerSpec,
-} from './source'
-import {
-  AggregatableDedupKey,
-  AggregatableSourceRegistrationTime,
-  AggregatableTriggerDatum,
-  AggregatableValues,
-  AggregatableValuesConfiguration,
-  AggregatableValuesValue,
-  DedupKey,
-  EventTriggerDatum,
-  FilterConfig,
-  FilterPair,
-  Trigger,
-} from './trigger'
-import {
   CtxFunc,
   ItemErrorAction,
   LengthOpts,
-  clamp,
   isInteger,
   isInRange,
   isLengthValid,
   matchesPattern,
   required,
   suitableOrigin,
-  suitableSite,
   withDefault,
 } from './validate'
 import * as validate from './validate'
-import * as privacy from '../flexible-event/privacy'
 
 const { None, some } = Maybe
 
@@ -60,7 +33,7 @@ const uintRegex = /^[0-9]+$/
 const intRegex = /^-?[0-9]+$/
 const hex128Regex = /^0[xX][0-9A-Fa-f]{1,32}$/
 
-const UINT32_MAX: number = 2 ** 32 - 1
+export const UINT32_MAX: number = 2 ** 32 - 1
 
 export interface RegistrationOptions {
   vsv: VendorSpecificValues
@@ -68,12 +41,7 @@ export interface RegistrationOptions {
   scopes?: boolean | undefined
 }
 
-export interface SourceOptions extends RegistrationOptions {
-  sourceType: SourceType
-  noteInfoGain?: boolean | undefined
-}
-
-class RegistrationContext<
+export class RegistrationContext<
   Opts extends RegistrationOptions = RegistrationOptions,
 > extends Context {
   constructor(
@@ -83,8 +51,6 @@ class RegistrationContext<
     super()
   }
 }
-
-type SourceContext = RegistrationContext<SourceOptions>
 
 const {
   exclusive,
@@ -100,12 +66,14 @@ const {
   /*warnUnknownMsg=*/ 'unknown field'
 )
 
-type StructFields<
+export { exclusive, field }
+
+export type StructFields<
   T extends object,
   C extends Context = Context,
 > = validate.StructFields<T, JsonDict, C>
 
-function struct<T extends object, C extends Context>(
+export function struct<T extends object, C extends Context>(
   d: Json,
   ctx: C,
   fields: StructFields<T, C>,
@@ -114,7 +82,7 @@ function struct<T extends object, C extends Context>(
   return object(d, ctx).flatMap(structInternal, ctx, fields, warnUnknown)
 }
 
-type TypeSwitch<T, C extends Context = Context> = {
+export type TypeSwitch<T, C extends Context = Context> = {
   boolean?: CtxFunc<C, boolean, Maybe<T>>
   number?: CtxFunc<C, number, Maybe<T>>
   string?: CtxFunc<C, string, Maybe<T>>
@@ -122,7 +90,7 @@ type TypeSwitch<T, C extends Context = Context> = {
   object?: CtxFunc<C, JsonDict, Maybe<T>>
 }
 
-function typeSwitch<T, C extends Context = Context>(
+export function typeSwitch<T, C extends Context = Context>(
   j: Json,
   ctx: C,
   ts: TypeSwitch<T, C>
@@ -150,11 +118,11 @@ function typeSwitch<T, C extends Context = Context>(
   return None
 }
 
-function string(j: Json, ctx: Context): Maybe<string> {
+export function string(j: Json, ctx: Context): Maybe<string> {
   return typeSwitch(j, ctx, { string: some })
 }
 
-function bool(j: Json, ctx: Context): Maybe<boolean> {
+export function bool(j: Json, ctx: Context): Maybe<boolean> {
   return typeSwitch(j, ctx, { boolean: some })
 }
 
@@ -162,11 +130,11 @@ function isObject(j: Json): j is JsonDict {
   return j !== null && typeof j === 'object' && j.constructor === Object
 }
 
-function object(j: Json, ctx: Context): Maybe<JsonDict> {
+export function object(j: Json, ctx: Context): Maybe<JsonDict> {
   return typeSwitch(j, ctx, { object: some })
 }
 
-function keyValues<V, C extends Context = Context>(
+export function keyValues<V, C extends Context = Context>(
   j: Json,
   ctx: C,
   f: CtxFunc<C, [key: string, val: Json], Maybe<V>>,
@@ -184,11 +152,11 @@ function keyValues<V, C extends Context = Context>(
   })
 }
 
-function list(j: Json, ctx: Context): Maybe<Json[]> {
+export function list(j: Json, ctx: Context): Maybe<Json[]> {
   return typeSwitch(j, ctx, { list: some })
 }
 
-function uint(j: Json, ctx: Context): Maybe<bigint> {
+export function uint(j: Json, ctx: Context): Maybe<bigint> {
   return string(j, ctx)
     .filter(
       matchesPattern,
@@ -199,7 +167,7 @@ function uint(j: Json, ctx: Context): Maybe<bigint> {
     .map(BigInt)
 }
 
-function uint64(j: Json, ctx: Context): Maybe<bigint> {
+export function uint64(j: Json, ctx: Context): Maybe<bigint> {
   return uint(j, ctx).filter(
     isInRange,
     ctx,
@@ -209,23 +177,23 @@ function uint64(j: Json, ctx: Context): Maybe<bigint> {
   )
 }
 
-function number(j: Json, ctx: Context): Maybe<number> {
+export function number(j: Json, ctx: Context): Maybe<number> {
   return typeSwitch(j, ctx, { number: some })
 }
 
-function nonNegativeInteger(j: Json, ctx: Context): Maybe<number> {
+export function nonNegativeInteger(j: Json, ctx: Context): Maybe<number> {
   return number(j, ctx)
     .filter(isInteger, ctx)
     .filter(isInRange, ctx, 0, Infinity, 'must be non-negative')
 }
 
-function positiveInteger(j: Json, ctx: Context): Maybe<number> {
+export function positiveInteger(j: Json, ctx: Context): Maybe<number> {
   return number(j, ctx)
     .filter(isInteger, ctx)
     .filter(isInRange, ctx, 1, Infinity, 'must be positive')
 }
 
-function int64(j: Json, ctx: Context): Maybe<bigint> {
+export function int64(j: Json, ctx: Context): Maybe<bigint> {
   return string(j, ctx)
     .filter(matchesPattern, ctx, intRegex, 'string must represent an integer')
     .map(BigInt)
@@ -238,135 +206,17 @@ function int64(j: Json, ctx: Context): Maybe<bigint> {
     )
 }
 
-function hex128(j: Json, ctx: Context): Maybe<bigint> {
+export function hex128(j: Json, ctx: Context): Maybe<bigint> {
   return string(j, ctx)
     .filter(matchesPattern, ctx, hex128Regex, 'must be a hex128')
     .map(BigInt)
 }
 
-function destination(j: Json, ctx: Context): Maybe<Set<string>> {
-  return typeSwitch(j, ctx, {
-    string: (j) => suitableSite(j, ctx).map((s) => new Set([s])),
-    list: (j) =>
-      set(j, ctx, (j) => string(j, ctx).flatMap(suitableSite, ctx), {
-        minLength: 1,
-        maxLength: 3,
-      }),
-  })
-}
-
-function maxEventLevelReports(
-  j: Json | undefined,
-  ctx: SourceContext
-): Maybe<number> {
-  return j === undefined
-    ? some(
-        constants.defaultEventLevelAttributionsPerSource[ctx.opts.sourceType]
-      )
-    : number(j, ctx)
-        .filter(isInteger, ctx)
-        .filter(
-          isInRange,
-          ctx,
-          0,
-          constants.maxSettableEventLevelAttributionsPerSource
-        )
-}
-
-function startTime(
-  j: Json,
-  ctx: Context,
-  expiry: Maybe<number>
-): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter((n) => {
-      if (expiry.value === undefined) {
-        ctx.error('cannot be fully validated without a valid expiry')
-        return false
-      }
-      return isInRange(
-        n,
-        ctx,
-        0,
-        expiry.value,
-        `must be non-negative and <= expiry (${expiry.value})`
-      )
-    })
-}
-
-function endTimes(
-  j: Json,
-  ctx: Context,
-  expiry: Maybe<number>,
-  startTime: Maybe<number>
-): Maybe<number[]> {
-  if (startTime.value === undefined) {
-    ctx.error('cannot be fully validated without a valid start_time')
-    return None
-  }
-
-  if (expiry.value === undefined) {
-    ctx.error('cannot be fully validated without a valid expiry')
-    return None
-  }
-
-  let prev = startTime.value
-  let prevDesc = 'start_time'
-
-  const endTime = (j: Json): Maybe<number> =>
-    positiveInteger(j, ctx)
-      .map(clamp, ctx, constants.minReportWindow, expiry.value!, ' (expiry)')
-      .filter(
-        isInRange,
-        ctx,
-        prev + 1,
-        Infinity,
-        `must be > ${prevDesc} (${prev})`
-      )
-      .peek((n) => {
-        prev = n
-        prevDesc = 'previous end_time'
-      })
-
-  return array(j, ctx, endTime, {
-    minLength: 1,
-    maxLength: 5,
-    itemErrorAction: ItemErrorAction.earlyExit, // suppress unhelpful cascaded errors
-  })
-}
-
-function eventReportWindows(
-  j: Json,
-  ctx: SourceContext,
-  expiry: Maybe<number>
-): Maybe<EventReportWindows> {
-  return object(j, ctx).flatMap((j) => {
-    const startTimeValue = field(
-      'start_time',
-      withDefault(startTime, 0),
-      expiry
-    )(j, ctx)
-
-    return struct(j, ctx, {
-      startTime: () => startTimeValue,
-      endTimes: field('end_times', required(endTimes), expiry, startTimeValue),
-    })
-  })
-}
-
-function legacyDuration(j: Json, ctx: Context): Maybe<number | bigint> {
-  return typeSwitch<number | bigint>(j, ctx, {
-    number: nonNegativeInteger,
-    string: uint64,
-  })
-}
-
-type SetOpts = LengthOpts & {
+export type SetOpts = LengthOpts & {
   requireDistinct?: boolean
 }
 
-function set<T extends number | string, C extends Context = Context>(
+export function set<T extends number | string, C extends Context = Context>(
   j: Json,
   ctx: C,
   f: CtxFunc<C, Json, Maybe<T>>,
@@ -377,11 +227,11 @@ function set<T extends number | string, C extends Context = Context>(
     .filter((set) => isLengthValid(set.size, ctx, opts))
 }
 
-type ArrayOpts = LengthOpts & {
+export type ArrayOpts = LengthOpts & {
   itemErrorAction?: ItemErrorAction
 }
 
-function array<T, C extends Context = Context>(
+export function array<T, C extends Context = Context>(
   j: Json,
   ctx: C,
   f: CtxFunc<C, Json, Maybe<T>>,
@@ -394,113 +244,12 @@ function array<T, C extends Context = Context>(
     )
 }
 
-function filterDataKeyValue(
-  [key, j]: [string, Json],
-  ctx: Context
-): Maybe<Set<string>> {
-  if (key === 'source_type' || key === '_lookback_window') {
-    ctx.error('is prohibited because it is implicitly set')
-    return None
-  }
-  if (key.startsWith('_')) {
-    ctx.error('is prohibited as keys starting with "_" are reserved')
-    return None
-  }
-
-  const filterStringLength = (s: string, errorPrefix: string = '') => {
-    if (s.length > constants.maxLengthPerFilterString) {
-      ctx.error(
-        `${errorPrefix}exceeds max length per filter string (${s.length} > ${constants.maxLengthPerFilterString})`
-      )
-      return false
-    }
-    return true
-  }
-
-  if (!filterStringLength(key, 'key ')) {
-    return None
-  }
-
-  return set(j, ctx, (j) => string(j, ctx).filter(filterStringLength), {
-    maxLength: constants.maxValuesPerFilterDataEntry,
-  })
-}
-
-export function filterData(j: Json, ctx: Context): Maybe<FilterData> {
-  return keyValues(
-    j,
-    ctx,
-    filterDataKeyValue,
-    constants.maxEntriesPerFilterData
-  )
-}
-
-function filterKeyValue(
-  [key, j]: [string, Json],
-  ctx: Context
-): Maybe<Set<string>> {
-  if (key.startsWith('_')) {
-    ctx.error('is prohibited as keys starting with "_" are reserved')
-    return None
-  }
-
-  const peek =
-    key === 'source_type'
-      ? (s: string) => {
-          if (!(s in SourceType)) {
-            const allowed = Object.keys(SourceType).join(', ')
-            ctx.warning(
-              `unknown value ${s} (${key} can only match one of ${allowed})`
-            )
-          }
-        }
-      : () => {}
-
-  return set(j, ctx, (j) => string(j, ctx).peek(peek))
-}
-
-function filterConfig(j: Json, ctx: Context): Maybe<FilterConfig> {
-  // `lookbackWindow` must come before `map` to ensure it is processed first.
-  return struct(
-    j,
-    ctx,
-    {
-      lookbackWindow: field(
-        '_lookback_window',
-        withDefault(positiveInteger, null)
-      ),
-      map: (j) => keyValues(j, ctx, filterKeyValue),
-    },
-    /*warnUnknown=*/ false
-  )
-}
-
-function orFilters(j: Json, ctx: Context): Maybe<FilterConfig[]> {
-  return typeSwitch(j, ctx, {
-    list: (j) => array(j, ctx, filterConfig),
-    object: (j) => filterConfig(j, ctx).map((v) => [v]),
-  })
-}
-
-const filterFields: StructFields<FilterPair> = {
-  positive: field('filters', withDefault(orFilters, [])),
-  negative: field('not_filters', withDefault(orFilters, [])),
-}
-
-export function filterPair(j: Json, ctx: Context): Maybe<FilterPair> {
-  return struct(j, ctx, filterFields)
-}
-
-const commonDebugFields: StructFields<CommonDebug> = {
+export const commonDebugFields: StructFields<CommonDebug> = {
   debugKey: field('debug_key', withDefault(uint64, null)),
   debugReporting: field('debug_reporting', withDefault(bool, false)),
 }
 
-const dedupKeyField: StructFields<DedupKey> = {
-  dedupKey: field('deduplication_key', withDefault(uint64, null)),
-}
-
-const priorityField: StructFields<Priority> = {
+export const priorityField: StructFields<Priority> = {
   priority: field('priority', withDefault(int64, 0n)),
 }
 
@@ -515,7 +264,7 @@ function aggregatableDebugType(
   })
 }
 
-const keyPieceField: StructFields<KeyPiece> = {
+export const keyPieceField: StructFields<KeyPiece> = {
   keyPiece: field('key_piece', required(hex128)),
 }
 
@@ -557,7 +306,7 @@ function aggregatableDebugReportingDataList(
   })
 }
 
-const aggregationCoordinatorOriginField: StructFields<
+export const aggregationCoordinatorOriginField: StructFields<
   AggregationCoordinatorOrigin,
   RegistrationContext
 > = {
@@ -567,7 +316,7 @@ const aggregationCoordinatorOriginField: StructFields<
   ),
 }
 
-const aggregatableDebugReportingConfig: StructFields<
+export const aggregatableDebugReportingConfig: StructFields<
   AggregatableDebugReportingConfig,
   RegistrationContext
 > = {
@@ -580,7 +329,7 @@ const aggregatableDebugReportingConfig: StructFields<
   ...keyPieceField,
 }
 
-function aggregationKeyIdentifierLength(
+export function aggregationKeyIdentifierLength(
   s: string,
   ctx: Context,
   errPrefix: string = ''
@@ -594,861 +343,27 @@ function aggregationKeyIdentifierLength(
   return true
 }
 
-function aggregationKey([key, j]: [string, Json], ctx: Context): Maybe<bigint> {
-  if (!aggregationKeyIdentifierLength(key, ctx, 'key ')) {
-    return None
-  }
-  return hex128(j, ctx)
-}
-
-function aggregationKeys(j: Json, ctx: Context): Maybe<AggregationKeys> {
-  return keyValues(
-    j,
-    ctx,
-    aggregationKey,
-    constants.maxAggregationKeysPerSource
-  )
-}
-
-function roundAwayFromZeroToNearestDay(n: number): number {
-  if (n <= 0 || !Number.isInteger(n)) {
-    throw new RangeError()
-  }
-
-  const r = n + constants.SECONDS_PER_DAY / 2
-  return r - (r % constants.SECONDS_PER_DAY)
-}
-
-function expiry(j: Json, ctx: SourceContext): Maybe<number> {
-  return legacyDuration(j, ctx)
-    .map(clamp, ctx, ...constants.validSourceExpiryRange)
-    .map(Number) // guaranteed to fit based on the clamping
-    .map((n) => {
-      switch (ctx.opts.sourceType) {
-        case SourceType.event: {
-          const r = roundAwayFromZeroToNearestDay(n)
-          if (n !== r) {
-            ctx.warning(
-              `will be rounded to nearest day (${r}) as source type is event`
-            )
-          }
-          return r
-        }
-        case SourceType.navigation:
-          return n
-      }
-    })
-}
-
-function singleReportWindow(
+export function aggregatableKeyValueValue(
   j: Json,
-  ctx: Context,
-  expiry: Maybe<number>
-): Maybe<number> {
-  return legacyDuration(j, ctx)
-    .map((n) => {
-      if (expiry.value === undefined) {
-        ctx.error('cannot be fully validated without a valid expiry')
-        return None
-      }
-      return clamp(n, ctx, constants.minReportWindow, expiry.value, ' (expiry)')
-    })
-    .map(Number)
-}
-
-function defaultEventReportWindows(
-  end: number,
-  ctx: SourceContext
-): EventReportWindows {
-  const endTimes = constants.defaultEarlyEventLevelReportWindows[
-    ctx.opts.sourceType
-  ].filter((e) => e < end)
-  endTimes.push(end)
-  return { startTime: 0, endTimes }
-}
-
-function eventReportWindow(
-  j: Json,
-  ctx: SourceContext,
-  expiry: Maybe<number>
-): Maybe<EventReportWindows> {
-  return singleReportWindow(j, ctx, expiry).map(defaultEventReportWindows, ctx)
-}
-
-function eventLevelEpsilon(j: Json, ctx: SourceContext): Maybe<number> {
-  return number(j, ctx).filter(
-    isInRange,
-    ctx,
-    0,
-    ctx.opts.vsv.maxSettableEventLevelEpsilon
-  )
-}
-
-function channelCapacity(s: Source, ctx: SourceContext): void {
-  const numStatesWords = 'number of possible output states'
-
-  const perTriggerDataConfigs = s.triggerSpecs.flatMap((spec) =>
-    Array<privacy.PerTriggerDataConfig>(spec.triggerData.size).fill(
-      new privacy.PerTriggerDataConfig(
-        spec.eventReportWindows.endTimes.length,
-        spec.summaryBuckets.length
-      )
-    )
-  )
-
-  const config = new privacy.Config(
-    s.maxEventLevelReports,
-    perTriggerDataConfigs
-  )
-
-  const out = config.computeConfigData(
-    s.eventLevelEpsilon,
-    ctx.opts.vsv.maxEventLevelChannelCapacityPerSource[ctx.opts.sourceType]
-  )
-
-  const maxTriggerStates = ctx.opts.vsv.maxTriggerStateCardinality
-
-  if (out.numStates > maxTriggerStates) {
-    ctx.error(
-      `${numStatesWords} (${out.numStates}) exceeds max cardinality (${maxTriggerStates})`
-    )
-  }
-
-  if (
-    ctx.opts.sourceType === SourceType.event &&
-    out.numStates > s.maxEventStates
-  ) {
-    ctx.error(
-      `${numStatesWords} (${out.numStates}) exceeds max event states (${s.maxEventStates})`
-    )
-  }
-
-  const maxInfoGain =
-    ctx.opts.vsv.maxEventLevelChannelCapacityPerSource[ctx.opts.sourceType]
-  const infoGainMsg = `information gain${
-    s.attributionScopeLimit !== null ? ' for attribution scope' : ''
-  }: ${out.infoGain.toFixed(2)}`
-
-  if (out.infoGain > maxInfoGain) {
-    ctx.error(
-      `${infoGainMsg} exceeds max event-level channel capacity per ${
-        ctx.opts.sourceType
-      } source (${maxInfoGain.toFixed(2)})`
-    )
-  } else if (ctx.opts.noteInfoGain) {
-    ctx.note(infoGainMsg)
-  }
-
-  if (ctx.opts.noteInfoGain) {
-    ctx.note(`${numStatesWords}: ${out.numStates}`)
-    ctx.note(`randomized trigger rate: ${out.flipProb.toFixed(7)}`)
-  }
-}
-
-function sourceAggregatableDebugReportingConfig(
-  j: Json,
-  ctx: RegistrationContext
-): Maybe<SourceAggregatableDebugReportingConfig> {
-  return struct(j, ctx, {
-    budget: field('budget', required(aggregatableKeyValueValue)),
-    ...aggregatableDebugReportingConfig,
-  }).filter((s) => {
-    for (const d of s.debugData) {
-      if (d.value > s.budget) {
-        // TODO: Consider passing the parsed budget to validate the debug data and
-        // give more precise path information.
-        ctx.error(`data contains value greater than budget (${s.budget})`)
-        return false
-      }
-    }
-    return true
-  })
-}
-
-function summaryBuckets(
-  j: Json | undefined,
-  ctx: Context,
-  maxEventLevelReports: Maybe<number>
-): Maybe<number[]> {
-  let maxLength
-  if (maxEventLevelReports.value === undefined) {
-    ctx.error(
-      'cannot be fully validated without a valid max_event_level_reports'
-    )
-    maxLength = constants.maxSettableEventLevelAttributionsPerSource
-  } else {
-    maxLength = maxEventLevelReports.value
-  }
-
-  if (j === undefined) {
-    return maxEventLevelReports.map(makeDefaultSummaryBuckets)
-  }
-
-  let prev = 0
-  let prevDesc = 'implicit minimum'
-
-  const bucket = (j: Json): Maybe<number> =>
-    number(j, ctx)
-      .filter(isInteger, ctx)
-      .filter(
-        isInRange,
-        ctx,
-        prev + 1,
-        UINT32_MAX,
-        `must be > ${prevDesc} (${prev}) and <= uint32 max (${UINT32_MAX})`
-      )
-      .peek((n) => {
-        prev = n
-        prevDesc = 'previous value'
-      })
-
-  return array(j, ctx, bucket, {
-    minLength: 1,
-    maxLength,
-    maxLengthErrSuffix: ' (max_event_level_reports)',
-    itemErrorAction: ItemErrorAction.earlyExit, // suppress unhelpful cascaded errors
-  })
-}
-
-function fullFlexTriggerDatum(j: Json, ctx: Context): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter(isInRange, ctx, 0, UINT32_MAX)
-}
-
-function triggerDataSet(
-  j: Json,
-  ctx: Context,
-  allowEmpty: boolean = false
-): Maybe<Set<number>> {
-  return set(j, ctx, fullFlexTriggerDatum, {
-    minLength: allowEmpty ? 0 : 1,
-    maxLength: constants.maxTriggerDataPerSource,
-    requireDistinct: true,
-  })
-}
-
-type TriggerSpecDeps = {
-  expiry: Maybe<number>
-  eventReportWindows: Maybe<EventReportWindows>
-  maxEventLevelReports: Maybe<number>
-}
-
-function makeDefaultSummaryBuckets(maxEventLevelReports: number): number[] {
-  return Array.from({ length: maxEventLevelReports }, (_, i) => i + 1)
-}
-
-function triggerSpec(
-  j: Json,
-  ctx: SourceContext,
-  deps: TriggerSpecDeps
-): Maybe<TriggerSpec> {
-  return struct(j, ctx, {
-    eventReportWindows: field('event_report_windows', (j) =>
-      j === undefined
-        ? deps.eventReportWindows
-        : eventReportWindows(j, ctx, deps.expiry)
-    ),
-
-    summaryBuckets: field(
-      'summary_buckets',
-      summaryBuckets,
-      deps.maxEventLevelReports
-    ),
-
-    summaryOperator: field(
-      'summary_operator',
-      withDefault(enumerated, SummaryOperator.count),
-      SummaryOperator
-    ),
-
-    triggerData: field('trigger_data', required(triggerDataSet)),
-  })
-}
-
-function triggerSpecs(
-  j: Json,
-  ctx: SourceContext,
-  deps: TriggerSpecDeps
-): Maybe<TriggerSpec[]> {
-  return array(j, ctx, (j) => triggerSpec(j, ctx, deps), {
-    maxLength: constants.maxTriggerDataPerSource,
-  }).filter((specs) => {
-    const triggerData = new Set<number>()
-    const dups = new Set<number>()
-    for (const spec of specs) {
-      for (const triggerDatum of spec.triggerData) {
-        if (triggerData.has(triggerDatum)) {
-          dups.add(triggerDatum)
-        } else {
-          triggerData.add(triggerDatum)
-        }
-      }
-    }
-
-    let ok = true
-    if (triggerData.size > constants.maxTriggerDataPerSource) {
-      ctx.error(
-        `exceeds maximum number of distinct trigger_data (${triggerData.size} > ${constants.maxTriggerDataPerSource})`
-      )
-      ok = false
-    }
-
-    if (dups.size > 0) {
-      ctx.error(`duplicate trigger_data: ${Array.from(dups).join(', ')}`)
-      ok = false
-    }
-
-    return ok
-  })
-}
-
-function triggerSpecsFromTriggerData(
-  j: Json,
-  ctx: Context,
-  deps: TriggerSpecDeps
-): Maybe<TriggerSpec[]> {
-  return triggerDataSet(j, ctx, /*allowEmpty=*/ true).map((triggerData) => {
-    if (
-      triggerData.size === 0 ||
-      deps.eventReportWindows.value === undefined ||
-      deps.maxEventLevelReports.value === undefined
-    ) {
-      return []
-    }
-
-    return [
-      {
-        eventReportWindows: deps.eventReportWindows.value,
-        summaryBuckets: makeDefaultSummaryBuckets(
-          deps.maxEventLevelReports.value
-        ),
-        summaryOperator: SummaryOperator.count,
-        triggerData: triggerData,
-      },
-    ]
-  })
-}
-
-function defaultTriggerSpecs(
-  ctx: SourceContext,
-  eventReportWindows: Maybe<EventReportWindows>,
-  maxEventLevelReports: Maybe<number>
-): Maybe<TriggerSpec[]> {
-  return eventReportWindows.flatMap((eventReportWindows) =>
-    maxEventLevelReports.map((maxEventLevelReports) => [
-      {
-        eventReportWindows,
-        summaryBuckets: Array.from(
-          { length: maxEventLevelReports },
-          (_, i) => i + 1
-        ),
-        summaryOperator: SummaryOperator.count,
-        triggerData: new Set(
-          Array.from(
-            {
-              length: Number(
-                constants.defaultTriggerDataCardinality[ctx.opts.sourceType]
-              ),
-            },
-            (_, i) => i
-          )
-        ),
-      },
-    ])
-  )
-}
-
-function isTriggerDataMatchingValidForSpecs(s: Source, ctx: Context): boolean {
-  return ctx.scope('trigger_data_matching', () => {
-    if (s.triggerDataMatching !== TriggerDataMatching.modulus) {
-      return true
-    }
-
-    const triggerData: number[] = s.triggerSpecs
-      .flatMap((spec) => Array.from(spec.triggerData))
-      .sort()
-
-    if (triggerData.some((triggerDatum, i) => triggerDatum !== i)) {
-      ctx.error(
-        'trigger_data must form a contiguous sequence of integers starting at 0 for modulus'
-      )
-      return false
-    }
-
-    return true
-  })
-}
-
-function warnInconsistentMaxEventLevelReportsAndTriggerSpecs(
-  s: Source,
   ctx: Context
-): void {
-  const allowsReports = s.maxEventLevelReports > 0
-  const hasSpecs = s.triggerSpecs.length > 0
-
-  if (allowsReports && !hasSpecs) {
-    ctx.warning(
-      'max_event_level_reports > 0 but event-level attribution will always fail because trigger_specs is empty'
-    )
-  } else if (hasSpecs && !allowsReports) {
-    ctx.warning(
-      'trigger_specs non-empty but event-level attribution will always fail because max_event_level_reports = 0'
-    )
-  }
-}
-
-function source(j: Json, ctx: SourceContext): Maybe<Source> {
-  return object(j, ctx)
-    .flatMap((j) => {
-      const expiryVal = field(
-        'expiry',
-        withDefault(expiry, constants.validSourceExpiryRange[1])
-      )(j, ctx)
-
-      const eventReportWindowsVal = exclusive(
-        {
-          event_report_window: (j) => eventReportWindow(j, ctx, expiryVal),
-          event_report_windows: (j) => eventReportWindows(j, ctx, expiryVal),
-        },
-        expiryVal.map(defaultEventReportWindows, ctx)
-      )(j, ctx)
-
-      const maxEventLevelReportsVal = field(
-        'max_event_level_reports',
-        maxEventLevelReports
-      )(j, ctx)
-
-      const defaultTriggerSpecsVal = defaultTriggerSpecs(
-        ctx,
-        eventReportWindowsVal,
-        maxEventLevelReportsVal
-      )
-
-      const triggerSpecsDeps = {
-        expiry: expiryVal,
-        eventReportWindows: eventReportWindowsVal,
-        maxEventLevelReports: maxEventLevelReportsVal,
-      }
-
-      const triggerSpecsVal = exclusive(
-        {
-          trigger_data: (j) =>
-            triggerSpecsFromTriggerData(j, ctx, triggerSpecsDeps),
-          ...(ctx.opts.fullFlex
-            ? {
-                trigger_specs: (j) => triggerSpecs(j, ctx, triggerSpecsDeps),
-              }
-            : {}),
-        },
-        defaultTriggerSpecsVal
-      )(j, ctx)
-
-      const attributionScopeLimitVal = ctx.opts.scopes
-        ? field('attribution_scope_limit', withDefault(positiveUint32, null))(
-            j,
-            ctx
-          )
-        : some(null)
-
-      return struct(j, ctx, {
-        aggregatableReportWindow: field('aggregatable_report_window', (j) =>
-          j === undefined ? expiryVal : singleReportWindow(j, ctx, expiryVal)
-        ),
-        aggregationKeys: field(
-          'aggregation_keys',
-          withDefault(aggregationKeys, new Map())
-        ),
-        destination: field('destination', required(destination)),
-        eventLevelEpsilon: field(
-          'event_level_epsilon',
-          withDefault(
-            eventLevelEpsilon,
-            ctx.opts.vsv.maxSettableEventLevelEpsilon
-          )
-        ),
-        expiry: () => expiryVal,
-        filterData: field('filter_data', withDefault(filterData, new Map())),
-        maxEventLevelReports: () => maxEventLevelReportsVal,
-        sourceEventId: field('source_event_id', withDefault(uint64, 0n)),
-        triggerSpecs: () => triggerSpecsVal,
-        aggregatableDebugReporting: field(
-          'aggregatable_debug_reporting',
-          withDefault(sourceAggregatableDebugReportingConfig, null)
-        ),
-
-        triggerDataMatching: field(
-          'trigger_data_matching',
-          withDefault(enumerated, TriggerDataMatching.modulus),
-          TriggerDataMatching
-        ),
-        destinationLimitPriority: field(
-          'destination_limit_priority',
-          withDefault(int64, 0n)
-        ),
-        attributionScopeLimit: () => attributionScopeLimitVal,
-        attributionScopes: ctx.opts.scopes
-          ? field(
-              'attribution_scopes',
-              withDefault(attributionScopesForSource, new Set<string>()),
-              attributionScopeLimitVal
-            )
-          : () => some(new Set<string>()),
-        maxEventStates: ctx.opts.scopes
-          ? field(
-              'max_event_states',
-              withDefault(maxEventStates, constants.defaultMaxEventStates),
-              attributionScopeLimitVal
-            )
-          : () => some(constants.defaultMaxEventStates),
-
-        ...commonDebugFields,
-        ...priorityField,
-      })
-    })
-    .filter(isTriggerDataMatchingValidForSpecs, ctx)
-    .peek(channelCapacity, ctx)
-    .peek(warnInconsistentMaxEventLevelReportsAndTriggerSpecs, ctx)
-}
-
-function sourceKeys(j: Json, ctx: Context): Maybe<Set<string>> {
-  return set(j, ctx, (j) =>
-    string(j, ctx).filter(aggregationKeyIdentifierLength, ctx)
-  )
-}
-
-function aggregatableTriggerData(
-  j: Json,
-  ctx: RegistrationContext
-): Maybe<AggregatableTriggerDatum[]> {
-  return array(j, ctx, (j) =>
-    struct(j, ctx, {
-      sourceKeys: field('source_keys', withDefault(sourceKeys, new Set())),
-      ...filterFields,
-      ...keyPieceField,
-    })
-  )
-}
-
-function aggregatableKeyValueValue(j: Json, ctx: Context): Maybe<number> {
+): Maybe<number> {
   return number(j, ctx)
     .filter(isInteger, ctx)
     .filter(isInRange, ctx, 1, constants.allowedAggregatableBudgetPerSource)
 }
 
-function aggregatableKeyValueFilteringId(
+export function enumerated<T>(
   j: Json,
   ctx: Context,
-  maxBytes: Maybe<number>
-): Maybe<bigint> {
-  return uint(j, ctx).filter((n) => {
-    if (maxBytes.value === undefined) {
-      ctx.error(
-        `cannot be fully validated without a valid aggregatable_filtering_id_max_bytes`
-      )
-      return false
-    }
-    return isInRange(
-      n,
-      ctx,
-      0n,
-      256n ** BigInt(maxBytes.value) - 1n,
-      maxBytes.value == constants.defaultAggregatableFilteringIdMaxBytes
-        ? 'must be in the range [0, 255]. It exceeds the default max size of 1 byte. To increase, specify the aggregatable_filtering_id_max_bytes property.'
-        : undefined
-    )
-  })
-}
-
-function aggregatableKeyValue(
-  [key, j]: [string, Json],
-  ctx: Context,
-  maxBytes: Maybe<number>
-): Maybe<AggregatableValuesValue> {
-  if (!aggregationKeyIdentifierLength(key, ctx, 'key ')) {
-    return None
-  }
-
-  return typeSwitch(j, ctx, {
-    number: (j) =>
-      aggregatableKeyValueValue(j, ctx).map((j) => ({
-        value: j,
-        filteringId: constants.defaultFilteringIdValue,
-      })),
-    object: (j) =>
-      struct(j, ctx, {
-        value: field('value', required(aggregatableKeyValueValue)),
-        filteringId: field(
-          'filtering_id',
-          withDefault(aggregatableKeyValueFilteringId, 0n),
-          maxBytes
-        ),
-      }),
-  })
-}
-
-function aggregatableKeyValues(
-  j: Json,
-  ctx: Context,
-  maxBytes: Maybe<number>
-): Maybe<AggregatableValues> {
-  return keyValues(j, ctx, (j) => aggregatableKeyValue(j, ctx, maxBytes))
-}
-
-function aggregatableValuesConfigurations(
-  j: Json,
-  ctx: Context,
-  maxBytes: Maybe<number>
-): Maybe<AggregatableValuesConfiguration[]> {
-  return typeSwitch(j, ctx, {
-    object: (j) =>
-      aggregatableKeyValues(j, ctx, maxBytes).map((values) => [
-        { values, positive: [], negative: [] },
-      ]),
-    list: (j) =>
-      array(j, ctx, (j) =>
-        struct(j, ctx, {
-          values: field('values', required(aggregatableKeyValues), maxBytes),
-          ...filterFields,
-        })
-      ),
-  })
-}
-
-function aggregatableFilteringIdMaxBytes(
-  j: Json,
-  ctx: Context,
-  aggregatableSourceRegTime: Maybe<AggregatableSourceRegistrationTime>
-): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter(
-      isInRange,
-      ctx,
-      1,
-      constants.maxAggregatableFilteringIdMaxBytesValue
-    )
-    .filter((n) => {
-      if (aggregatableSourceRegTime.value === undefined) {
-        ctx.error(
-          `cannot be fully validated without a valid aggregatable_source_registration_time`
-        )
-        return false
-      }
-      if (
-        aggregatableSourceRegTime.value !==
-          AggregatableSourceRegistrationTime.exclude &&
-        n !== constants.defaultAggregatableFilteringIdMaxBytes
-      ) {
-        ctx.error(
-          `with a non-default value (higher than ${constants.defaultAggregatableFilteringIdMaxBytes}) is prohibited for aggregatable_source_registration_time ${aggregatableSourceRegTime.value}`
-        )
-        return false
-      }
-
-      return true
-    })
-}
-
-function eventTriggerValue(j: Json, ctx: RegistrationContext): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter(
-      isInRange,
-      ctx,
-      1,
-      UINT32_MAX,
-      `must be >= 1 and <= uint32 max (${UINT32_MAX})`
-    )
-}
-
-function eventTriggerData(
-  j: Json,
-  ctx: RegistrationContext
-): Maybe<EventTriggerDatum[]> {
-  return array(j, ctx, (j) =>
-    struct(j, ctx, {
-      triggerData: field('trigger_data', withDefault(uint64, 0n)),
-
-      value: ctx.opts.fullFlex
-        ? field('value', withDefault(eventTriggerValue, 1))
-        : () => some(1),
-
-      ...filterFields,
-      ...dedupKeyField,
-      ...priorityField,
-    })
-  )
-}
-
-function positiveUint32(j: Json, ctx: Context): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter(isInRange, ctx, 1, UINT32_MAX)
-}
-
-function maxEventStates(
-  j: Json,
-  ctx: SourceContext,
-  attributionScopeLimit: Maybe<number | null>
-): Maybe<number> {
-  return number(j, ctx)
-    .filter(isInteger, ctx)
-    .filter(isInRange, ctx, 1, ctx.opts.vsv.maxTriggerStateCardinality)
-    .filter((n) => {
-      if (attributionScopeLimit.value === undefined) {
-        ctx.error(
-          'cannot be fully validated without a valid attribution_scope_limit'
-        )
-        return false
-      }
-      if (
-        attributionScopeLimit.value === null &&
-        n !== constants.defaultMaxEventStates
-      ) {
-        ctx.error(
-          `must be default (${constants.defaultMaxEventStates}) if attribution_scope_limit is not set`
-        )
-        return false
-      }
-      return true
-    })
-}
-
-function attributionScopesForSource(
-  j: Json,
-  ctx: SourceContext,
-  attributionScopeLimit: Maybe<number | null>
-): Maybe<Set<string>> {
-  const attributionScopeStringLength = (s: string) => {
-    if (s.length > constants.maxLengthPerAttributionScope) {
-      ctx.error(
-        `exceeds max length per attribution scope (${s.length} > ${constants.maxLengthPerAttributionScope})`
-      )
-      return false
-    }
-    return true
-  }
-
-  return set(j, ctx, (j) =>
-    string(j, ctx).filter(attributionScopeStringLength)
-  ).filter((scopes) => {
-    if (attributionScopeLimit.value === undefined) {
-      ctx.error(
-        'cannot be fully validated without a valid attribution_scope_limit'
-      )
-      return false
-    }
-    if (attributionScopeLimit.value === null) {
-      if (scopes.size > 0) {
-        ctx.error('must be empty if attribution_scope_limit is not set')
-        return false
-      }
-      return true
-    }
-    if (scopes.size === 0) {
-      ctx.error('must be non-empty if attribution_scope_limit is set')
-      return false
-    }
-    const maxLength = Math.min(
-      attributionScopeLimit.value,
-      constants.maxAttributionScopesPerSource
-    )
-    const errorMsg =
-      'size must be less than or equal to ' +
-      (attributionScopeLimit.value < constants.maxAttributionScopesPerSource
-        ? 'attribution_scope_limit'
-        : 'max number of attribution scopes') +
-      ` (${maxLength}) if attribution_scope_limit is set`
-
-    return isInRange(scopes.size, ctx, 1, maxLength, errorMsg)
-  })
-}
-
-function aggregatableDedupKeys(
-  j: Json,
-  ctx: RegistrationContext
-): Maybe<AggregatableDedupKey[]> {
-  return array(j, ctx, (j) =>
-    struct(j, ctx, {
-      ...dedupKeyField,
-      ...filterFields,
-    })
-  )
-}
-
-function enumerated<T>(j: Json, ctx: Context, e: Record<string, T>): Maybe<T> {
+  e: Record<string, T>
+): Maybe<T> {
   return string(j, ctx).flatMap(validate.enumerated, ctx, e)
 }
 
-function warnInconsistentAggregatableKeys(t: Trigger, ctx: Context): void {
-  const allAggregatableValueKeys = new Set<string>()
-  for (const cfg of t.aggregatableValuesConfigurations) {
-    for (const key of cfg.values.keys()) {
-      allAggregatableValueKeys.add(key)
-    }
-  }
-
-  const triggerDataKeys = new Set<string>()
-
-  ctx.scope('aggregatable_trigger_data', () => {
-    for (const [index, datum] of t.aggregatableTriggerData.entries()) {
-      ctx.scope(index, () => {
-        for (const key of datum.sourceKeys) {
-          triggerDataKeys.add(key)
-
-          if (!allAggregatableValueKeys.has(key)) {
-            ctx.scope('source_keys', () =>
-              ctx.warning(
-                `key "${key}" will never result in a contribution due to absence from aggregatable_values`
-              )
-            )
-          }
-        }
-      })
-    }
-  })
-
-  ctx.scope('aggregatable_values', () => {
-    for (const key of allAggregatableValueKeys) {
-      if (!triggerDataKeys.has(key)) {
-        ctx.warning(
-          `key "${key}"'s absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0`
-        )
-      }
-    }
-  })
-}
-
-function triggerContextID(
-  j: Json,
-  ctx: Context,
-  aggregatableSourceRegTime: Maybe<AggregatableSourceRegistrationTime>
-): Maybe<string> {
-  return string(j, ctx).filter((s) => {
-    if (s.length > constants.maxLengthPerTriggerContextID) {
-      ctx.error(
-        `exceeds max length per trigger context ID (${s.length} > ${constants.maxLengthPerTriggerContextID})`
-      )
-      return false
-    }
-    if (aggregatableSourceRegTime.value === undefined) {
-      ctx.error(
-        `cannot be fully validated without a valid aggregatable_source_registration_time`
-      )
-      return false
-    }
-    if (
-      aggregatableSourceRegTime.value !==
-      AggregatableSourceRegistrationTime.exclude
-    ) {
-      ctx.error(
-        `is prohibited for aggregatable_source_registration_time ${aggregatableSourceRegTime.value}`
-      )
-      return false
-    }
-    return true
-  })
+export function positiveUint32(j: Json, ctx: Context): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter(isInRange, ctx, 1, UINT32_MAX)
 }
 
 function aggregationCoordinatorOrigin(
@@ -1470,70 +385,6 @@ function aggregationCoordinatorOrigin(
         })
 }
 
-function trigger(j: Json, ctx: RegistrationContext): Maybe<Trigger> {
-  return object(j, ctx)
-    .flatMap((j) => {
-      const aggregatableSourceRegTimeVal = field(
-        'aggregatable_source_registration_time',
-        withDefault(enumerated, AggregatableSourceRegistrationTime.exclude),
-        AggregatableSourceRegistrationTime
-      )(j, ctx)
-
-      const aggregatableFilteringIdMaxBytesVal = field(
-        'aggregatable_filtering_id_max_bytes',
-        withDefault(
-          aggregatableFilteringIdMaxBytes,
-          constants.defaultAggregatableFilteringIdMaxBytes
-        ),
-        aggregatableSourceRegTimeVal
-      )(j, ctx)
-
-      return struct(j, ctx, {
-        aggregatableTriggerData: field(
-          'aggregatable_trigger_data',
-          withDefault(aggregatableTriggerData, [])
-        ),
-        aggregatableFilteringIdMaxBytes: () =>
-          aggregatableFilteringIdMaxBytesVal,
-        aggregatableValuesConfigurations: field(
-          'aggregatable_values',
-          withDefault(aggregatableValuesConfigurations, []),
-          aggregatableFilteringIdMaxBytesVal
-        ),
-        aggregatableDedupKeys: field(
-          'aggregatable_deduplication_keys',
-          withDefault(aggregatableDedupKeys, [])
-        ),
-        aggregatableSourceRegistrationTime: () => aggregatableSourceRegTimeVal,
-        eventTriggerData: field(
-          'event_trigger_data',
-          withDefault(eventTriggerData, [])
-        ),
-        triggerContextID: field(
-          'trigger_context_id',
-          withDefault(triggerContextID, null),
-          aggregatableSourceRegTimeVal
-        ),
-        aggregatableDebugReporting: field(
-          'aggregatable_debug_reporting',
-          withDefault(struct, null),
-          aggregatableDebugReportingConfig
-        ),
-        attributionScopes: ctx.opts.scopes
-          ? field(
-              'attribution_scopes',
-              withDefault(set, new Set<string>()),
-              string
-            )
-          : () => some(new Set<string>()),
-        ...aggregationCoordinatorOriginField,
-        ...commonDebugFields,
-        ...filterFields,
-      })
-    })
-    .peek(warnInconsistentAggregatableKeys, ctx)
-}
-
 export function validateJSON<T, C extends Context = Context>(
   ctx: C,
   json: string,
@@ -1549,26 +400,4 @@ export function validateJSON<T, C extends Context = Context>(
 
   const v = f(value as Json, ctx)
   return [ctx.finish(), v]
-}
-
-export function validateSource(
-  json: string,
-  opts: Readonly<SourceOptions>
-): [ValidationResult, Maybe<Source>] {
-  return validateJSON(
-    new RegistrationContext(opts, constants.sourceAggregatableDebugTypes),
-    json,
-    source
-  )
-}
-
-export function validateTrigger(
-  json: string,
-  opts: Readonly<RegistrationOptions>
-): [ValidationResult, Maybe<Trigger>] {
-  return validateJSON(
-    new RegistrationContext(opts, constants.triggerAggregatableDebugTypes),
-    json,
-    trigger
-  )
 }

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -1,0 +1,834 @@
+import * as constants from '../constants'
+import { SourceType } from '../source-type'
+import * as context from './context'
+import { Maybe } from './maybe'
+import {
+  AggregationKeys,
+  EventReportWindows,
+  FilterData,
+  Source,
+  SourceAggregatableDebugReportingConfig,
+  SummaryOperator,
+  TriggerDataMatching,
+  TriggerSpec,
+} from './source'
+import {
+  ItemErrorAction,
+  clamp,
+  isInteger,
+  isInRange,
+  required,
+  suitableSite,
+  withDefault,
+} from './validate'
+import * as privacy from '../flexible-event/privacy'
+import { serializeSource } from './to-json'
+import {
+  Json,
+  RegistrationContext,
+  RegistrationOptions,
+  UINT32_MAX,
+  aggregatableDebugReportingConfig,
+  aggregatableKeyValueValue,
+  aggregationKeyIdentifierLength,
+  array,
+  commonDebugFields,
+  enumerated,
+  exclusive,
+  field,
+  hex128,
+  int64,
+  keyValues,
+  nonNegativeInteger,
+  number,
+  object,
+  positiveInteger,
+  positiveUint32,
+  priorityField,
+  set,
+  string,
+  struct,
+  typeSwitch,
+  uint64,
+  validateJSON,
+} from './validate-json'
+import { Validator } from './validator'
+
+export interface SourceOptions extends RegistrationOptions {
+  sourceType: SourceType
+  noteInfoGain?: boolean | undefined
+}
+
+type Context = RegistrationContext<SourceOptions>
+
+function destination(j: Json, ctx: Context): Maybe<Set<string>> {
+  return typeSwitch(j, ctx, {
+    string: (j) => suitableSite(j, ctx).map((s) => new Set([s])),
+    list: (j) =>
+      set(j, ctx, (j) => string(j, ctx).flatMap(suitableSite, ctx), {
+        minLength: 1,
+        maxLength: 3,
+      }),
+  })
+}
+
+function maxEventLevelReports(
+  j: Json | undefined,
+  ctx: Context
+): Maybe<number> {
+  return j === undefined
+    ? Maybe.some(
+        constants.defaultEventLevelAttributionsPerSource[ctx.opts.sourceType]
+      )
+    : number(j, ctx)
+        .filter(isInteger, ctx)
+        .filter(
+          isInRange,
+          ctx,
+          0,
+          constants.maxSettableEventLevelAttributionsPerSource
+        )
+}
+
+function startTime(
+  j: Json,
+  ctx: Context,
+  expiry: Maybe<number>
+): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter((n) => {
+      if (expiry.value === undefined) {
+        ctx.error('cannot be fully validated without a valid expiry')
+        return false
+      }
+      return isInRange(
+        n,
+        ctx,
+        0,
+        expiry.value,
+        `must be non-negative and <= expiry (${expiry.value})`
+      )
+    })
+}
+
+function endTimes(
+  j: Json,
+  ctx: Context,
+  expiry: Maybe<number>,
+  startTime: Maybe<number>
+): Maybe<number[]> {
+  if (startTime.value === undefined) {
+    ctx.error('cannot be fully validated without a valid start_time')
+    return Maybe.None
+  }
+
+  if (expiry.value === undefined) {
+    ctx.error('cannot be fully validated without a valid expiry')
+    return Maybe.None
+  }
+
+  let prev = startTime.value
+  let prevDesc = 'start_time'
+
+  const endTime = (j: Json): Maybe<number> =>
+    positiveInteger(j, ctx)
+      .map(clamp, ctx, constants.minReportWindow, expiry.value!, ' (expiry)')
+      .filter(
+        isInRange,
+        ctx,
+        prev + 1,
+        Infinity,
+        `must be > ${prevDesc} (${prev})`
+      )
+      .peek((n) => {
+        prev = n
+        prevDesc = 'previous end_time'
+      })
+
+  return array(j, ctx, endTime, {
+    minLength: 1,
+    maxLength: 5,
+    itemErrorAction: ItemErrorAction.earlyExit, // suppress unhelpful cascaded errors
+  })
+}
+
+function eventReportWindows(
+  j: Json,
+  ctx: Context,
+  expiry: Maybe<number>
+): Maybe<EventReportWindows> {
+  return object(j, ctx).flatMap((j) => {
+    const startTimeValue = field(
+      'start_time',
+      withDefault(startTime, 0),
+      expiry
+    )(j, ctx)
+
+    return struct(j, ctx, {
+      startTime: () => startTimeValue,
+      endTimes: field('end_times', required(endTimes), expiry, startTimeValue),
+    })
+  })
+}
+
+function legacyDuration(j: Json, ctx: Context): Maybe<number | bigint> {
+  return typeSwitch<number | bigint>(j, ctx, {
+    number: nonNegativeInteger,
+    string: uint64,
+  })
+}
+
+function filterDataKeyValue(
+  [key, j]: [string, Json],
+  ctx: context.Context
+): Maybe<Set<string>> {
+  if (key === 'source_type' || key === '_lookback_window') {
+    ctx.error('is prohibited because it is implicitly set')
+    return Maybe.None
+  }
+  if (key.startsWith('_')) {
+    ctx.error('is prohibited as keys starting with "_" are reserved')
+    return Maybe.None
+  }
+
+  const filterStringLength = (s: string, errorPrefix: string = '') => {
+    if (s.length > constants.maxLengthPerFilterString) {
+      ctx.error(
+        `${errorPrefix}exceeds max length per filter string (${s.length} > ${constants.maxLengthPerFilterString})`
+      )
+      return false
+    }
+    return true
+  }
+
+  if (!filterStringLength(key, 'key ')) {
+    return Maybe.None
+  }
+
+  return set(j, ctx, (j) => string(j, ctx).filter(filterStringLength), {
+    maxLength: constants.maxValuesPerFilterDataEntry,
+  })
+}
+
+export function filterData(j: Json, ctx: context.Context): Maybe<FilterData> {
+  return keyValues(
+    j,
+    ctx,
+    filterDataKeyValue,
+    constants.maxEntriesPerFilterData
+  )
+}
+
+function aggregationKey([key, j]: [string, Json], ctx: Context): Maybe<bigint> {
+  if (!aggregationKeyIdentifierLength(key, ctx, 'key ')) {
+    return Maybe.None
+  }
+  return hex128(j, ctx)
+}
+
+function aggregationKeys(j: Json, ctx: Context): Maybe<AggregationKeys> {
+  return keyValues(
+    j,
+    ctx,
+    aggregationKey,
+    constants.maxAggregationKeysPerSource
+  )
+}
+
+function roundAwayFromZeroToNearestDay(n: number): number {
+  if (n <= 0 || !Number.isInteger(n)) {
+    throw new RangeError()
+  }
+
+  const r = n + constants.SECONDS_PER_DAY / 2
+  return r - (r % constants.SECONDS_PER_DAY)
+}
+
+function expiry(j: Json, ctx: Context): Maybe<number> {
+  return legacyDuration(j, ctx)
+    .map(clamp, ctx, ...constants.validSourceExpiryRange)
+    .map(Number) // guaranteed to fit based on the clamping
+    .map((n) => {
+      switch (ctx.opts.sourceType) {
+        case SourceType.event: {
+          const r = roundAwayFromZeroToNearestDay(n)
+          if (n !== r) {
+            ctx.warning(
+              `will be rounded to nearest day (${r}) as source type is event`
+            )
+          }
+          return r
+        }
+        case SourceType.navigation:
+          return n
+      }
+    })
+}
+
+function singleReportWindow(
+  j: Json,
+  ctx: Context,
+  expiry: Maybe<number>
+): Maybe<number> {
+  return legacyDuration(j, ctx)
+    .map((n) => {
+      if (expiry.value === undefined) {
+        ctx.error('cannot be fully validated without a valid expiry')
+        return Maybe.None
+      }
+      return clamp(n, ctx, constants.minReportWindow, expiry.value, ' (expiry)')
+    })
+    .map(Number)
+}
+
+function defaultEventReportWindows(
+  end: number,
+  ctx: Context
+): EventReportWindows {
+  const endTimes = constants.defaultEarlyEventLevelReportWindows[
+    ctx.opts.sourceType
+  ].filter((e) => e < end)
+  endTimes.push(end)
+  return { startTime: 0, endTimes }
+}
+
+function eventReportWindow(
+  j: Json,
+  ctx: Context,
+  expiry: Maybe<number>
+): Maybe<EventReportWindows> {
+  return singleReportWindow(j, ctx, expiry).map(defaultEventReportWindows, ctx)
+}
+
+function eventLevelEpsilon(j: Json, ctx: Context): Maybe<number> {
+  return number(j, ctx).filter(
+    isInRange,
+    ctx,
+    0,
+    ctx.opts.vsv.maxSettableEventLevelEpsilon
+  )
+}
+
+function channelCapacity(s: Source, ctx: Context): void {
+  const numStatesWords = 'number of possible output states'
+
+  const perTriggerDataConfigs = s.triggerSpecs.flatMap((spec) =>
+    Array<privacy.PerTriggerDataConfig>(spec.triggerData.size).fill(
+      new privacy.PerTriggerDataConfig(
+        spec.eventReportWindows.endTimes.length,
+        spec.summaryBuckets.length
+      )
+    )
+  )
+
+  const config = new privacy.Config(
+    s.maxEventLevelReports,
+    perTriggerDataConfigs
+  )
+
+  const out = config.computeConfigData(
+    s.eventLevelEpsilon,
+    ctx.opts.vsv.maxEventLevelChannelCapacityPerSource[ctx.opts.sourceType]
+  )
+
+  const maxTriggerStates = ctx.opts.vsv.maxTriggerStateCardinality
+
+  if (out.numStates > maxTriggerStates) {
+    ctx.error(
+      `${numStatesWords} (${out.numStates}) exceeds max cardinality (${maxTriggerStates})`
+    )
+  }
+
+  if (
+    ctx.opts.sourceType === SourceType.event &&
+    out.numStates > s.maxEventStates
+  ) {
+    ctx.error(
+      `${numStatesWords} (${out.numStates}) exceeds max event states (${s.maxEventStates})`
+    )
+  }
+
+  const maxInfoGain =
+    ctx.opts.vsv.maxEventLevelChannelCapacityPerSource[ctx.opts.sourceType]
+  const infoGainMsg = `information gain${
+    s.attributionScopeLimit !== null ? ' for attribution scope' : ''
+  }: ${out.infoGain.toFixed(2)}`
+
+  if (out.infoGain > maxInfoGain) {
+    ctx.error(
+      `${infoGainMsg} exceeds max event-level channel capacity per ${
+        ctx.opts.sourceType
+      } source (${maxInfoGain.toFixed(2)})`
+    )
+  } else if (ctx.opts.noteInfoGain) {
+    ctx.note(infoGainMsg)
+  }
+
+  if (ctx.opts.noteInfoGain) {
+    ctx.note(`${numStatesWords}: ${out.numStates}`)
+    ctx.note(`randomized trigger rate: ${out.flipProb.toFixed(7)}`)
+  }
+}
+
+function sourceAggregatableDebugReportingConfig(
+  j: Json,
+  ctx: RegistrationContext
+): Maybe<SourceAggregatableDebugReportingConfig> {
+  return struct(j, ctx, {
+    budget: field('budget', required(aggregatableKeyValueValue)),
+    ...aggregatableDebugReportingConfig,
+  }).filter((s) => {
+    for (const d of s.debugData) {
+      if (d.value > s.budget) {
+        // TODO: Consider passing the parsed budget to validate the debug data and
+        // give more precise path information.
+        ctx.error(`data contains value greater than budget (${s.budget})`)
+        return false
+      }
+    }
+    return true
+  })
+}
+
+function summaryBuckets(
+  j: Json | undefined,
+  ctx: Context,
+  maxEventLevelReports: Maybe<number>
+): Maybe<number[]> {
+  let maxLength
+  if (maxEventLevelReports.value === undefined) {
+    ctx.error(
+      'cannot be fully validated without a valid max_event_level_reports'
+    )
+    maxLength = constants.maxSettableEventLevelAttributionsPerSource
+  } else {
+    maxLength = maxEventLevelReports.value
+  }
+
+  if (j === undefined) {
+    return maxEventLevelReports.map(makeDefaultSummaryBuckets)
+  }
+
+  let prev = 0
+  let prevDesc = 'implicit minimum'
+
+  const bucket = (j: Json): Maybe<number> =>
+    number(j, ctx)
+      .filter(isInteger, ctx)
+      .filter(
+        isInRange,
+        ctx,
+        prev + 1,
+        UINT32_MAX,
+        `must be > ${prevDesc} (${prev}) and <= uint32 max (${UINT32_MAX})`
+      )
+      .peek((n) => {
+        prev = n
+        prevDesc = 'previous value'
+      })
+
+  return array(j, ctx, bucket, {
+    minLength: 1,
+    maxLength,
+    maxLengthErrSuffix: ' (max_event_level_reports)',
+    itemErrorAction: ItemErrorAction.earlyExit, // suppress unhelpful cascaded errors
+  })
+}
+
+function fullFlexTriggerDatum(j: Json, ctx: Context): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter(isInRange, ctx, 0, UINT32_MAX)
+}
+
+function triggerDataSet(
+  j: Json,
+  ctx: Context,
+  allowEmpty: boolean = false
+): Maybe<Set<number>> {
+  return set(j, ctx, fullFlexTriggerDatum, {
+    minLength: allowEmpty ? 0 : 1,
+    maxLength: constants.maxTriggerDataPerSource,
+    requireDistinct: true,
+  })
+}
+
+type TriggerSpecDeps = {
+  expiry: Maybe<number>
+  eventReportWindows: Maybe<EventReportWindows>
+  maxEventLevelReports: Maybe<number>
+}
+
+function makeDefaultSummaryBuckets(maxEventLevelReports: number): number[] {
+  return Array.from({ length: maxEventLevelReports }, (_, i) => i + 1)
+}
+
+function triggerSpec(
+  j: Json,
+  ctx: Context,
+  deps: TriggerSpecDeps
+): Maybe<TriggerSpec> {
+  return struct(j, ctx, {
+    eventReportWindows: field('event_report_windows', (j) =>
+      j === undefined
+        ? deps.eventReportWindows
+        : eventReportWindows(j, ctx, deps.expiry)
+    ),
+
+    summaryBuckets: field(
+      'summary_buckets',
+      summaryBuckets,
+      deps.maxEventLevelReports
+    ),
+
+    summaryOperator: field(
+      'summary_operator',
+      withDefault(enumerated, SummaryOperator.count),
+      SummaryOperator
+    ),
+
+    triggerData: field('trigger_data', required(triggerDataSet)),
+  })
+}
+
+function triggerSpecs(
+  j: Json,
+  ctx: Context,
+  deps: TriggerSpecDeps
+): Maybe<TriggerSpec[]> {
+  return array(j, ctx, (j) => triggerSpec(j, ctx, deps), {
+    maxLength: constants.maxTriggerDataPerSource,
+  }).filter((specs) => {
+    const triggerData = new Set<number>()
+    const dups = new Set<number>()
+    for (const spec of specs) {
+      for (const triggerDatum of spec.triggerData) {
+        if (triggerData.has(triggerDatum)) {
+          dups.add(triggerDatum)
+        } else {
+          triggerData.add(triggerDatum)
+        }
+      }
+    }
+
+    let ok = true
+    if (triggerData.size > constants.maxTriggerDataPerSource) {
+      ctx.error(
+        `exceeds maximum number of distinct trigger_data (${triggerData.size} > ${constants.maxTriggerDataPerSource})`
+      )
+      ok = false
+    }
+
+    if (dups.size > 0) {
+      ctx.error(`duplicate trigger_data: ${Array.from(dups).join(', ')}`)
+      ok = false
+    }
+
+    return ok
+  })
+}
+
+function triggerSpecsFromTriggerData(
+  j: Json,
+  ctx: Context,
+  deps: TriggerSpecDeps
+): Maybe<TriggerSpec[]> {
+  return triggerDataSet(j, ctx, /*allowEmpty=*/ true).map((triggerData) => {
+    if (
+      triggerData.size === 0 ||
+      deps.eventReportWindows.value === undefined ||
+      deps.maxEventLevelReports.value === undefined
+    ) {
+      return []
+    }
+
+    return [
+      {
+        eventReportWindows: deps.eventReportWindows.value,
+        summaryBuckets: makeDefaultSummaryBuckets(
+          deps.maxEventLevelReports.value
+        ),
+        summaryOperator: SummaryOperator.count,
+        triggerData: triggerData,
+      },
+    ]
+  })
+}
+
+function defaultTriggerSpecs(
+  ctx: Context,
+  eventReportWindows: Maybe<EventReportWindows>,
+  maxEventLevelReports: Maybe<number>
+): Maybe<TriggerSpec[]> {
+  return eventReportWindows.flatMap((eventReportWindows) =>
+    maxEventLevelReports.map((maxEventLevelReports) => [
+      {
+        eventReportWindows,
+        summaryBuckets: Array.from(
+          { length: maxEventLevelReports },
+          (_, i) => i + 1
+        ),
+        summaryOperator: SummaryOperator.count,
+        triggerData: new Set(
+          Array.from(
+            {
+              length: Number(
+                constants.defaultTriggerDataCardinality[ctx.opts.sourceType]
+              ),
+            },
+            (_, i) => i
+          )
+        ),
+      },
+    ])
+  )
+}
+
+function isTriggerDataMatchingValidForSpecs(s: Source, ctx: Context): boolean {
+  return ctx.scope('trigger_data_matching', () => {
+    if (s.triggerDataMatching !== TriggerDataMatching.modulus) {
+      return true
+    }
+
+    const triggerData: number[] = s.triggerSpecs
+      .flatMap((spec) => Array.from(spec.triggerData))
+      .sort()
+
+    if (triggerData.some((triggerDatum, i) => triggerDatum !== i)) {
+      ctx.error(
+        'trigger_data must form a contiguous sequence of integers starting at 0 for modulus'
+      )
+      return false
+    }
+
+    return true
+  })
+}
+
+function warnInconsistentMaxEventLevelReportsAndTriggerSpecs(
+  s: Source,
+  ctx: Context
+): void {
+  const allowsReports = s.maxEventLevelReports > 0
+  const hasSpecs = s.triggerSpecs.length > 0
+
+  if (allowsReports && !hasSpecs) {
+    ctx.warning(
+      'max_event_level_reports > 0 but event-level attribution will always fail because trigger_specs is empty'
+    )
+  } else if (hasSpecs && !allowsReports) {
+    ctx.warning(
+      'trigger_specs non-empty but event-level attribution will always fail because max_event_level_reports = 0'
+    )
+  }
+}
+
+function source(j: Json, ctx: Context): Maybe<Source> {
+  return object(j, ctx)
+    .flatMap((j) => {
+      const expiryVal = field(
+        'expiry',
+        withDefault(expiry, constants.validSourceExpiryRange[1])
+      )(j, ctx)
+
+      const eventReportWindowsVal = exclusive(
+        {
+          event_report_window: (j) => eventReportWindow(j, ctx, expiryVal),
+          event_report_windows: (j) => eventReportWindows(j, ctx, expiryVal),
+        },
+        expiryVal.map(defaultEventReportWindows, ctx)
+      )(j, ctx)
+
+      const maxEventLevelReportsVal = field(
+        'max_event_level_reports',
+        maxEventLevelReports
+      )(j, ctx)
+
+      const defaultTriggerSpecsVal = defaultTriggerSpecs(
+        ctx,
+        eventReportWindowsVal,
+        maxEventLevelReportsVal
+      )
+
+      const triggerSpecsDeps = {
+        expiry: expiryVal,
+        eventReportWindows: eventReportWindowsVal,
+        maxEventLevelReports: maxEventLevelReportsVal,
+      }
+
+      const triggerSpecsVal = exclusive(
+        {
+          trigger_data: (j) =>
+            triggerSpecsFromTriggerData(j, ctx, triggerSpecsDeps),
+          ...(ctx.opts.fullFlex
+            ? {
+                trigger_specs: (j) => triggerSpecs(j, ctx, triggerSpecsDeps),
+              }
+            : {}),
+        },
+        defaultTriggerSpecsVal
+      )(j, ctx)
+
+      const attributionScopeLimitVal = ctx.opts.scopes
+        ? field('attribution_scope_limit', withDefault(positiveUint32, null))(
+            j,
+            ctx
+          )
+        : Maybe.some(null)
+
+      return struct(j, ctx, {
+        aggregatableReportWindow: field('aggregatable_report_window', (j) =>
+          j === undefined ? expiryVal : singleReportWindow(j, ctx, expiryVal)
+        ),
+        aggregationKeys: field(
+          'aggregation_keys',
+          withDefault(aggregationKeys, new Map())
+        ),
+        destination: field('destination', required(destination)),
+        eventLevelEpsilon: field(
+          'event_level_epsilon',
+          withDefault(
+            eventLevelEpsilon,
+            ctx.opts.vsv.maxSettableEventLevelEpsilon
+          )
+        ),
+        expiry: () => expiryVal,
+        filterData: field('filter_data', withDefault(filterData, new Map())),
+        maxEventLevelReports: () => maxEventLevelReportsVal,
+        sourceEventId: field('source_event_id', withDefault(uint64, 0n)),
+        triggerSpecs: () => triggerSpecsVal,
+        aggregatableDebugReporting: field(
+          'aggregatable_debug_reporting',
+          withDefault(sourceAggregatableDebugReportingConfig, null)
+        ),
+
+        triggerDataMatching: field(
+          'trigger_data_matching',
+          withDefault(enumerated, TriggerDataMatching.modulus),
+          TriggerDataMatching
+        ),
+        destinationLimitPriority: field(
+          'destination_limit_priority',
+          withDefault(int64, 0n)
+        ),
+        attributionScopeLimit: () => attributionScopeLimitVal,
+        attributionScopes: ctx.opts.scopes
+          ? field(
+              'attribution_scopes',
+              withDefault(attributionScopesForSource, new Set<string>()),
+              attributionScopeLimitVal
+            )
+          : () => Maybe.some(new Set<string>()),
+        maxEventStates: ctx.opts.scopes
+          ? field(
+              'max_event_states',
+              withDefault(maxEventStates, constants.defaultMaxEventStates),
+              attributionScopeLimitVal
+            )
+          : () => Maybe.some(constants.defaultMaxEventStates),
+
+        ...commonDebugFields,
+        ...priorityField,
+      })
+    })
+    .filter(isTriggerDataMatchingValidForSpecs, ctx)
+    .peek(channelCapacity, ctx)
+    .peek(warnInconsistentMaxEventLevelReportsAndTriggerSpecs, ctx)
+}
+
+function maxEventStates(
+  j: Json,
+  ctx: Context,
+  attributionScopeLimit: Maybe<number | null>
+): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter(isInRange, ctx, 1, ctx.opts.vsv.maxTriggerStateCardinality)
+    .filter((n) => {
+      if (attributionScopeLimit.value === undefined) {
+        ctx.error(
+          'cannot be fully validated without a valid attribution_scope_limit'
+        )
+        return false
+      }
+      if (
+        attributionScopeLimit.value === null &&
+        n !== constants.defaultMaxEventStates
+      ) {
+        ctx.error(
+          `must be default (${constants.defaultMaxEventStates}) if attribution_scope_limit is not set`
+        )
+        return false
+      }
+      return true
+    })
+}
+
+function attributionScopesForSource(
+  j: Json,
+  ctx: Context,
+  attributionScopeLimit: Maybe<number | null>
+): Maybe<Set<string>> {
+  const attributionScopeStringLength = (s: string) => {
+    if (s.length > constants.maxLengthPerAttributionScope) {
+      ctx.error(
+        `exceeds max length per attribution scope (${s.length} > ${constants.maxLengthPerAttributionScope})`
+      )
+      return false
+    }
+    return true
+  }
+
+  return set(j, ctx, (j) =>
+    string(j, ctx).filter(attributionScopeStringLength)
+  ).filter((scopes) => {
+    if (attributionScopeLimit.value === undefined) {
+      ctx.error(
+        'cannot be fully validated without a valid attribution_scope_limit'
+      )
+      return false
+    }
+    if (attributionScopeLimit.value === null) {
+      if (scopes.size > 0) {
+        ctx.error('must be empty if attribution_scope_limit is not set')
+        return false
+      }
+      return true
+    }
+    if (scopes.size === 0) {
+      ctx.error('must be non-empty if attribution_scope_limit is set')
+      return false
+    }
+    const maxLength = Math.min(
+      attributionScopeLimit.value,
+      constants.maxAttributionScopesPerSource
+    )
+    const errorMsg =
+      'size must be less than or equal to ' +
+      (attributionScopeLimit.value < constants.maxAttributionScopesPerSource
+        ? 'attribution_scope_limit'
+        : 'max number of attribution scopes') +
+      ` (${maxLength}) if attribution_scope_limit is set`
+
+    return isInRange(scopes.size, ctx, 1, maxLength, errorMsg)
+  })
+}
+
+export function validateSource(
+  json: string,
+  opts: Readonly<SourceOptions>
+): [context.ValidationResult, Maybe<Source>] {
+  return validateJSON(
+    new RegistrationContext(opts, constants.sourceAggregatableDebugTypes),
+    json,
+    source
+  )
+}
+
+export function validator(opts: Readonly<SourceOptions>): Validator<Source> {
+  return {
+    validate: (input) => validateSource(input, opts),
+    serialize: (value) => serializeSource(value, opts),
+  }
+}

--- a/ts/src/header-validator/validate-trigger.ts
+++ b/ts/src/header-validator/validate-trigger.ts
@@ -1,0 +1,435 @@
+import * as constants from '../constants'
+import { SourceType } from '../source-type'
+import * as context from './context'
+import { Maybe } from './maybe'
+import { serializeTrigger } from './to-json'
+import {
+  AggregatableDedupKey,
+  AggregatableSourceRegistrationTime,
+  AggregatableTriggerDatum,
+  AggregatableValues,
+  AggregatableValuesConfiguration,
+  AggregatableValuesValue,
+  DedupKey,
+  EventTriggerDatum,
+  FilterConfig,
+  FilterPair,
+  Trigger,
+} from './trigger'
+import { isInteger, isInRange, required, withDefault } from './validate'
+import { Validator } from './validator'
+import {
+  Json,
+  RegistrationContext as Context,
+  RegistrationOptions,
+  StructFields,
+  UINT32_MAX,
+  aggregatableDebugReportingConfig,
+  aggregatableKeyValueValue,
+  aggregationCoordinatorOriginField,
+  aggregationKeyIdentifierLength,
+  array,
+  commonDebugFields,
+  enumerated,
+  field,
+  keyPieceField,
+  keyValues,
+  number,
+  object,
+  positiveInteger,
+  priorityField,
+  set,
+  string,
+  struct,
+  typeSwitch,
+  uint,
+  uint64,
+  validateJSON,
+} from './validate-json'
+
+function filterKeyValue(
+  [key, j]: [string, Json],
+  ctx: context.Context
+): Maybe<Set<string>> {
+  if (key.startsWith('_')) {
+    ctx.error('is prohibited as keys starting with "_" are reserved')
+    return Maybe.None
+  }
+
+  const peek =
+    key === 'source_type'
+      ? (s: string) => {
+          if (!(s in SourceType)) {
+            const allowed = Object.keys(SourceType).join(', ')
+            ctx.warning(
+              `unknown value ${s} (${key} can only match one of ${allowed})`
+            )
+          }
+        }
+      : () => {}
+
+  return set(j, ctx, (j) => string(j, ctx).peek(peek))
+}
+
+function filterConfig(j: Json, ctx: context.Context): Maybe<FilterConfig> {
+  // `lookbackWindow` must come before `map` to ensure it is processed first.
+  return struct(
+    j,
+    ctx,
+    {
+      lookbackWindow: field(
+        '_lookback_window',
+        withDefault(positiveInteger, null)
+      ),
+      map: (j) => keyValues(j, ctx, filterKeyValue),
+    },
+    /*warnUnknown=*/ false
+  )
+}
+
+function orFilters(j: Json, ctx: context.Context): Maybe<FilterConfig[]> {
+  return typeSwitch(j, ctx, {
+    list: (j) => array(j, ctx, filterConfig),
+    object: (j) => filterConfig(j, ctx).map((v) => [v]),
+  })
+}
+
+const filterFields: StructFields<FilterPair> = {
+  positive: field('filters', withDefault(orFilters, [])),
+  negative: field('not_filters', withDefault(orFilters, [])),
+}
+
+export function filterPair(j: Json, ctx: context.Context): Maybe<FilterPair> {
+  return struct(j, ctx, filterFields)
+}
+
+const dedupKeyField: StructFields<DedupKey, Context> = {
+  dedupKey: field('deduplication_key', withDefault(uint64, null)),
+}
+
+function sourceKeys(j: Json, ctx: Context): Maybe<Set<string>> {
+  return set(j, ctx, (j) =>
+    string(j, ctx).filter(aggregationKeyIdentifierLength, ctx)
+  )
+}
+
+function aggregatableTriggerData(
+  j: Json,
+  ctx: Context
+): Maybe<AggregatableTriggerDatum[]> {
+  return array(j, ctx, (j) =>
+    struct(j, ctx, {
+      sourceKeys: field('source_keys', withDefault(sourceKeys, new Set())),
+      ...filterFields,
+      ...keyPieceField,
+    })
+  )
+}
+
+function aggregatableKeyValueFilteringId(
+  j: Json,
+  ctx: Context,
+  maxBytes: Maybe<number>
+): Maybe<bigint> {
+  return uint(j, ctx).filter((n) => {
+    if (maxBytes.value === undefined) {
+      ctx.error(
+        `cannot be fully validated without a valid aggregatable_filtering_id_max_bytes`
+      )
+      return false
+    }
+    return isInRange(
+      n,
+      ctx,
+      0n,
+      256n ** BigInt(maxBytes.value) - 1n,
+      maxBytes.value == constants.defaultAggregatableFilteringIdMaxBytes
+        ? 'must be in the range [0, 255]. It exceeds the default max size of 1 byte. To increase, specify the aggregatable_filtering_id_max_bytes property.'
+        : undefined
+    )
+  })
+}
+
+function aggregatableKeyValue(
+  [key, j]: [string, Json],
+  ctx: Context,
+  maxBytes: Maybe<number>
+): Maybe<AggregatableValuesValue> {
+  if (!aggregationKeyIdentifierLength(key, ctx, 'key ')) {
+    return Maybe.None
+  }
+
+  return typeSwitch(j, ctx, {
+    number: (j) =>
+      aggregatableKeyValueValue(j, ctx).map((j) => ({
+        value: j,
+        filteringId: constants.defaultFilteringIdValue,
+      })),
+    object: (j) =>
+      struct(j, ctx, {
+        value: field('value', required(aggregatableKeyValueValue)),
+        filteringId: field(
+          'filtering_id',
+          withDefault(aggregatableKeyValueFilteringId, 0n),
+          maxBytes
+        ),
+      }),
+  })
+}
+
+function aggregatableKeyValues(
+  j: Json,
+  ctx: Context,
+  maxBytes: Maybe<number>
+): Maybe<AggregatableValues> {
+  return keyValues(j, ctx, (j) => aggregatableKeyValue(j, ctx, maxBytes))
+}
+
+function aggregatableValuesConfigurations(
+  j: Json,
+  ctx: Context,
+  maxBytes: Maybe<number>
+): Maybe<AggregatableValuesConfiguration[]> {
+  return typeSwitch(j, ctx, {
+    object: (j) =>
+      aggregatableKeyValues(j, ctx, maxBytes).map((values) => [
+        { values, positive: [], negative: [] },
+      ]),
+    list: (j) =>
+      array(j, ctx, (j) =>
+        struct(j, ctx, {
+          values: field('values', required(aggregatableKeyValues), maxBytes),
+          ...filterFields,
+        })
+      ),
+  })
+}
+
+function aggregatableFilteringIdMaxBytes(
+  j: Json,
+  ctx: Context,
+  aggregatableSourceRegTime: Maybe<AggregatableSourceRegistrationTime>
+): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter(
+      isInRange,
+      ctx,
+      1,
+      constants.maxAggregatableFilteringIdMaxBytesValue
+    )
+    .filter((n) => {
+      if (aggregatableSourceRegTime.value === undefined) {
+        ctx.error(
+          `cannot be fully validated without a valid aggregatable_source_registration_time`
+        )
+        return false
+      }
+      if (
+        aggregatableSourceRegTime.value !==
+          AggregatableSourceRegistrationTime.exclude &&
+        n !== constants.defaultAggregatableFilteringIdMaxBytes
+      ) {
+        ctx.error(
+          `with a non-default value (higher than ${constants.defaultAggregatableFilteringIdMaxBytes}) is prohibited for aggregatable_source_registration_time ${aggregatableSourceRegTime.value}`
+        )
+        return false
+      }
+
+      return true
+    })
+}
+
+function eventTriggerValue(j: Json, ctx: Context): Maybe<number> {
+  return number(j, ctx)
+    .filter(isInteger, ctx)
+    .filter(
+      isInRange,
+      ctx,
+      1,
+      UINT32_MAX,
+      `must be >= 1 and <= uint32 max (${UINT32_MAX})`
+    )
+}
+
+function eventTriggerData(j: Json, ctx: Context): Maybe<EventTriggerDatum[]> {
+  return array(j, ctx, (j) =>
+    struct(j, ctx, {
+      triggerData: field('trigger_data', withDefault(uint64, 0n)),
+
+      value: ctx.opts.fullFlex
+        ? field('value', withDefault(eventTriggerValue, 1))
+        : () => Maybe.some(1),
+
+      ...filterFields,
+      ...dedupKeyField,
+      ...priorityField,
+    })
+  )
+}
+
+function aggregatableDedupKeys(
+  j: Json,
+  ctx: Context
+): Maybe<AggregatableDedupKey[]> {
+  return array(j, ctx, (j) =>
+    struct(j, ctx, {
+      ...dedupKeyField,
+      ...filterFields,
+    })
+  )
+}
+
+function warnInconsistentAggregatableKeys(t: Trigger, ctx: Context): void {
+  const allAggregatableValueKeys = new Set<string>()
+  for (const cfg of t.aggregatableValuesConfigurations) {
+    for (const key of cfg.values.keys()) {
+      allAggregatableValueKeys.add(key)
+    }
+  }
+
+  const triggerDataKeys = new Set<string>()
+
+  ctx.scope('aggregatable_trigger_data', () => {
+    for (const [index, datum] of t.aggregatableTriggerData.entries()) {
+      ctx.scope(index, () => {
+        for (const key of datum.sourceKeys) {
+          triggerDataKeys.add(key)
+
+          if (!allAggregatableValueKeys.has(key)) {
+            ctx.scope('source_keys', () =>
+              ctx.warning(
+                `key "${key}" will never result in a contribution due to absence from aggregatable_values`
+              )
+            )
+          }
+        }
+      })
+    }
+  })
+
+  ctx.scope('aggregatable_values', () => {
+    for (const key of allAggregatableValueKeys) {
+      if (!triggerDataKeys.has(key)) {
+        ctx.warning(
+          `key "${key}"'s absence from aggregatable_trigger_data source_keys equivalent to presence with key_piece 0x0`
+        )
+      }
+    }
+  })
+}
+
+function triggerContextID(
+  j: Json,
+  ctx: Context,
+  aggregatableSourceRegTime: Maybe<AggregatableSourceRegistrationTime>
+): Maybe<string> {
+  return string(j, ctx).filter((s) => {
+    if (s.length > constants.maxLengthPerTriggerContextID) {
+      ctx.error(
+        `exceeds max length per trigger context ID (${s.length} > ${constants.maxLengthPerTriggerContextID})`
+      )
+      return false
+    }
+    if (aggregatableSourceRegTime.value === undefined) {
+      ctx.error(
+        `cannot be fully validated without a valid aggregatable_source_registration_time`
+      )
+      return false
+    }
+    if (
+      aggregatableSourceRegTime.value !==
+      AggregatableSourceRegistrationTime.exclude
+    ) {
+      ctx.error(
+        `is prohibited for aggregatable_source_registration_time ${aggregatableSourceRegTime.value}`
+      )
+      return false
+    }
+    return true
+  })
+}
+
+function trigger(j: Json, ctx: Context): Maybe<Trigger> {
+  return object(j, ctx)
+    .flatMap((j) => {
+      const aggregatableSourceRegTimeVal = field(
+        'aggregatable_source_registration_time',
+        withDefault(enumerated, AggregatableSourceRegistrationTime.exclude),
+        AggregatableSourceRegistrationTime
+      )(j, ctx)
+
+      const aggregatableFilteringIdMaxBytesVal = field(
+        'aggregatable_filtering_id_max_bytes',
+        withDefault(
+          aggregatableFilteringIdMaxBytes,
+          constants.defaultAggregatableFilteringIdMaxBytes
+        ),
+        aggregatableSourceRegTimeVal
+      )(j, ctx)
+
+      return struct(j, ctx, {
+        aggregatableTriggerData: field(
+          'aggregatable_trigger_data',
+          withDefault(aggregatableTriggerData, [])
+        ),
+        aggregatableFilteringIdMaxBytes: () =>
+          aggregatableFilteringIdMaxBytesVal,
+        aggregatableValuesConfigurations: field(
+          'aggregatable_values',
+          withDefault(aggregatableValuesConfigurations, []),
+          aggregatableFilteringIdMaxBytesVal
+        ),
+        aggregatableDedupKeys: field(
+          'aggregatable_deduplication_keys',
+          withDefault(aggregatableDedupKeys, [])
+        ),
+        aggregatableSourceRegistrationTime: () => aggregatableSourceRegTimeVal,
+        eventTriggerData: field(
+          'event_trigger_data',
+          withDefault(eventTriggerData, [])
+        ),
+        triggerContextID: field(
+          'trigger_context_id',
+          withDefault(triggerContextID, null),
+          aggregatableSourceRegTimeVal
+        ),
+        aggregatableDebugReporting: field(
+          'aggregatable_debug_reporting',
+          withDefault(struct, null),
+          aggregatableDebugReportingConfig
+        ),
+        attributionScopes: ctx.opts.scopes
+          ? field(
+              'attribution_scopes',
+              withDefault(set, new Set<string>()),
+              string
+            )
+          : () => Maybe.some(new Set<string>()),
+        ...aggregationCoordinatorOriginField,
+        ...commonDebugFields,
+        ...filterFields,
+      })
+    })
+    .peek(warnInconsistentAggregatableKeys, ctx)
+}
+
+function validateTrigger(
+  json: string,
+  opts: Readonly<RegistrationOptions>
+): [context.ValidationResult, Maybe<Trigger>] {
+  return validateJSON(
+    new Context(opts, constants.triggerAggregatableDebugTypes),
+    json,
+    trigger
+  )
+}
+
+export function validator(
+  opts: Readonly<RegistrationOptions>
+): Validator<Trigger> {
+  return {
+    validate: (input) => validateTrigger(input, opts),
+    serialize: (value) => serializeTrigger(value, opts),
+  }
+}

--- a/ts/src/header-validator/validator.ts
+++ b/ts/src/header-validator/validator.ts
@@ -1,29 +1,9 @@
 import { ValidationResult } from './context'
 import { Maybe } from './maybe'
-import { Source } from './source'
-import { Trigger } from './trigger'
-import * as toJson from './to-json'
-import * as json from './validate-json'
 
 export interface Validator<T> {
   validate(input: string): [ValidationResult, Maybe<T>]
   serialize(value: T): string
-}
-
-export function source(opts: Readonly<json.SourceOptions>): Validator<Source> {
-  return {
-    validate: (input) => json.validateSource(input, opts),
-    serialize: (value) => toJson.serializeSource(value, opts),
-  }
-}
-
-export function trigger(
-  opts: Readonly<json.RegistrationOptions>
-): Validator<Trigger> {
-  return {
-    validate: (input) => json.validateTrigger(input, opts),
-    serialize: (value) => toJson.serializeTrigger(value, opts),
-  }
 }
 
 export interface Output extends ValidationResult {


### PR DESCRIPTION
Common functionality is retained in `validate-json.ts`. Source- and trigger-specific functionality is moved into separate files, though unfortunately the diff doesn't indicate that the new files are effectively copied from `validate-json.ts`.