### PR TITLE
Add dictionary for attribution scope fields.

### DIFF
--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -240,7 +240,6 @@ TODO: Update script to allow for testing different configurations that include `
 Note that the `attribution scopes/limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
 
 ### Additional Privacy Limits
-s
 It is possible for an adversary to register multiple navigation sources during source registration, and use these multiple sources, each with a different attribution scopes value, to gain additional information about a user based on which attribution scope is chosen. To prevent this abuse the number of unique attribution scope sets per reporting origin per navigation needs to be limited.
 
 TODO: update [parameters](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md) table with new rate limit

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -31,7 +31,7 @@ In general, the approach here is to allow API callers to specify a list of strin
 
 ### API changes
 
-The following optional parameter will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, which contains required parameters `values`, `limit`, and optional parameter `max_event_states`:
+The following optional parameter will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, which contains required parameters `values`, `limit`, and an optional parameter `max_event_states`:
 
 ```jsonc
 {
@@ -89,7 +89,7 @@ If there are multiple sources whose `attribution_scopes/values` contains at leas
 
 If the trigger registration's `attribution_scopes` is empty, then all sources are considered for attribution.
 
-Once a `attribution scopes/limit` is set, the last K values (where K = `attribution scopes/limit`) of `attribution_scopes/values` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes/values` will be treated as if the attribution scopes were empty.
+Once a `attribution scopes/limit` is set, the last K values (where K = `attribution scopes/limit`) of `attribution_scopes/values` will be considered the final set of attribution scopes values and any source with additional values will be treated as if the attribution scopes were not set.
 
 If a source registration is specified with a configuration that has a higher number of event states than the most recent `max_event_states` for the same reporting origin, then the source will be rejected and the registration will fail. Additionally, if the `max_event_states` field is changed in a future source registration, then all other previous pending source registrations with a different `max_event_states` will be ignored in subsequent attribution report generation flows, but will still count towards rate limits. 
 
@@ -162,11 +162,11 @@ The user then converts at a later time on the destination site by purchasing a p
 // trigger registration 1 for advertiser1 at t=4
 {
   ..., // existing fields
-   "attribution_scopes": ["advertiser1"]
+  "attribution_scopes": ["advertiser1"]
 }
 ```
 
-The API automatically performs attribution between any sources that have `attribution_scopes/values` that are not disjoint with the trigger `attribution_scopes`. Any sources that do not have an `attribution_scopes` that matches at least one of the trigger registration `attribution_scopes` are deleted (assuming the source that is chosen passes the top-level filter check; if it does not then no sources are deleted). In this example, the API caller would receive an attribution report attributing the trigger registration to advertiser1’s second source registration.
+The API automatically performs attribution between any sources that have `attribution_scopes/values` that are not disjoint with the trigger `attribution_scopes`. Any sources that do not have an `attribution_scopes/values` that matches at least one of the trigger registration `attribution_scopes` are deleted (assuming the source that is chosen passes the top-level filter check; if it does not then no sources are deleted). In this example, the API caller would receive an attribution report attributing the trigger registration to advertiser1’s second source registration.
 
 ### Example 2: multiple attribution scope values per source and trigger
 

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -214,9 +214,7 @@ The user then converts at a later time on the destination site and makes a purch
 // trigger registration 1 for product related to products 2 and 3 at t=3
 {
   ..., // existing fields
-  "attribution_scopes": {
-    "values": ["product2", "product3"]
-  }
+  "attribution_scopes": ["product2", "product3"]
 }
 ```
 
@@ -242,7 +240,7 @@ TODO: Update script to allow for testing different configurations that include `
 Note that the `attribution scopes/limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
 
 ### Additional Privacy Limits
-
+s
 It is possible for an adversary to register multiple navigation sources during source registration, and use these multiple sources, each with a different attribution scopes value, to gain additional information about a user based on which attribution scope is chosen. To prevent this abuse the number of unique attribution scope sets per reporting origin per navigation needs to be limited.
 
 TODO: update [parameters](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md) table with new rate limit

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -89,15 +89,15 @@ If there are multiple sources whose `attribution_scopes/values` contains at leas
 
 If the trigger registration's `attribution_scopes` is empty, then all sources are considered for attribution.
 
-Once a `limit` is set, the last K values (where K = `limit`) of `attribution_scopes` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes` values will be treated as if the attribution scopes were empty.
+Once a `attribution scopes/limit` is set, the last K values (where K = `attribution scopes/limit`) of `attribution_scopes/values` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes/values` will be treated as if the attribution scopes were empty.
 
 If a source registration is specified with a configuration that has a higher number of event states than the most recent `max_event_states` for the same reporting origin, then the source will be rejected and the registration will fail. Additionally, if the `max_event_states` field is changed in a future source registration, then all other previous pending source registrations with a different `max_event_states` will be ignored in subsequent attribution report generation flows, but will still count towards rate limits. 
 
 ### Updating attribution scope values
 
-An API caller may want to update the value of `limit` for certain registrations or at a certain time. For example, when an advertiser starts a new campaign the API caller may want to increase the value of `limit` to account for this new campaign.
+An API caller may want to update the value of `attribution scopes/limit` for certain registrations or at a certain time. For example, when an advertiser starts a new campaign the API caller may want to increase the value of `attribution scopes/limit` to account for this new campaign.
 
-The `limit` value can be updated during source registration at any time. However, any pending sources (previously registered) that have been specified with an `limit` less than the current source registration’s `limit` will be deleted.
+The `attribution scopes/limit` value can be updated during source registration at any time. However, any pending sources (previously registered) that have been specified with an `attribution scopes/limit` less than the current source registration’s `attribution scopes/limit` will be deleted.
 
 ### Deletion logic
 
@@ -107,7 +107,7 @@ If the current trigger passes the top-level filter check during the attribution 
 
 ### Example 1: distinct attribution scopes
 
-This example shows an API caller that manages 3 advertisers that all sell products on the same destination site (scheme + eTLD+1). In this example the API caller uses an `limit` of 3 and tracks each advertiser with a distinct `attribution_scopes` value. Additionally, the user browsing the web sees 4 different ads from these advertisers and each one has a source registration associated:
+This example shows an API caller that manages 3 advertisers that all sell products on the same destination site (scheme + eTLD+1). In this example the API caller uses an `attribution scopes/limit` of 3 and tracks each advertiser with a distinct `attribution_scopes/values` value. Additionally, the user browsing the web sees 4 different ads from these advertisers and each one has a source registration associated:
 
 ```jsonc
 // source registration 1 for advertiser1 at t=0
@@ -162,9 +162,7 @@ The user then converts at a later time on the destination site by purchasing a p
 // trigger registration 1 for advertiser1 at t=4
 {
   ..., // existing fields
-  "attribution_scopes": {
-    "values": ["advertiser1"]
-  }
+   "attribution_scopes": ["advertiser1"]
 }
 ```
 
@@ -237,11 +235,11 @@ The use of `attribution_scopes` will have some impact on the amount of utility t
 
 Flexible event-level configurations that use `attribution_scopes` will be verified against two separate limits:
   * The base flexible event-level configuration will continue to be verified against the current information gain limit.
-  * The second check will take into account the `limit` and `max_event_states` values, in addition to the flexible event-level configuration, as part of the information gain calculation and be verified against a separate [information gain limit](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md).
+  * The second check will take into account the `attribution scopes/limit` and `attribution scopes/max_event_states` values, in addition to the flexible event-level configuration, as part of the information gain calculation and be verified against a separate [information gain limit](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md).
 
-TODO: Update script to allow for testing different configurations that include `limit`
+TODO: Update script to allow for testing different configurations that include `attribution scopes/limit`
 
-Note that the `limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
+Note that the `attribution scopes/limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
 
 ### Additional Privacy Limits
 

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -31,7 +31,7 @@ In general, the approach here is to allow API callers to specify a list of strin
 
 ### API changes
 
