### PR TITLE
Limit 1 unique scopes set per navigation per reporting origin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2062,6 +2062,8 @@ or null |osSourceHeader|, a [=registration info=] |registrationInfo|, and a
                 with "`Attribution-Reporting-Register-Source`",
                 |webSourceHeader|, |reportingOrigin|, |contextOrigin|, and |fenced|.
             1. Return.
+        1. If |sourceType| is "<code>[=source type/navigation=]</code>", enforce
+            the [attribution-scope privacy limit](#attribution-scope).
         1. [=process an attribution source|Process=] |source|.
     : "<code>[=registrar/os=]</code>"
     ::
@@ -5383,8 +5385,8 @@ Possible mitigations:
 
 *This section is non-normative.*
 
-It is possible for an adversary to register multiple [=source type/navigation=] sources in response to a single navigation, and use these multiple sources, each with a different non-empty [=attribution source/attribution scopes=] value, to gain additional information about a user based on which attribution scope is chosen. To prevent this abuse the number of unique attribution scope sets per reporting origin per navigation needs to be limited.
+It is possible for an adversary to register multiple [=source type/navigation=] sources in response to a single navigation, and use these multiple sources, each with a different [=attribution source/attribution scopes=] value, to gain additional information about a user based on which attribution scope is chosen. To prevent this abuse the number of unique attribution scope sets per reporting origin per navigation needs to be limited.
 
 Proposed mitigation:
 
-Limit to 1 unique non-empty attribution scope set per reporting origin per navigation. Extraneous sources will be dropped.
+Limit to 1 unique attribution scope set per reporting origin per navigation. Extraneous sources will be dropped.


### PR DESCRIPTION
Previously we only enforce the limit for non-empty scopes set. It's easier to understand when empty scopes set is also considered.

Also make it clearer in what stage this limit is checked.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1427.html" title="Last updated on Sep 13, 2024, 12:38 AM UTC (d7adbeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1427/21d1eee...linnan-github:d7adbeb.html" title="Last updated on Sep 13, 2024, 12:38 AM UTC (d7adbeb)">Diff</a>