### PR TITLE
Fix broken link in specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3298,7 +3298,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Run [=obtain and deliver debug reports on source registration=] with
         "<code>[=source debug data type/source-destination-limit=]</code>" and |source|.
     1. Return.
-1. Let |destinationLimitReplaced| be true if |sourcesToDeleteForDestinationLimit| is not [=set/is empty|empty],
+1. Let |destinationLimitReplaced| be true if |sourcesToDeleteForDestinationLimit| is not [=set/is empty|empty=],
     otherwise false.
 1. Run [=delete sources for unexpired destination limit=] with |sourcesToDeleteForDestinationLimit| and |source|'s [=attribution source/source time=].
 1. [=Remove or update sources for attribution scopes=] with |source|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1416.html" title="Last updated on Sep 4, 2024, 3:55 PM UTC (2c3f2c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1416/311c662...apasel422:2c3f2c8.html" title="Last updated on Sep 4, 2024, 3:55 PM UTC (2c3f2c8)">Diff</a>