-The following optional parameters will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, `values`, `limit`, and `max_event_states`:
+The following optional parameter will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, which contains required parameters `values`, `limit`, and optional parameter `max_event_states`:
 
 ```jsonc
 {
@@ -42,8 +42,7 @@ The following optional parameters will be added to the JSON in `Attribution-Repo
     // Required
     // Represents the total number of distinct scopes allowed per destination for the source reporting origin.
     // This is used to calculate the information gain for event-level reports.
-    // Attribution scope limit values must be positive integers.  
-    // Defaults to null if omitted.
+    // Attribution scope limit values must be positive integers.
     "limit": <int>,
   
     // Required

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -38,7 +38,7 @@ The following optional parameters will be added to the JSON in `Attribution-Repo
   ..., // existing fields
 
   // Optional
-  "attribution_scopes" {
+  "attribution_scopes": {
     // Required
     // Represents the total number of distinct scopes allowed per destination for the source reporting origin.
     // This is used to calculate the information gain for event-level reports.
@@ -90,7 +90,7 @@ If there are multiple sources whose `attribution_scopes/values` contains at leas
 
 If the trigger registration's `attribution_scopes` is empty, then all sources are considered for attribution.
 
-Once an `limit` is set, the last K values (where K = `limit`) of `attribution_scopes` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes` values will be treated as if the attribution scopes were empty.
+Once a `limit` is set, the last K values (where K = `limit`) of `attribution_scopes` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes` values will be treated as if the attribution scopes were empty.
 
 If a source registration is specified with a configuration that has a higher number of event states than the most recent `max_event_states` for the same reporting origin, then the source will be rejected and the registration will fail. Additionally, if the `max_event_states` field is changed in a future source registration, then all other previous pending source registrations with a different `max_event_states` will be ignored in subsequent attribution report generation flows, but will still count towards rate limits. 
 
@@ -114,7 +114,7 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 1 for advertiser1 at t=0
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 3,
     "values": ["advertiser1"],
     "max_event_states": 3
@@ -126,7 +126,7 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 2 for advertiser1 at t=1
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 3,
     "values": ["advertiser1"],
     "max_event_states": 3
@@ -138,7 +138,7 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 3 for advertiser2 at t=2
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 3,
     "values": ["advertiser2"],
     "max_event_states": 3
@@ -149,7 +149,7 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 4 for advertiser3 at t=3
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 3,
     "values": ["advertiser3"],
     "max_event_states": 3
@@ -163,7 +163,7 @@ The user then converts at a later time on the destination site by purchasing a p
 // trigger registration 1 for advertiser1 at t=4
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "values": ["advertiser1"]
   }
 }
@@ -179,7 +179,7 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 1 for campaign promoting products 1, 2, and 3 at t=0
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 4,
     "values": ["product1", "product2", "product3"],
     "max_event_states": 3
@@ -191,7 +191,7 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 2 for campaign promoting only product 2 at t=1
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 4,
     "values": ["product2"],
     "max_event_states": 3
@@ -203,7 +203,7 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 3 for campaign promoting only product 4 at t=2
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "limit": 4,
     "values": ["product4"],
     "max_event_states": 3
@@ -217,7 +217,7 @@ The user then converts at a later time on the destination site and makes a purch
 // trigger registration 1 for product related to products 2 and 3 at t=3
 {
   ..., // existing fields
-  "attribution_scopes" {
+  "attribution_scopes": {
     "values": ["product2", "product3"]
   }
 }

--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -31,38 +31,40 @@ In general, the approach here is to allow API callers to specify a list of strin
 
 ### API changes
 
-The following optional parameters will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, `attribution_scope_limit`, and `max_event_states`:
+The following optional parameters will be added to the JSON in `Attribution-Reporting-Register-Source` during source registration: `attribution_scopes`, `values`, `limit`, and `max_event_states`:
 
 ```jsonc
 {
   ..., // existing fields
 
   // Optional
-  // Represents the total number of distinct scopes allowed per destination for the source reporting origin.
-  // This is used to calculate the information gain for event-level reports.
-  // Attribution scope limit values must be positive integers.  
-  // Defaults to null if omitted.
-  "attribution_scope_limit": <int>,
-
-  // Optional
-  // Represents a list of attribution scopes for a particular source.
-  // This is used to define the values that will be used to perform pre-attribution filtering.
-  // Attribution scope values must be strings. Each string has a maximum length of 50.
-  // The maximum length of the attribution_scopes list is the minimum of the attribution_scope_limit value and 20.
-  // Defaults to the empty list if omitted.
-  "attribution_scopes": <list of strings>,
-
-  // Optional
-  // Represents the maximum number of event states that an API caller plans to use across all
-  // subsequent event-source registrations.
-  // Example: default event source for event-level reports supports 1 attribution report, 1 reporting window,
-  // and 1 bit of trigger data for a total of 3 event states.
-  // This is used to calculate the information gain for event-level reports.
-  // Max event states must be positive integers.
-  // Defaults to 3 if omitted.
-  // The flexible event-level script linked in the Privacy Considerations section below can be used to
-  // calculate number of states based on a configuration.
-  "max_event_states": <int>
+  "attribution_scopes" {
+    // Required
+    // Represents the total number of distinct scopes allowed per destination for the source reporting origin.
+    // This is used to calculate the information gain for event-level reports.
+    // Attribution scope limit values must be positive integers.  
+    // Defaults to null if omitted.
+    "limit": <int>,
+  
+    // Required
+    // Represents a list of attribution scopes for a particular source.
+    // This is used to define the values that will be used to perform pre-attribution filtering.
+    // Attribution scope values must be strings. Each string has a maximum length of 50.
+    // The maximum length of the attribution scopes list is the minimum of the limit value and 20.
+    "values": <list of strings>,
+  
+    // Optional
+    // Represents the maximum number of event states that an API caller plans to use across all
+    // subsequent event-source registrations.
+    // Example: default event source for event-level reports supports 1 attribution report, 1 reporting window,
+    // and 1 bit of trigger data for a total of 3 event states.
+    // This is used to calculate the information gain for event-level reports.
+    // Max event states must be positive integers.
+    // Defaults to 3 if omitted.
+    // The flexible event-level script linked in the Privacy Considerations section below can be used to
+    // calculate number of states based on a configuration.
+    "max_event_states": <int>
+  }
 }
 ```
 
@@ -82,21 +84,21 @@ The following optional parameter will be added to the JSON in  `Attribution-Repo
 }
 ```
 
-Only sources whose `attribution_scopes` contains at least one of the trigger’s `attribution_scopes` will be considered for attribution. Note that this filtering takes place before attributing a trigger to a particular source.
+Only sources whose `attribution_scopes/values` contains at least one of the trigger’s `attribution_scopes` will be considered for attribution. Note that this filtering takes place before attributing a trigger to a particular source.
 
-If there are multiple sources whose `attribution_scopes` contains at least one of the trigger’s `attribution_scopes`, then attribution will take place among the sources within the particular `attribution_scopes` according to current [Attribution Reporting API logic](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#trigger-attribution-algorithm).
+If there are multiple sources whose `attribution_scopes/values` contains at least one of the trigger’s `attribution_scopes`, then attribution will take place among the sources within the particular `attribution_scopes` according to current [Attribution Reporting API logic](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#trigger-attribution-algorithm).
 
 If the trigger registration's `attribution_scopes` is empty, then all sources are considered for attribution.
 
-Once an `attribution_scope_limit` is set, the last K values (where K = `attribution_scope_limit`) of `attribution_scopes` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes` values will be treated as if the attribution scopes were empty.
+Once an `limit` is set, the last K values (where K = `limit`) of `attribution_scopes` will be considered the final set of `attribution_scopes` values and any source with additional `attribution_scopes` values will be treated as if the attribution scopes were empty.
 
 If a source registration is specified with a configuration that has a higher number of event states than the most recent `max_event_states` for the same reporting origin, then the source will be rejected and the registration will fail. Additionally, if the `max_event_states` field is changed in a future source registration, then all other previous pending source registrations with a different `max_event_states` will be ignored in subsequent attribution report generation flows, but will still count towards rate limits. 
 
 ### Updating attribution scope values
 
