### PR TITLE
Refactor source matching with attribution scopes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4301,7 +4301,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     with |trigger|.
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=set/is empty=] and |hasAggregatableData| is false, return.
-1. Let (|sourcesToAttribute|, |matchingSources|) be the result of running [=find matching sources=] with |trigger|.
+1. Let (|sourceToAttribute|, |matchingSources|) be the result of running [=find matching sources=] with |trigger|.
 1. If |sourceToAttribute| is null:
     1. Run [=obtain and deliver debug reports on trigger registration=] with
         « ("<code>[=trigger debug data type/trigger-no-matching-source=]</code>", null) »,

--- a/index.bs
+++ b/index.bs
@@ -4260,6 +4260,14 @@ To <dfn>check if an [=attribution source=] and [=attribution trigger=] have matc
 
 To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
 
+An [=attribution source=] |a| <dfn for="attribution source">is higher-priority than</dfn> an [=attribution source=] |b|
+if the following steps return true:
+
+1. |a|'s [=attribution source/priority=] is greater than |b|'s [=attribution source/priority=], return true.
+1. |a|'s [=attribution source/priority=] is less than |b|'s [=attribution source/priority=], return false.
+1. If |a|'s [=attribution source/source time=] is greater than |b|'s [=attribution source/source time=], return true.
+1. Return false.
+
 1. Let |matchingSources| be a new [=list=].
 1. [=set/iterate|For each=] |source| of the [=attribution source cache=]:
     1. If |source|'s [=attribution source/attribution destinations=] does not [=set/contains|contain=] |trigger|'s [=attribution trigger/attribution destination=], [=iteration/continue=].
@@ -4267,11 +4275,6 @@ To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
     1. If |source|'s [=attribution source/expiry time=] is less than or equal to |trigger|'s [=attribution trigger/trigger time=], [=iteration/continue=].
     1. [=list/Append=] |source| to |matchingSources|.
 1. Let |sourceToAttribute| be null.
-1. An [=attribution source=] |a| <dfn for="attribution source">is higher-priority than</dfn> an [=attribution source=] |b|
-    if any of the following are true:
-      * |a|'s [=attribution source/priority=] is greater than |b|'s [=attribution source/priority=].
-      * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
-         [=attribution source/source time=] is greater than |b|'s [=attribution source/source time=].
 1. [=list/iterate|For each=] |source| of |matchingSources|:
     1. If the result of [=checking if an attribution source and attribution trigger have matching attribution scopes=]
         with |source| and |trigger| is false, [=iteration/continue=].
@@ -4298,8 +4301,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     with |trigger|.
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=set/is empty=] and |hasAggregatableData| is false, return.
-1. Let |matchingSourcesResult| be the result of running [=find matching sources=] with |trigger|.
-1. Let |sourceToAttribute| be |matchingSourcesResult|[0].
+1. Let (|sourcesToAttribute, |matchingSources|) be the result of running [=find matching sources=] with |trigger|.
 1. If |sourceToAttribute| is null:
     1. Run [=obtain and deliver debug reports on trigger registration=] with
         « ("<code>[=trigger debug data type/trigger-no-matching-source=]</code>", null) »,
@@ -4318,7 +4320,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     1. If |hasAggregatableData| is true, then run [=generate null attribution reports=]
         with |trigger| and [=generate null attribution reports/report=] set to null.
     1. Return.
-1. [=list/iterate|For each=] |item| of |matchingSourcesResult|[1]:
+1. [=list/iterate|For each=] |item| of |matchingSources|:
     1. [=set/Remove=] |item| from the [=attribution source cache=].
 1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=]
     with |trigger| and |sourceToAttribute|.

--- a/index.bs
+++ b/index.bs
@@ -4301,7 +4301,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     with |trigger|.
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=set/is empty=] and |hasAggregatableData| is false, return.
-1. Let (|sourcesToAttribute, |matchingSources|) be the result of running [=find matching sources=] with |trigger|.
+1. Let (|sourcesToAttribute|, |matchingSources|) be the result of running [=find matching sources=] with |trigger|.
 1. If |sourceToAttribute| is null:
     1. Run [=obtain and deliver debug reports on trigger registration=] with
         « ("<code>[=trigger debug data type/trigger-no-matching-source=]</code>", null) »,

--- a/index.bs
+++ b/index.bs
@@ -4266,17 +4266,24 @@ To <dfn>find matching sources</dfn> given an [=attribution trigger=] |trigger|:
     1. If |source|'s [=attribution source/reporting origin=] and |trigger|'s [=attribution trigger/reporting origin=] are not [=same origin=], [=iteration/continue=].
     1. If |source|'s [=attribution source/expiry time=] is less than or equal to |trigger|'s [=attribution trigger/trigger time=], [=iteration/continue=].
     1. [=list/Append=] |source| to |matchingSources|.
