### PR TITLE
Fix type and reference errors in specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1018,9 +1018,9 @@ An <dfn>attribution debug info</dfn> is a [=tuple=] with the following items:
 
 <dl dfn-for="attribution debug info">
 : <dfn>source debug key</dfn>
-:: Null or a [=string=].
+:: Null or a non-negative 64-bit integer.
 : <dfn>trigger debug key</dfn>
-:: Null or a [=string=].
+:: Null or a non-negative 64-bit integer.
 
 </dl>
 
@@ -2227,7 +2227,7 @@ To <dfn>serialize an attribution debug info</dfn> given a [=map=] |data| and an
 1. If the result of [=checking if attribution debugging can be enabled=] with |debugInfo| is false, return.
 1. [=map/Set=] |data|["`source_debug_key`"] to |debugInfo|'s [=attribution debug info/source debug key=],
     [=serialize an integer|serialized=].
-1. [=map/Set=] |data|["`trigger_debug_key`"] to |report|'s [=attribution debug info/trigger debug key=],
+1. [=map/Set=] |data|["`trigger_debug_key`"] to |debugInfo|'s [=attribution debug info/trigger debug key=],
     [=serialize an integer|serialized=].
 
 Note: We require both source and trigger debug keys to be present to avoid
@@ -4212,7 +4212,7 @@ given a [=set=] of [=trigger debug data=] |dataSet|, an [=attribution trigger=] 
 and an optional [=attribution source=] |sourceToAttribute|:
 
 1. If |trigger|'s [=attribution trigger/fenced=] is true, return.
-1. Let |config| be |trigger|'s [attribution trigger/aggregatable debug reporting config=].
+1. Let |config| be |trigger|'s [=attribution trigger/aggregatable debug reporting config=].
 1. Let |debugDataMap| be |config|'s [=aggregatable debug reporting config/debug data=].
 1. If |debugDataMap| [=map/is empty=], return.
 1. Let |sourceKeyPiece| be 0.


### PR DESCRIPTION
Attribution debug info's fields should be non-negative 64-bit integers, rather than strings, as the rest of the specification treats them as such, delaying the string conversion until the report body is serialized.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1412.html" title="Last updated on Sep 4, 2024, 3:07 PM UTC (efef874)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1412/6821cda...apasel422:efef874.html" title="Last updated on Sep 4, 2024, 3:07 PM UTC (efef874)">Diff</a>