-An API caller may want to update the value of `attribution_scope_limit` for certain registrations or at a certain time. For example, when an advertiser starts a new campaign the API caller may want to increase the value of `attribution_scope_limit` to account for this new campaign.
+An API caller may want to update the value of `limit` for certain registrations or at a certain time. For example, when an advertiser starts a new campaign the API caller may want to increase the value of `limit` to account for this new campaign.
 
-The `attribution_scope_limit` value can be updated during source registration at any time. However, any pending sources (previously registered) that have been specified with an `attribution_scope_limit` less than the current source registration’s `attribution_scope_limit` will be deleted.
+The `limit` value can be updated during source registration at any time. However, any pending sources (previously registered) that have been specified with an `limit` less than the current source registration’s `limit` will be deleted.
 
 ### Deletion logic
 
@@ -106,15 +108,17 @@ If the current trigger passes the top-level filter check during the attribution 
 
 ### Example 1: distinct attribution scopes
 
-This example shows an API caller that manages 3 advertisers that all sell products on the same destination site (scheme + eTLD+1). In this example the API caller uses an `attribution_scope_limit` of 3 and tracks each advertiser with a distinct `attribution_scopes` value. Additionally, the user browsing the web sees 4 different ads from these advertisers and each one has a source registration associated:
+This example shows an API caller that manages 3 advertisers that all sell products on the same destination site (scheme + eTLD+1). In this example the API caller uses an `limit` of 3 and tracks each advertiser with a distinct `attribution_scopes` value. Additionally, the user browsing the web sees 4 different ads from these advertisers and each one has a source registration associated:
 
 ```jsonc
 // source registration 1 for advertiser1 at t=0
 {
   ..., // existing fields
-  "attribution_scope_limit": 3,
-  "attribution_scopes": ["advertiser1"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 3,
+    "values": ["advertiser1"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -122,9 +126,11 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 2 for advertiser1 at t=1
 {
   ..., // existing fields
-  "attribution_scope_limit": 3,
-  "attribution_scopes": ["advertiser1"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 3,
+    "values": ["advertiser1"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -132,18 +138,22 @@ This example shows an API caller that manages 3 advertisers that all sell produc
 // source registration 3 for advertiser2 at t=2
 {
   ..., // existing fields
-  "attribution_scope_limit": 3,
-  "attribution_scopes": ["advertiser2"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 3,
+    "values": ["advertiser2"],
+    "max_event_states": 3
+  }
 }
 ```
 ```jsonc
 // source registration 4 for advertiser3 at t=3
 {
   ..., // existing fields
-  "attribution_scope_limit": 3,
-  "attribution_scopes": ["advertiser3"],
-  "max_num_event_states": 3
+  "attribution_scopes" {
+    "limit": 3,
+    "values": ["advertiser3"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -153,11 +163,13 @@ The user then converts at a later time on the destination site by purchasing a p
 // trigger registration 1 for advertiser1 at t=4
 {
   ..., // existing fields
-  "attribution_scopes": ["advertiser1"]
+  "attribution_scopes" {
+    "values": ["advertiser1"]
+  }
 }
 ```
 
-The API automatically performs attribution between any sources that have `attribution_scopes` that are not disjoint with the trigger `attribution_scopes`. Any sources that do not have an `attribution_scopes` that matches at least one of the trigger registration `attribution_scopes` are deleted (assuming the source that is chosen passes the top-level filter check; if it does not then no sources are deleted). In this example, the API caller would receive an attribution report attributing the trigger registration to advertiser1’s second source registration.
+The API automatically performs attribution between any sources that have `attribution_scopes/values` that are not disjoint with the trigger `attribution_scopes`. Any sources that do not have an `attribution_scopes` that matches at least one of the trigger registration `attribution_scopes` are deleted (assuming the source that is chosen passes the top-level filter check; if it does not then no sources are deleted). In this example, the API caller would receive an attribution report attributing the trigger registration to advertiser1’s second source registration.
 
 ### Example 2: multiple attribution scope values per source and trigger
 