-1. Set |matchingSources| to the result of [=list/sort in descending order|sorting=] |matchingSources|
-    in descending order, with |a| being less than |b| if any of the following are true:
-      * |a|'s [=attribution source/priority=] is less than |b|'s [=attribution source/priority=].
+1. Let |sourceToAttribute| be null.
+1. An [=attribution source=] |a| <dfn for="attribution source">is higher-priority than</dfn> an [=attribution source=] |b|
+    if any of the following are true:
+      * |a|'s [=attribution source/priority=] is greater than |b|'s [=attribution source/priority=].
       * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
-         [=attribution source/source time=] is less than |b|'s [=attribution source/source time=].
-      * the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |a| and |trigger| is false
-        and the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |b| and |trigger| is true
-1. If |matchingSources| is not [=list/is empty|empty=] and the result of running [=check if an attribution source and attribution trigger have matching attribution scopes=] with |matchingSources|[0] and |trigger| is false, return a new [=list=].
-1. Return |matchingSources|.
+         [=attribution source/source time=] is greater than |b|'s [=attribution source/source time=].
+1. [=list/iterate|For each=] |source| of |matchingSources|:
+    1. If the result of [=checking if an attribution source and attribution trigger have matching attribution scopes=]
+        with |source| and |trigger| is false, [=iteration/continue=].
+    1. If |sourceToAttribute| is null or |source| [=attribution source/is higher-priority than=]
+        |sourceToAttribute|, set |sourceToAttribute| to |source|.
+1. If |sourceToAttribute| is null, return the tuple (null, an [=list/is empty|empty=] [=list=]).
+1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
+1. Return the tuple (|sourceToAttribute|, |matchingSources|).
 
-Note: Sources with matching attribution scopes from the trigger will be prioritized. If no source matches attribution scopes from the trigger, an empty list will be returned.
+Note: We deliberately return all matching sources for deletion even if they don't have
+[=check if an attribution source and attribution trigger have matching attribution scopes|matching attribution scopes with the attribution trigger=]
+to avoid creating multiple [=attribution reports=] from a single cross-site user interaction.
 
 To <dfn>check if an [=attribution trigger=] contains aggregatable data</dfn> given an [=attribution trigger=] |trigger|,
 run the following steps:
@@ -4291,15 +4298,15 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     with |trigger|.
 1. If |trigger|'s [=attribution trigger/event-level trigger configurations=]
     [=set/is empty=] and |hasAggregatableData| is false, return.
-1. Let |matchingSources| be the result of running [=find matching sources=] with |trigger|.
-1. If |matchingSources| [=list/is empty=]:
+1. Let |matchingSourcesResult| be the result of running [=find matching sources=] with |trigger|.
+1. Let |sourceToAttribute| be |matchingSourcesResult|[0].
+1. If |sourceToAttribute| is null:
     1. Run [=obtain and deliver debug reports on trigger registration=] with
         « ("<code>[=trigger debug data type/trigger-no-matching-source=]</code>", null) »,
         |trigger|, and [=obtain and deliver debug reports on trigger registration/sourceToAttribute=] set to null.
     1. If |hasAggregatableData| is true, then run [=generate null attribution reports=]
         with |trigger| and [=generate null attribution reports/report=] set to null.
     1. Return.
-1. Let |sourceToAttribute| be |matchingSources|[0].
 1. If the result of running
     [=match an attribution source against filters and negated filters=] with
     |sourceToAttribute|, |trigger|'s [=attribution trigger/filters=],
@@ -4311,8 +4318,7 @@ To <dfn noexport>trigger attribution</dfn> given an [=attribution trigger=] |tri
     1. If |hasAggregatableData| is true, then run [=generate null attribution reports=]
         with |trigger| and [=generate null attribution reports/report=] set to null.
     1. Return.
-1. [=list/Remove=] |sourceToAttribute| from |matchingSources|.
-1. [=list/iterate|For each=] |item| of |matchingSources|:
+1. [=list/iterate|For each=] |item| of |matchingSourcesResult|[1]:
     1. [=set/Remove=] |item| from the [=attribution source cache=].
 1. Let |eventLevelResult| be the result of running [=trigger event-level attribution=]
     with |trigger| and |sourceToAttribute|.


### PR DESCRIPTION
Getting rid of sorting with scopes to avoid confusion.

Also added a non-normative note about the rational deleting sources with non-matching scopes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1406.html" title="Last updated on Aug 31, 2024, 1:14 PM UTC (044f41f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1406/a9a53f5...linnan-github:044f41f.html" title="Last updated on Aug 31, 2024, 1:14 PM UTC (044f41f)">Diff</a>