### PR TITLE
Remove redundant inclusion of pending source in scope records

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3198,8 +3198,6 @@ To <dfn>remove associated event-level reports and rate-limit records</dfn> given
 To <dfn>remove sources with unselected attribution scopes for destination</dfn> given a [=site=] |destination| and an [=attribution source=] |pendingSource|:
 1. Let |scopeRecords| be a new [=list=].
 1. Let |scopes| be |pendingSource|'s [=attribution source/attribution scopes=]'s [=attribution scopes/values=].
-1. [=set/iterate|For each=] |scope| in |scopes|:
-    1. [=list/Append=] the [=tuple=] (|scope|, |pendingSource|) to |scopeRecords|.
 1. [=set/iterate|For each=] |source| of the [=attribution source cache=]:
     1. If |source|'s [=attribution source/reporting origin=] and |pendingSource|'s [=attribution source/reporting origin=] are not [=same origin=], [=iteration/continue=].
     1. If |source|'s [=attribution source/attribution destinations=] does not [=set/contain=] |destination|, [=iteration/continue=].


### PR DESCRIPTION
The intent of this algorithm is that the pending source is never rejected, but including it in the record list makes it seem like it can be removed; that is only prevented by the "if selectedScopes does not contain record[0]" check.

The pending source's scopes are already included in the selected scopes set, so processing the pending source in the scopeRecords loop is redundant: The insertions will not have effect (the value is already contained), and the containment check vacuously succeeds for the same reason.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1409.html" title="Last updated on Sep 4, 2024, 1:22 PM UTC (2d26cda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1409/7772278...apasel422:2d26cda.html" title="Last updated on Sep 4, 2024, 1:22 PM UTC (2d26cda)">Diff</a>