@@ -167,9 +179,11 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 1 for campaign promoting products 1, 2, and 3 at t=0
 {
   ..., // existing fields
-  "attribution_scope_limit": 4,
-  "attribution_scopes": ["product1", "product2", "product3"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 4,
+    "values": ["product1", "product2", "product3"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -177,9 +191,11 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 2 for campaign promoting only product 2 at t=1
 {
   ..., // existing fields
-  "attribution_scope_limit": 4,
-  "attribution_scopes": ["product2"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 4,
+    "values": ["product2"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -187,9 +203,11 @@ This example shows an API caller that manages an ad banner that contains multipl
 // source registration 3 for campaign promoting only product 4 at t=2
 {
   ..., // existing fields
-  "attribution_scope_limit": 4,
-  "attribution_scopes": ["product4"],
-  "max_event_states": 3
+  "attribution_scopes" {
+    "limit": 4,
+    "values": ["product4"],
+    "max_event_states": 3
+  }
 }
 ```
 
@@ -199,11 +217,13 @@ The user then converts at a later time on the destination site and makes a purch
 // trigger registration 1 for product related to products 2 and 3 at t=3
 {
   ..., // existing fields
-  "attribution_scopes": ["product2", "product3"]
+  "attribution_scopes" {
+    "values": ["product2", "product3"]
+  }
 }
 ```
 
-In this example the API will start by finding any sources that have an `attribution_scopes` that matches at least one of the trigger registration `attribution_scopes`. In this example that would be source registration 1 and 2. The API will then perform attribution between these two sources. In this example source registration 2 will win the attribution process because it was the most recent source registration. The API caller would receive an attribution report attributing the trigger registration to source registration 2.
+In this example the API will start by finding any sources that have an `attribution_scopes/values` that matches at least one of the trigger registration `attribution_scopes`. In this example that would be source registration 1 and 2. The API will then perform attribution between these two sources. In this example source registration 2 will win the attribution process because it was the most recent source registration. The API caller would receive an attribution report attributing the trigger registration to source registration 2.
 
 ## Alternatives Considered
 
@@ -218,11 +238,11 @@ The use of `attribution_scopes` will have some impact on the amount of utility t
 
 Flexible event-level configurations that use `attribution_scopes` will be verified against two separate limits:
   * The base flexible event-level configuration will continue to be verified against the current information gain limit.
-  * The second check will take into account the `attribution_scope_limit` and `max_event_states` values, in addition to the flexible event-level configuration, as part of the information gain calculation and be verified against a separate [information gain limit](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md).
+  * The second check will take into account the `limit` and `max_event_states` values, in addition to the flexible event-level configuration, as part of the information gain calculation and be verified against a separate [information gain limit](https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md).
 
-TODO: Update script to allow for testing different configurations that include attribution_scope_limit
+TODO: Update script to allow for testing different configurations that include `limit`
 
-Note that the `attribution_scope_limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
+Note that the `limit` does not have any impact on the privacy mechanisms used in Aggregatable Reports.
 
 ### Additional Privacy Limits
 

--- a/index.bs
+++ b/index.bs
@@ -2694,7 +2694,7 @@ To <dfn>parse attribution scope values for source</dfn> from a [=map=] |map| and
 1. Let |result| be a new [=set=].
 1. Let |values| be |map|["<code>[=source-registration JSON key/values=]</code>"].
 1. If |values| is not a [=list=], return an error.
-1. If |values| [=set/is empty=], return an error.
+1. If |values| [=list/is empty=], return an error.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not a [=string=], return an error.
     1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.

--- a/index.bs
+++ b/index.bs
@@ -2683,8 +2683,8 @@ To <dfn>parse attribution scopes</dfn> from a [=map=] |map|:
 1. Return |attributionScopes|.
 
 To <dfn>parse max event states</dfn> from a [=map=] |map|:
-1. Let |maxEventStates| be [=default max event states=].
-1. If |map|["<code>[=source-registration JSON key/max_event_states=]</code>"] [=map/exists=], set |maxEventStates| to |map|["<code>[=source-registration JSON key/max_event_states=]</code>"].
+1. If |map|["<code>[=source-registration JSON key/max_event_states=]</code>"] does not [=map/exist=], return [=default max event states=].
+1. Let |maxEventStates| be |map|["<code>[=source-registration JSON key/max_event_states=]</code>"].
 1. If |maxEventStates| is not an integer or is less than or equal to 0, return an error.
 1. If |maxEventStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
 1. Return |maxEventStates|.
@@ -2694,11 +2694,11 @@ To <dfn>parse attribution scope values for source</dfn> from a [=map=] |map| and
 1. Let |result| be a new [=set=].
 1. Let |values| be |map|["<code>[=source-registration JSON key/values=]</code>"].
 1. If |values| is not a [=list=], return an error.
+1. If |values| [=set/is empty=], return an error.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not a [=string=], return an error.
     1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.
     1. [=set/Append=] |value| to |result|.
-1. If |result| [=set/is empty=], return an error.
 1. If |result|'s [=set/size=] is greater than |limit| or [=max attribution scopes per source=], return an error.
 1. Return |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -768,14 +768,14 @@ An aggregatable debug reporting config is a [=struct=] with the following items:
 
 </dl>
 
-<h3 dfn-type=dfn>Attribution scope data</h3>
+<h3 dfn-type=dfn>Attribution scopes</h3>
 
-An attribution scope data is a [=struct=] with the following items:
+An attribution scopes is a [=struct=] with the following items:
 
-<dl dfn-for="attribution scope data">
-: <dfn>attribution scope limit</dfn>
-:: A positive 32-bit integer representing the number of distinct [=attribution scope data/attribution scopes=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
-: <dfn>attribution scopes</dfn>
+<dl dfn-for="attribution scopes">
+: <dfn>limit</dfn>
+:: A positive 32-bit integer representing the number of distinct [=attribution scopes/values=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+: <dfn>values</dfn>
 :: A [=set=] of [=strings=].
 : <dfn>max event states</dfn>
 :: A positive integer representing the maximum number of [=trigger states=] for [=source type/event=] sources per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
@@ -852,8 +852,8 @@ An attribution source is a [=struct=] with the following items:
 :: An [=aggregatable debug reporting config=].
 : <dfn>destination limit priority</dfn>
 :: A 64-bit integer.
-: <dfn>attribution scope data</dfn> (default null)
-:: Null or an [=attribution scope data=].
+: <dfn>attribution scopes</dfn> (default null)
+:: Null or an [=attribution scopes=].
 
 </dl>
 
@@ -1394,14 +1394,14 @@ with a given ([=aggregatable debug rate-limit record/context site=], [=aggregata
 per [=aggregatable debug rate-limit window=]. Its value is (2<sup>20</sup>, 65536).
 
 <dfn>Default max event states</dfn> is a positive integer that controls the
-default [=attribution scope data/max event states=]. Its value is 3.
+default [=attribution scopes/max event states=]. Its value is 3.
 
 <dfn>Max length of attribution scope for source</dfn> is a positive integer that controls the
-maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution scope data/attribution scopes=].
+maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution scopes/values=].
 Its value is 50.
 
 <dfn>Max attribution scopes per source</dfn> is a positive integer that controls the
-maximum [=set/size=] of an [=attribution source=]'s [=attribution scope data/attribution scopes=].
+maximum [=set/size=] of an [=attribution source=]'s [=attribution scopes/values=].
 Its value is 20.
 
 # Vendor-Specific Values # {#vendor-specific-values}
@@ -2371,10 +2371,8 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_debug_reporting</code></dfn>"
 <li>"<dfn><code>aggregatable_report_window</code></dfn>"
 <li>"<dfn><code>aggregation_keys</code></dfn>"
-<li>"<dfn><code>budget</code></dfn>"
-<li>"<dfn><code>attribution_scope_data</code></dfn>"
-<li>"<dfn><code>attribution_scope_limit</code></dfn>"
 <li>"<dfn><code>attribution_scopes</code></dfn>"
+<li>"<dfn><code>budget</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>destination</code></dfn>"
@@ -2385,6 +2383,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>event_report_windows</code></dfn>"
 <li>"<dfn><code>expiry</code></dfn>"
 <li>"<dfn><code>filter_data</code></dfn>"
+<li>"<dfn><code>limit</code></dfn>"
 <li>"<dfn><code>max_event_level_reports</code></dfn>"
 <li>"<dfn><code>max_event_states</code></dfn>"
 <li>"<dfn><code>priority</code></dfn>"
@@ -2395,6 +2394,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>trigger_data</code></dfn>"
 <li>"<dfn><code>trigger_data_matching</code></dfn>"
 <li>"<dfn><code>trigger_specs</code></dfn>"
+<li>"<dfn><code>values</code></dfn>"
 </ul>
 
 To <dfn>parse an attribution destination</dfn> from a [=string=] |str|:
@@ -2662,25 +2662,25 @@ non-negative integer |defaultBudget|, and an [=aggregatable debug reporting conf
     with |value|, |budget|, |supportedTypes|, and |defaultConfig|.
 1. Return the [=tuple=] (|budget|, |config|).
 
-To <dfn>parse attribution scope data</dfn> from a [=map=] |map|:
-1. If |map|["<code>[=source-registration JSON key/attribution_scope_data=]</code>"] does not [=map/exists|exist=], return null.
-1. Let |value| be |map|["<code>[=source-registration JSON key/attribution_scope_data=]</code>"].
+To <dfn>parse attribution scopes</dfn> from a [=map=] |map|:
+1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exists|exist=], return null.
+1. Let |value| be |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"].
 1. If |value| is not a [=map=], return an error.
-1. If |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"] does not [=map/exists|exist=], return an error.
-1. Set |attributionScopeLimit| to |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"].
-1. If |attributionScopeLimit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return an error.
+1. If |value|["<code>[=source-registration JSON key/limit=]</code>"] does not [=map/exists|exist=], return an error.
+1. Set |limit| to |value|["<code>[=source-registration JSON key/limit=]</code>"].
+1. If |limit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return an error.
 1. Let |maxEventStates| be the result of running [=parse max event states=] with |value|.
 1. If |maxEventStates| is an error, return an error.
-1. Let |attributionScopes| be the result of running [=parse attribution scopes for source=] with |value| and |attributionScopeLimit|.
-1. If |attributionScopes| is an error, return an error.
-1. Let |attributionScopeData| be a new [=attribution scope data=] with the items:
-    : [=attribution scope data/attribution scope limit=]
-    :: |attributionScopeLimit|
-    : [=attribution scope data/attribution scopes=]
-    :: |attributionScopeLimit|
-    : [=attribution scope data/max event states=]
+1. Let |values| be the result of running [=parse attribution scope values for source=] with |value| and |limit|.
+1. If |values| is an error, return an error.
+1. Let |attributionScopes| be a new [=attribution scopes=] with the items:
+    : [=attribution scopes/limit=]
+    :: |limit|
+    : [=attribution scopes/values=]
+    :: |values|
+    : [=attribution scopes/max event states=]
     :: |maxEventStates|
-1. Return |attributionScopeData|.
+1. Return |attributionScopes|.
 
 To <dfn>parse max event states</dfn> from a [=map=] |map|:
 1. Let |maxEventStates| be [=default max event states=].
@@ -2689,22 +2689,22 @@ To <dfn>parse max event states</dfn> from a [=map=] |map|:
 1. If |maxEventStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
 1. Return |maxEventStates|.
 
-To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a 32-bit positive integer |attributionScopeLimit|:
-1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return an error.
+To <dfn>parse attribution scope values for source</dfn> from a [=map=] |map| and a 32-bit positive integer |limit|:
+1. If |map|["<code>[=source-registration JSON key/values=]</code>"] does not [=map/exist=], return an error.
 1. Let |result| be a new [=set=].
-1. Let |values| be |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"].
+1. Let |values| be |map|["<code>[=source-registration JSON key/values=]</code>"].
 1. If |values| is not a [=list=], return an error.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not a [=string=], return an error.
     1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.
     1. [=set/Append=] |value| to |result|.
 1. If |result| [=set/is empty=], return an error.
-1. If |result|'s [=set/size=] is greater than |attributionScopeLimit| or [=max attribution scopes per source=], return an error.
+1. If |result|'s [=set/size=] is greater than |limit| or [=max attribution scopes per source=], return an error.
 1. Return |result|.
 
-Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
+Note: Empty attribution scopes are not allowed if |limit| is set,
 to prevent the selection of both sources with and without scopes, which would effectively
-result in |attributionScopeLimit| + 1 scopes.
+result in |limit| + 1 scopes.
 
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
@@ -2775,7 +2775,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
     |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
 1. If |triggerSpecs| is an error, return null.
-1. Let |attributionScopeData| be the result of running [=parse attribution scope data=] with |value|.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes=] with |value|.
+1. If |attributionScopes| is an error, return null.
 1. Let |epsilon| be the user agent's [=max settable event-level epsilon=].
 1. Set |epsilon| to |value|["<code>[=source-registration JSON key/event_level_epsilon=]</code>"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
@@ -2842,8 +2843,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |aggregatableDebugReportingConfig|
     : [=attribution source/destination limit priority=]
     :: |destinationLimitPriority|
-    : [=attribution source/attribution scope data=]
-    :: |attributionScopeData|
+    : [=attribution source/attribution scopes=]
+    :: |attributionScopes|
 1. Return |source|.
 
 Issue: Determine proper charset-handling for the JSON header value.

--- a/index.bs
+++ b/index.bs
@@ -853,7 +853,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>destination limit priority</dfn>
 :: A 64-bit integer.
 : <dfn>attribution scope data</dfn> (default null)
-:: An [=attribution scope data=].
+:: Null or an [=attribution scope data=].
 
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -768,6 +768,20 @@ An aggregatable debug reporting config is a [=struct=] with the following items:
 
 </dl>
 
+<h3 dfn-type=dfn>Attribution scope data</h3>
+
+An attribution scope data is a [=struct=] with the following items:
+
+<dl dfn-for="attribution scope data">
+: <dfn>attribution scope limit</dfn>
+:: A positive 32-bit integer representing the number of distinct [=attribution scope data/attribution scopes=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+: <dfn>attribution scopes</dfn>
+:: A [=set=] of [=strings=].
+: <dfn>max event states</dfn>
+:: A positive integer representing the maximum number of [=trigger states=] for [=source type/event=] sources per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+
+</dl>
+
 <h3 dfn-type=dfn>Attribution source</h3>
 
 An attribution source is a [=struct=] with the following items:
@@ -838,12 +852,8 @@ An attribution source is a [=struct=] with the following items:
 :: An [=aggregatable debug reporting config=].
 : <dfn>destination limit priority</dfn>
 :: A 64-bit integer.
-: <dfn>attribution scope limit</dfn>
-:: Null or a positive 32-bit integer representing the number of distinct [=attribution source/attribution scopes=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
-: <dfn>attribution scopes</dfn>
-:: A [=set=] of [=strings=].
-: <dfn>max event states</dfn>
-:: A positive integer representing the maximum number of [=trigger states=] for [=source type/event=] sources per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+: <dfn>attribution scope data</dfn> (default null)
+:: An [=attribution scope data=].
 
 </dl>
 
@@ -1384,14 +1394,14 @@ with a given ([=aggregatable debug rate-limit record/context site=], [=aggregata
 per [=aggregatable debug rate-limit window=]. Its value is (2<sup>20</sup>, 65536).
 
 <dfn>Default max event states</dfn> is a positive integer that controls the
-default [=attribution source/max event states=]. Its value is 3.
+default [=attribution scope data/max event states=]. Its value is 3.
 
 <dfn>Max length of attribution scope for source</dfn> is a positive integer that controls the
-maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution source/attribution scopes=].
+maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution scope data/attribution scopes=].
 Its value is 50.
 
 <dfn>Max attribution scopes per source</dfn> is a positive integer that controls the
-maximum [=set/size=] of an [=attribution source=]'s [=attribution source/attribution scopes=].
+maximum [=set/size=] of an [=attribution source=]'s [=attribution scope data/attribution scopes=].
 Its value is 20.
 
 # Vendor-Specific Values # {#vendor-specific-values}
@@ -2362,6 +2372,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_report_window</code></dfn>"
 <li>"<dfn><code>aggregation_keys</code></dfn>"
 <li>"<dfn><code>budget</code></dfn>"
+<li>"<dfn><code>attribution_scope_data</code></dfn>"
 <li>"<dfn><code>attribution_scope_limit</code></dfn>"
 <li>"<dfn><code>attribution_scopes</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
@@ -2651,30 +2662,44 @@ non-negative integer |defaultBudget|, and an [=aggregatable debug reporting conf
     with |value|, |budget|, |supportedTypes|, and |defaultConfig|.
 1. Return the [=tuple=] (|budget|, |config|).
 
-To <dfn>parse max event states</dfn> from a [=map=] |map| and
-a possibly null 32-bit positive integer |attributionScopeLimit|:
+To <dfn>parse attribution scope data</dfn> from a [=map=] |map|:
+1. If |map|["<code>[=source-registration JSON key/attribution_scope_data=]</code>"] does not [=map/exists|exist=], return null.
+1. Let |value| be |map|["<code>[=source-registration JSON key/attribution_scope_data=]</code>"].
+1. If |value| is not a [=map=], return an error.
+1. If |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"] does not [=map/exists|exist=], return an error.
+1. Set |attributionScopeLimit| to |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"].
+1. If |attributionScopeLimit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return an error.
+1. Let |maxEventStates| be the result of running [=parse max event states=] with |value|.
+1. If |maxEventStates| is an error, return an error.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes for source=] with |value| and |attributionScopeLimit|.
+1. If |attributionScopes| is an error, return an error.
+1. Let |attributionScopeData| be a new [=attribution scope data=] with the items:
+    : [=attribution scope data/attribution scope limit=]
+    :: |attributionScopeLimit|
+    : [=attribution scope data/attribution scopes=]
+    :: |attributionScopeLimit|
+    : [=attribution scope data/max event states=]
+    :: |maxEventStates|
+1. Return |attributionScopeData|.
+
+To <dfn>parse max event states</dfn> from a [=map=] |map|:
 1. Let |maxEventStates| be [=default max event states=].
 1. If |map|["<code>[=source-registration JSON key/max_event_states=]</code>"] [=map/exists=], set |maxEventStates| to |map|["<code>[=source-registration JSON key/max_event_states=]</code>"].
 1. If |maxEventStates| is not an integer or is less than or equal to 0, return an error.
 1. If |maxEventStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
-1. If |maxEventStates| is not equal to [=default max event states=] and |attributionScopeLimit| is null, return an error.
 1. Return |maxEventStates|.
 
-To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a possibly null 32-bit positive integer |attributionScopeLimit|:
+To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a 32-bit positive integer |attributionScopeLimit|:
+1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return an error.
 1. Let |result| be a new [=set=].
-1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return |result|.
 1. Let |values| be |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"].
 1. If |values| is not a [=list=], return an error.
 1. [=list/iterate|For each=] |value| of |values|:
     1. If |value| is not a [=string=], return an error.
     1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.
     1. [=set/Append=] |value| to |result|.
-1. If |attributionScopeLimit| is null:
-    1. If |result| is not [=set/is empty|empty=], return an error.
-    1. Return |result|.
 1. If |result| [=set/is empty=], return an error.
-1. If |result|'s [=set/size=] is greater than |attributionScopeLimit|, return an error.
-1. If |result|'s [=set/size=] is greater than [=max attribution scopes per source=], return an error.
+1. If |result|'s [=set/size=] is greater than |attributionScopeLimit| or [=max attribution scopes per source=], return an error.
 1. Return |result|.
 
 Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
@@ -2750,15 +2775,7 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
     |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
 1. If |triggerSpecs| is an error, return null.
-1. Let |attributionScopeLimit| be null.
-1. If |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"] [=map/exists=]:
-    1. Set |attributionScopeLimit| to |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"].
-    1. If |attributionScopeLimit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return null.
-1. Let |maxEventStates| be the result of running
-    [=parse max event states=] with |value| and |attributionScopeLimit|.
-1. If |maxEventStates| is an error, return null.
-1. Let |attributionScopes| be the result of running [=parse attribution scopes for source=] with |value| and |attributionScopeLimit|.
-1. If |attributionScopes| is an error, return null.
+1. Let |attributionScopeData| be the result of running [=parse attribution scope data=] with |value|.
 1. Let |epsilon| be the user agent's [=max settable event-level epsilon=].
 1. Set |epsilon| to |value|["<code>[=source-registration JSON key/event_level_epsilon=]</code>"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
@@ -2825,12 +2842,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |aggregatableDebugReportingConfig|
     : [=attribution source/destination limit priority=]
     :: |destinationLimitPriority|
-    : [=attribution source/attribution scopes=]
-    :: |attributionScopes|
-    : [=attribution source/attribution scope limit=]
-    :: |attributionScopeLimit|
-    : [=attribution source/max event states=]
-    :: |maxEventStates|
+    : [=attribution source/attribution scope data=]
+    :: |attributionScopeData|
 1. Return |source|.
 
 Issue: Determine proper charset-handling for the JSON header value.

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2684,6 +2684,20 @@ const testCases: TestCase[] = [
 
   // Attribution Scope
   {
+    name: 'attribution-scopes-not-a-dictionary',
+    input: `{
+      "destination": "https://a.test",
+      "attribution_scopes": ["1"]
+    }`,
+    parseScopes: true,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes'],
+        msg: 'must be an object',
+      },
+    ],
+  },
+  {
     name: 'attribution-scope-limit-negative',
     input: `{
       "destination": "https://a.test",
@@ -2801,6 +2815,22 @@ const testCases: TestCase[] = [
       {
         path: ['attribution_scopes', 'values'],
         msg: 'cannot be fully validated without a valid limit',
+      },
+    ],
+  },
+  {
+    name: 'missing-attribution-scope-values',
+    input: `{
+      "destination": "https://a.test",
+      "attribution_scopes": {
+        "limit": 3
+      }
+    }`,
+    parseScopes: true,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes', 'values'],
+        msg: 'required',
       },
     ],
   },

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -45,9 +45,9 @@ const testCases: TestCase[] = [
           "value": 123
         } ]
       },
-      "attribution_scope_data": {
-        "attribution_scope_limit": 3,
-        "attribution_scopes": ["1"],
+      "attribution_scopes": {
+        "limit": 3,
+        "values": ["1"],
         "max_event_states": 4
       }
     }`,
@@ -91,9 +91,9 @@ const testCases: TestCase[] = [
         aggregationCoordinatorOrigin:
           'https://publickeyservice.msmt.aws.privacysandboxservices.com',
       },
-      attributionScopeData: {
-        attributionScopeLimit: 3,
-        attributionScopes: new Set<string>('1'),
+      attributionScopes: {
+        limit: 3,
+        values: new Set<string>('1'),
         maxEventStates: 4,
       },
     }),
@@ -104,15 +104,15 @@ const testCases: TestCase[] = [
     name: 'unknown-field',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scopes": false,
-        "attribution_scope_limit": false,
+      "attribution_scopes": {
+        "values": false,
+        "limit": false,
         "max_event_states": false
       }
     }`,
     expectedWarnings: [
       {
-        path: ['attribution_scope_data'],
+        path: ['attribution_scopes'],
         msg: 'unknown field',
       },
     ],
@@ -1448,9 +1448,9 @@ const testCases: TestCase[] = [
     name: 'trigger-state-cardinality-invalid-scopes',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 3,
-        "attribution_scopes": ["1"],
+      "attribution_scopes": {
+        "limit": 3,
+        "values": ["1"],
         "max_event_states": 2
       }
     }`,
@@ -2687,20 +2687,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-negative',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": -1,
-        "attribution_scopes": ["1"]
+      "attribution_scopes": {
+        "limit": -1,
+        "values": ["1"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'must be in the range [1, 4294967295]',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2708,20 +2708,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-zero',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 0,
-        "attribution_scopes": ["1"]
+      "attribution_scopes": {
+        "limit": 0,
+        "values": ["1"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'must be in the range [1, 4294967295]',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2729,20 +2729,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-not-integer',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1.5,
-        "attribution_scopes": ["1"]
+      "attribution_scopes": {
+        "limit": 1.5,
+        "values": ["1"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'must be an integer',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2750,20 +2750,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-exceeds-max',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 4294967296,
-        "attribution_scopes": ["1"]
+      "attribution_scopes": {
+        "limit": 4294967296,
+        "values": ["1"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'must be in the range [1, 4294967295]',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2771,16 +2771,16 @@ const testCases: TestCase[] = [
     name: 'empty-attribution-scopes-with-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 3,
-        "attribution_scopes": []
+      "attribution_scopes": {
+        "limit": 3,
+        "values": []
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'must be non-empty if attribution_scope_limit is set',
+        path: ['attribution_scopes', 'values'],
+        msg: 'must be non-empty if limit is set',
       },
     ],
   },
@@ -2788,19 +2788,19 @@ const testCases: TestCase[] = [
     name: 'missing-attribution-scope-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scopes": ["1", "2"]
+      "attribution_scopes": {
+        "values": ["1", "2"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'required',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2808,20 +2808,20 @@ const testCases: TestCase[] = [
     name: 'invalid-attribution-scope-limit-not-an-integer',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scopes": ["1"],
-        "attribution_scope_limit": true
+      "attribution_scopes": {
+        "values": ["1"],
+        "limit": true
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        path: ['attribution_scopes', 'limit'],
         msg: 'must be a number',
       },
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+        path: ['attribution_scopes', 'values'],
+        msg: 'cannot be fully validated without a valid limit',
       },
     ],
   },
@@ -2829,16 +2829,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-negative',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": ["1"],
+      "attribution_scopes": {
+        "limit": 1,
+        "values": ["1"],
         "max_event_states": -1
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'max_event_states'],
+        path: ['attribution_scopes', 'max_event_states'],
         msg: 'must be in the range [1, 4294967295]',
       },
     ],
@@ -2847,16 +2847,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-zero',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": ["1"],
+      "attribution_scopes": {
+        "limit": 1,
+        "values": ["1"],
         "max_event_states": 0
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'max_event_states'],
+        path: ['attribution_scopes', 'max_event_states'],
         msg: 'must be in the range [1, 4294967295]',
       },
     ],
@@ -2865,16 +2865,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-not-integer',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": ["1"],
+      "attribution_scopes": {
+        "limit": 1,
+        "values": ["1"],
         "max_event_states": 1.5
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'max_event_states'],
+        path: ['attribution_scopes', 'max_event_states'],
         msg: 'must be an integer',
       },
     ],
@@ -2883,16 +2883,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-size-exceeds-attribution-scope-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": ["1", "2"]
+      "attribution_scopes": {
+        "limit": 1,
+        "values": ["1", "2"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'size must be less than or equal to attribution_scope_limit (1) if attribution_scope_limit is set',
+        path: ['attribution_scopes', 'values'],
+        msg: 'size must be less than or equal to limit (1) if limit is set',
       },
     ],
   },
@@ -2900,16 +2900,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-not-string',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 2,
-        "attribution_scopes": [1]
+      "attribution_scopes": {
+        "limit": 2,
+        "values": [1]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be a string',
-        path: ['attribution_scope_data', 'attribution_scopes', 0],
+        path: ['attribution_scopes', 'values', 0],
       },
     ],
   },
@@ -2917,16 +2917,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-empty-list',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": []
+      "attribution_scopes": {
+        "limit": 1,
+        "values": []
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        msg: 'must be non-empty if attribution_scope_limit is set',
-        path: ['attribution_scope_data', 'attribution_scopes'],
+        msg: 'must be non-empty if limit is set',
+        path: ['attribution_scopes', 'values'],
       },
     ],
   },
@@ -2934,16 +2934,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-not-list',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": 1
+      "attribution_scopes": {
+        "limit": 1,
+        "values": 1
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be a list',
-        path: ['attribution_scope_data', 'attribution_scopes'],
+        path: ['attribution_scopes', 'values'],
       },
     ],
   },
@@ -2951,16 +2951,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-many',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 21,
-        "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
+      "attribution_scopes": {
+        "limit": 21,
+        "values": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scopes'],
-        msg: 'size must be less than or equal to max number of attribution scopes (20) if attribution_scope_limit is set',
+        path: ['attribution_scopes', 'values'],
+        msg: 'size must be less than or equal to max number of attribution scopes (20) if limit is set',
       },
     ],
   },
@@ -2968,15 +2968,15 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-long',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_data": {
-        "attribution_scope_limit": 1,
-        "attribution_scopes": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+      "attribution_scopes": {
+        "limit": 1,
+        "values": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
       }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_data', 'attribution_scopes', 0],
+        path: ['attribution_scopes', 'values', 0],
         msg: 'exceeds max length per attribution scope (51 > 50)',
       },
     ],

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -45,9 +45,11 @@ const testCases: TestCase[] = [
           "value": 123
         } ]
       },
-      "attribution_scope_limit": 3,
-      "attribution_scopes": ["1"],
-      "max_event_states": 4
+      "attribution_scope_data": {
+        "attribution_scope_limit": 3,
+        "attribution_scopes": ["1"],
+        "max_event_states": 4
+      }
     }`,
     sourceType: SourceType.navigation,
     parseScopes: true,
@@ -89,9 +91,11 @@ const testCases: TestCase[] = [
         aggregationCoordinatorOrigin:
           'https://publickeyservice.msmt.aws.privacysandboxservices.com',
       },
-      attributionScopeLimit: 3,
-      attributionScopes: new Set<string>('1'),
-      maxEventStates: 4,
+      attributionScopeData: {
+        attributionScopeLimit: 3,
+        attributionScopes: new Set<string>('1'),
+        maxEventStates: 4,
+      },
     }),
   },
 
