### PR TITLE
Omit source_registration_time field while excluding source registration time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4622,16 +4622,9 @@ of running the following steps:
 
 1. If |report|'s [=aggregatable report/debug mode=] is <strong>enabled</strong>,
     [=map/set=] |sharedInfo|["`debug_mode`"] to "`enabled`".
-1. If |report| is an [=aggregatable attribution report=]:
-    1. If |report|'s [=aggregatable attribution report/source registration time configuration=] is:
-        <dl class="switch">
-        : "<code>[=aggregatable source registration time configuration/include=]</code>"</dt>
-        :: [=map/Set=] |sharedInfo|["`source_registration_time`"] to the result of [=obtaining rounded source time=]
-            with |report|'s [=aggregatable attribution report/source time=], [=serialize an integer|serialized=].
-        : "<code>[=aggregatable source registration time configuration/exclude=]</code>"
-        :: [=map/Set=] |sharedInfo|["`source_registration_time`"] to "`0`".
-
-        </dl>
+1. If |report| is an [=aggregatable attribution report=] and |report|'s [=aggregatable attribution report/source registration time configuration=] is "<code>[=aggregatable source registration time configuration/include=]</code>":
+    [=map/set=] |sharedInfo|["`source_registration_time`"] to the result of [=obtaining rounded source time=]
+    with |report|'s [=aggregatable attribution report/source time=], [=serialize an integer|serialized=].
 
 1. Return the [=string=] resulting from executing [=serialize an infra value to a json string=] on |sharedInfo|.
 


### PR DESCRIPTION
This is compatible with currently supported aggregation service versions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1395.html" title="Last updated on Aug 15, 2024, 6:35 PM UTC (0bd7aa8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1395/cd5c617...linnan-github:0bd7aa8.html" title="Last updated on Aug 15, 2024, 6:35 PM UTC (0bd7aa8)">Diff</a>