### PR TITLE
Only set source or trigger debug keys when both are present

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -757,16 +757,6 @@ Source and trigger registrations will both accept a new field `debug_key`:
 }
 ```
 
-Reports will include up to two new parameters which pass any specified debug keys
-from source and trigger events unaltered:
-```jsonc
-{
-  // normal report fields...
-  "source_debug_key": "[64-bit unsigned integer]",
-  "trigger_debug_key": "[64-bit unsigned integer]"
-}
-```
-
 If a report is created with both source and trigger debug keys, a duplicate debug
 report will be sent immediately to a
 `.well-known/attribution-reporting/debug/report-event-attribution`
@@ -774,9 +764,13 @@ endpoint. The debug reports will be identical to normal reports, including the
 two debug key fields. Including these keys in both allows tying normal reports
 to the separate stream of debug reports.
 
-Note that event-level reports associated with false trigger events
-will not have `trigger_debug_key`s. This allows developers to more
-closely understand how noise is applied in the API.
+```jsonc
+{
+  // normal report fields...
+  "source_debug_key": "[64-bit unsigned integer]",
+  "trigger_debug_key": "[64-bit unsigned integer]"
+}
+```
 
 #### Verbose debugging reports
 

--- a/index.bs
+++ b/index.bs
@@ -2231,6 +2231,9 @@ To <dfn>serialize an attribution debug info</dfn> given a [=map=] |data| and an
 1. [=map/Set=] |data|["`trigger_debug_key`"] to |report|'s [=attribution debug info/trigger debug key=],
     [=serialize an integer|serialized=].
 
+Note: We require both source and trigger debug keys to be present to avoid
+privacy leak from one-sided third-party cookie access.
+
 <h3 id="obtaining-and-delivering-aggregatable-debug-report">Obtaining and delivering an aggregatable debug report</h3>
 
 To <dfn>check if aggregatable debug reporting should be blocked by rate-limit</dfn>

--- a/index.bs
+++ b/index.bs
@@ -2231,7 +2231,7 @@ To <dfn>serialize an attribution debug info</dfn> given a [=map=] |data| and an
     [=serialize an integer|serialized=].
 
 Note: We require both source and trigger debug keys to be present to avoid
-privacy leak from one-sided third-party cookie access.
+a privacy leak from one-sided third-party cookie access.
 
 <h3 id="obtaining-and-delivering-aggregatable-debug-report">Obtaining and delivering an aggregatable debug report</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -2224,8 +2224,7 @@ To <dfn>check if attribution debugging can be enabled</dfn> given an [=attributi
 To <dfn>serialize an attribution debug info</dfn> given a [=map=] |data| and an
 [=attribution debug info=] |debugInfo|:
 
-1. If |debugInfo|'s [=attribution debug info/source debug key=] is null, return.
-1. If |debugInfo|'s [=attribution debug info/trigger debug key=] is null, return.
+1. If the result of [=checking if attribution debugging can be enabled=] with |debugInfo| is false, return.
 1. [=map/Set=] |data|["`source_debug_key`"] to |debugInfo|'s [=attribution debug info/source debug key=],
     [=serialize an integer|serialized=].
 1. [=map/Set=] |data|["`trigger_debug_key`"] to |report|'s [=attribution debug info/trigger debug key=],

--- a/index.bs
+++ b/index.bs
@@ -2224,11 +2224,11 @@ To <dfn>check if attribution debugging can be enabled</dfn> given an [=attributi
 To <dfn>serialize an attribution debug info</dfn> given a [=map=] |data| and an
 [=attribution debug info=] |debugInfo|:
 
-1. If |debugInfo|'s [=attribution debug info/source debug key=] is not null, [=map/set=]
-    |data|["`source_debug_key`"] to |debugInfo|'s [=attribution debug info/source debug key=],
+1. If |debugInfo|'s [=attribution debug info/source debug key=] is null, return.
+1. If |debugInfo|'s [=attribution debug info/trigger debug key=] is null, return.
+1. [=map/Set=] |data|["`source_debug_key`"] to |debugInfo|'s [=attribution debug info/source debug key=],
     [=serialize an integer|serialized=].
-1. If |debugInfo|'s [=attribution debug info/trigger debug key=] is not null, [=map/set=]
-    |data|["`trigger_debug_key`"] to |report|'s [=attribution debug info/trigger debug key=],
+1. [=map/Set=] |data|["`trigger_debug_key`"] to |report|'s [=attribution debug info/trigger debug key=],
     [=serialize an integer|serialized=].
 
 <h3 id="obtaining-and-delivering-aggregatable-debug-report">Obtaining and delivering an aggregatable debug report</h3>


### PR DESCRIPTION
To improve privacy, source or trigger debug keys will be set in attribution reports only when both are present. This is to avoid privacy leak from one-sided 3P cookie access.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1403.html" title="Last updated on Aug 28, 2024, 2:33 PM UTC (4c64897)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1403/5de498e...linnan-github:4c64897.html" title="Last updated on Aug 28, 2024, 2:33 PM UTC (4c64897)">Diff</a>