@@ -100,21 +104,15 @@ const testCases: TestCase[] = [
     name: 'unknown-field',
     input: `{
       "destination": "https://a.test",
-      "attribution_scopes": false,
-      "attribution_scope_limit": false,
-      "max_event_states": false
+      "attribution_scope_data": {
+        "attribution_scopes": false,
+        "attribution_scope_limit": false,
+        "max_event_states": false
+      }
     }`,
     expectedWarnings: [
       {
-        path: ['attribution_scopes'],
-        msg: 'unknown field',
-      },
-      {
-        path: ['attribution_scope_limit'],
-        msg: 'unknown field',
-      },
-      {
-        path: ['max_event_states'],
+        path: ['attribution_scope_data'],
         msg: 'unknown field',
       },
     ],
@@ -1450,9 +1448,11 @@ const testCases: TestCase[] = [
     name: 'trigger-state-cardinality-invalid-scopes',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 3,
-      "attribution_scopes": ["1"],
-      "max_event_states": 2
+      "attribution_scope_data": {
+        "attribution_scope_limit": 3,
+        "attribution_scopes": ["1"],
+        "max_event_states": 2
+      }
     }`,
     sourceType: SourceType.event,
     vsv: {
@@ -2687,13 +2687,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-negative',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": -1
+      "attribution_scope_data": {
+        "attribution_scope_limit": -1,
+        "attribution_scopes": ["1"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
         msg: 'must be in the range [1, 4294967295]',
+      },
+      {
+        path: ['attribution_scope_data', 'attribution_scopes'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
   },
@@ -2701,13 +2708,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-zero',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 0
+      "attribution_scope_data": {
+        "attribution_scope_limit": 0,
+        "attribution_scopes": ["1"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
         msg: 'must be in the range [1, 4294967295]',
+      },
+      {
+        path: ['attribution_scope_data', 'attribution_scopes'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
   },
@@ -2715,13 +2729,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-not-integer',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1.5
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1.5,
+        "attribution_scopes": ["1"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
         msg: 'must be an integer',
+      },
+      {
+        path: ['attribution_scope_data', 'attribution_scopes'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
   },
@@ -2729,13 +2750,20 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-limit-exceeds-max',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 4294967296
+      "attribution_scope_data": {
+        "attribution_scope_limit": 4294967296,
+        "attribution_scopes": ["1"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
         msg: 'must be in the range [1, 4294967295]',
+      },
+      {
+        path: ['attribution_scope_data', 'attribution_scopes'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
   },
@@ -2743,79 +2771,56 @@ const testCases: TestCase[] = [
     name: 'empty-attribution-scopes-with-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 3,
-      "attribution_scopes": []
+      "attribution_scope_data": {
+        "attribution_scope_limit": 3,
+        "attribution_scopes": []
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
         msg: 'must be non-empty if attribution_scope_limit is set',
       },
     ],
   },
   {
-    name: 'missing-attribution-scope-limit-attribution-scopes',
+    name: 'missing-attribution-scope-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scopes": ["1", "2"]
+      "attribution_scope_data": {
+        "attribution_scopes": ["1", "2"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes'],
-        msg: 'must be empty if attribution_scope_limit is not set',
-      },
-    ],
-  },
-  {
-    name: 'missing-attribution-scope-limit-max-event-states',
-    input: `{
-      "destination": "https://a.test",
-      "max_event_states": 5
-    }`,
-    parseScopes: true,
-    expectedErrors: [
-      {
-        path: ['max_event_states'],
-        msg: 'must be default (3) if attribution_scope_limit is not set',
-      },
-    ],
-  },
-  {
-    name: 'invalid-attribution-scope-limit-attribution-scopes',
-    input: `{
-      "destination": "https://a.test",
-      "attribution_scopes": ["1"],
-      "attribution_scope_limit": true
-    }`,
-    parseScopes: true,
-    expectedErrors: [
-      {
-        path: ['attribution_scope_limit'],
-        msg: 'must be a number',
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
+        msg: 'required',
       },
       {
-        path: ['attribution_scopes'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
         msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
   },
   {
-    name: 'invalid-attribution-scope-limit-amx-event-states',
+    name: 'invalid-attribution-scope-limit-not-an-integer',
     input: `{
       "destination": "https://a.test",
-      "max_event_states": 1,
-      "attribution_scope_limit": true
+      "attribution_scope_data": {
+        "attribution_scopes": ["1"],
+        "attribution_scope_limit": true
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scope_limit'],
+        path: ['attribution_scope_data', 'attribution_scope_limit'],
         msg: 'must be a number',
       },
       {
-        path: ['max_event_states'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
         msg: 'cannot be fully validated without a valid attribution_scope_limit',
       },
     ],
@@ -2824,13 +2829,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-negative',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "max_event_states": -1
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": ["1"],
+        "max_event_states": -1
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['max_event_states'],
+        path: ['attribution_scope_data', 'max_event_states'],
         msg: 'must be in the range [1, 4294967295]',
       },
     ],
