### PR TITLE
Fix spec build with remote end steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
         text: getting a property; url: dfn-getting-properties
         text: error code; url: dfn-error-code
+        text: remote end steps; url: dfn-remote-end-steps
 spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/
     text: generate a random UUID; url: #dfn-generate-a-random-uuid
 spec: structured header; type: dfn; urlPrefix: https://httpwg.org/specs/rfc8941;


### PR DESCRIPTION
This is due to "remote end steps" exported in private aggregation API (https://github.com/patcg-individual-drafts/private-aggregation-api/pull/147).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1400.html" title="Last updated on Aug 27, 2024, 3:27 PM UTC (bf1b94c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1400/6e2318b...linnan-github:bf1b94c.html" title="Last updated on Aug 27, 2024, 3:27 PM UTC (bf1b94c)">Diff</a>