@@ -2839,13 +2847,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-zero',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "max_event_states": 0
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": ["1"],
+        "max_event_states": 0
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['max_event_states'],
+        path: ['attribution_scope_data', 'max_event_states'],
         msg: 'must be in the range [1, 4294967295]',
       },
     ],
@@ -2854,13 +2865,16 @@ const testCases: TestCase[] = [
     name: 'max-event-states-not-integer',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "max_event_states": 1.5
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": ["1"],
+        "max_event_states": 1.5
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['max_event_states'],
+        path: ['attribution_scope_data', 'max_event_states'],
         msg: 'must be an integer',
       },
     ],
@@ -2869,13 +2883,15 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-size-exceeds-attribution-scope-limit',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "attribution_scopes": ["1", "2"]
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": ["1", "2"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
         msg: 'size must be less than or equal to attribution_scope_limit (1) if attribution_scope_limit is set',
       },
     ],
@@ -2884,14 +2900,16 @@ const testCases: TestCase[] = [
     name: 'attribution-scope-not-string',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 2,
-      "attribution_scopes": [1]
+      "attribution_scope_data": {
+        "attribution_scope_limit": 2,
+        "attribution_scopes": [1]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes', 0],
         msg: 'must be a string',
+        path: ['attribution_scope_data', 'attribution_scopes', 0],
       },
     ],
   },
@@ -2899,22 +2917,33 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-empty-list',
     input: `{
       "destination": "https://a.test",
-      "attribution_scopes": []
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": []
+      }
     }`,
     parseScopes: true,
+    expectedErrors: [
+      {
+        msg: 'must be non-empty if attribution_scope_limit is set',
+        path: ['attribution_scope_data', 'attribution_scopes'],
+      },
+    ],
   },
   {
     name: 'attribution-scopes-not-list',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "attribution_scopes": 1
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": 1
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be a list',
-        path: ['attribution_scopes'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
       },
     ],
   },
@@ -2922,13 +2951,15 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-many',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 21,
-      "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
+      "attribution_scope_data": {
+        "attribution_scope_limit": 21,
+        "attribution_scopes": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes'],
+        path: ['attribution_scope_data', 'attribution_scopes'],
         msg: 'size must be less than or equal to max number of attribution scopes (20) if attribution_scope_limit is set',
       },
     ],
@@ -2937,13 +2968,15 @@ const testCases: TestCase[] = [
     name: 'attribution-scopes-too-long',
     input: `{
       "destination": "https://a.test",
-      "attribution_scope_limit": 1,
-      "attribution_scopes": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+      "attribution_scope_data": {
+        "attribution_scope_limit": 1,
+        "attribution_scopes": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+      }
     }`,
     parseScopes: true,
     expectedErrors: [
       {
-        path: ['attribution_scopes', 0],
+        path: ['attribution_scope_data', 'attribution_scopes', 0],
         msg: 'exceeds max length per attribution scope (51 > 50)',
       },
     ],

--- a/ts/src/header-validator/source.ts
+++ b/ts/src/header-validator/source.ts
@@ -31,6 +31,12 @@ export enum TriggerDataMatching {
   modulus = 'modulus',
 }
 
+export type AttributionScopeData = {
+  attributionScopeLimit: number
+  attributionScopes: Set<string>
+  maxEventStates: number
+}
+
 export type Source = reg.CommonDebug &
   reg.Priority & {
     aggregatableReportWindow: number
@@ -47,7 +53,5 @@ export type Source = reg.CommonDebug &
     eventLevelEpsilon: number
     aggregatableDebugReporting: SourceAggregatableDebugReportingConfig | null
     destinationLimitPriority: bigint
-    attributionScopes: Set<string>
-    attributionScopeLimit: number | null
-    maxEventStates: number
+    attributionScopeData: AttributionScopeData | null
   }

--- a/ts/src/header-validator/source.ts
+++ b/ts/src/header-validator/source.ts
@@ -31,9 +31,9 @@ export enum TriggerDataMatching {
   modulus = 'modulus',
 }
 
-export type AttributionScopeData = {
-  attributionScopeLimit: number
-  attributionScopes: Set<string>
+export type AttributionScopes = {
+  limit: number
+  values: Set<string>
   maxEventStates: number
 }
 
@@ -53,5 +53,5 @@ export type Source = reg.CommonDebug &
     eventLevelEpsilon: number
     aggregatableDebugReporting: SourceAggregatableDebugReportingConfig | null
     destinationLimitPriority: bigint
-    attributionScopeData: AttributionScopeData | null
+    attributionScopes: AttributionScopes | null
   }

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -135,6 +135,22 @@ function serializeSourceAggregatableDebugReportingConfig(
   }
 }
 
+type AttributionScopeData = {
+  attribution_scope_limit: number
+  attribution_scopes: string[]
+  max_event_states: number
+}
+
+function serializeAttributionScopeData(
+  a: source.AttributionScopeData
+): AttributionScopeData {
+  return {
+    attribution_scope_limit: a.attributionScopeLimit,
+    attribution_scopes: Array.from(a.attributionScopes),
+    max_event_states: a.maxEventStates,
+  }
+}
+
 type NotFullFlexSource = Partial<EventReportWindows> & {
   trigger_data: number[]
   trigger_specs?: never
@@ -184,9 +200,7 @@ type Source = CommonDebug &
     source_event_id: string
     trigger_data_matching: string
     aggregatable_debug_reporting?: SourceAggregatableDebugReportingConfig
-    attribution_scopes?: string[]
-    attribution_scope_limit?: number
-    max_event_states?: number
+    attribution_scope_data?: AttributionScopeData
   }
 
 export interface Options {
@@ -199,17 +213,10 @@ export function serializeSource(
   opts: Readonly<Options>
 ): string {
   const scopeFields = opts.scopes
-    ? {
-        attribution_scopes: Array.from(s.attributionScopes),
-        ...ifNotNull(
-          'attribution_scope_limit',
-          s.attributionScopeLimit,
-          (v) => v
-        ),
-        max_event_states: s.maxEventStates,
-      }
+    ? ifNotNull('attribution_scope_data', s.attributionScopeData, (v) =>
+        serializeAttributionScopeData(v)
+      )
     : {}
-
   const source: Source = {
     ...serializeCommonDebug(s),
     ...serializePriority(s),

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -200,7 +200,7 @@ type Source = CommonDebug &
     source_event_id: string
     trigger_data_matching: string
     aggregatable_debug_reporting?: SourceAggregatableDebugReportingConfig
-    attribution_scope_data?: AttributionScopes
+    attribution_scopes?: AttributionScopes
   }
 
 export interface Options {

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -135,18 +135,18 @@ function serializeSourceAggregatableDebugReportingConfig(
   }
 }
 
-type AttributionScopeData = {
-  attribution_scope_limit: number
-  attribution_scopes: string[]
+type AttributionScopes = {
+  limit: number
+  values: string[]
   max_event_states: number
 }
 
-function serializeAttributionScopeData(
-  a: source.AttributionScopeData
-): AttributionScopeData {
+function serializeAttributionScopes(
+  a: source.AttributionScopes
+): AttributionScopes {
   return {
-    attribution_scope_limit: a.attributionScopeLimit,
-    attribution_scopes: Array.from(a.attributionScopes),
+    limit: a.limit,
+    values: Array.from(a.values),
     max_event_states: a.maxEventStates,
   }
 }
@@ -200,7 +200,7 @@ type Source = CommonDebug &
     source_event_id: string
     trigger_data_matching: string
     aggregatable_debug_reporting?: SourceAggregatableDebugReportingConfig
-    attribution_scope_data?: AttributionScopeData
+    attribution_scope_data?: AttributionScopes
   }
 
 export interface Options {
@@ -213,8 +213,8 @@ export function serializeSource(
   opts: Readonly<Options>
 ): string {
   const scopeFields = opts.scopes
-    ? ifNotNull('attribution_scope_data', s.attributionScopeData, (v) =>
-        serializeAttributionScopeData(v)
+    ? ifNotNull('attribution_scopes', s.attributionScopes, (v) =>
+        serializeAttributionScopes(v)
       )
     : {}
   const source: Source = {

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -745,9 +745,7 @@ function attributionScopesForSource(
     string(j, ctx).filter(attributionScopeStringLength)
   ).filter((scopes) => {
     if (attributionScopeLimit.value === undefined) {
-      ctx.error(
-        'cannot be fully validated without a valid limit'
-      )
+      ctx.error('cannot be fully validated without a valid limit')
       return false
     }
     if (scopes.size === 0) {


### PR DESCRIPTION
Wrap attribution scope fields into a dictionary for clarity.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/feifeiji89/attribution-reporting-api/pull/1391.html" title="Last updated on Aug 12, 2024, 8:28 PM UTC (6611cba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1391/aad5718...feifeiji89:6611cba.html" title="Last updated on Aug 12, 2024, 8:28 PM UTC (6611cba)">Diff</a>