### PR TITLE
Enable Scopes Validation by Default

### DIFF
--- a/ts/src/header-validator/index.html
+++ b/ts/src/header-validator/index.html
@@ -85,7 +85,6 @@ textarea {
       <p><label><input type=radio name=header value=info><code>Attribution-Reporting-Info</code></label>
       <p><label><input type=checkbox checked disabled>Use Chromium's vendor-specific values</label> <a href="https://github.com/WICG/attribution-reporting-api/blob/main/params/chromium-params.md" target=_blank>(details)</a>
       <p><label><input type=checkbox name=flex>Enable experimental Flexible Event fields</label> <a href="https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md" target=_blank>(details)</a>
-      <p><label><input type=checkbox name=scopes>Enable experimental Attribution Scope fields</label> <a href="https://github.com/WICG/attribution-reporting-api/blob/main/attribution_scopes.md" target=_blank>(details)</a>
     </fieldset>
     <fieldset id=output>
       <legend>Validation Result</legend>

--- a/ts/src/header-validator/index.ts
+++ b/ts/src/header-validator/index.ts
@@ -23,7 +23,6 @@ const sourceTypeFieldset =
 const effective = document.querySelector('#effective')!
 
 const flexCheckbox = form.elements.namedItem('flex') as HTMLInputElement
-const scopesCheckbox = form.elements.namedItem('scopes') as HTMLInputElement
 
 function sourceType(): SourceType {
   return parseSourceType(sourceTypeRadios.value)
@@ -32,7 +31,6 @@ function sourceType(): SourceType {
 function validate(): void {
   sourceTypeFieldset.disabled = true
   flexCheckbox.disabled = true
-  scopesCheckbox.disabled = true
 
   let v: validator.Validator<unknown>
 
@@ -40,22 +38,18 @@ function validate(): void {
     case 'source':
       sourceTypeFieldset.disabled = false
       flexCheckbox.disabled = false
-      scopesCheckbox.disabled = false
       v = source.validator({
         vsv: vsv.Chromium,
         sourceType: sourceType(),
         fullFlex: flexCheckbox.checked,
-        scopes: scopesCheckbox.checked,
         noteInfoGain: true,
       })
       break
     case 'trigger':
       flexCheckbox.disabled = false
-      scopesCheckbox.disabled = false
       v = trigger.validator({
         vsv: vsv.Chromium,
         fullFlex: flexCheckbox.checked,
-        scopes: scopesCheckbox.checked,
       })
       break
     case 'os-source':
@@ -106,7 +100,6 @@ document.querySelector('#linkify')!.addEventListener('click', () => {
   }
 
   url.searchParams.set('flex', flexCheckbox.checked.toString())
-  url.searchParams.set('scopes', scopesCheckbox.checked.toString())
 
   void navigator.clipboard.writeText(url.toString())
 })
@@ -144,6 +137,5 @@ if (st !== null && st in SourceType) {
 sourceTypeRadios.value = st
 
 flexCheckbox.checked = params.get('flex') === 'true'
-scopesCheckbox.checked = params.get('scopes') === 'true'
 
 validate()

--- a/ts/src/header-validator/main.ts
+++ b/ts/src/header-validator/main.ts
@@ -12,7 +12,6 @@ interface Arguments {
   file?: string
 
   fullFlex: boolean
-  scopes: boolean
   sourceType?: SourceType
 
   silent: boolean
@@ -47,10 +46,6 @@ const options = parse<Arguments>(
     fullFlex: {
       type: Boolean,
       description: 'If true, parse experimental Full Flexible Event fields.',
-    },
-    scopes: {
-      type: Boolean,
-      description: 'If true, parse experimental Attribution Scopes fields.',
     },
 
     silent: {
@@ -100,13 +95,11 @@ const out = validate<unknown>(
     ? trigger.validator({
         vsv: vsv.Chromium,
         fullFlex: options.fullFlex,
-        scopes: options.scopes,
       })
     : source.validator({
         vsv: vsv.Chromium,
         fullFlex: options.fullFlex,
         sourceType: options.sourceType,
-        scopes: options.scopes,
       })
 )
 

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -52,7 +52,6 @@ const testCases: TestCase[] = [
       }
     }`,
     sourceType: SourceType.navigation,
-    parseScopes: true,
     expected: Maybe.some({
       aggregatableReportWindow: 3601,
       aggregationKeys: new Map([['a', 15n]]),
@@ -104,15 +103,11 @@ const testCases: TestCase[] = [
     name: 'unknown-field',
     input: `{
       "destination": "https://a.test",
-      "attribution_scopes": {
-        "values": false,
-        "limit": false,
-        "max_event_states": false
-      }
+      "x": true
     }`,
     expectedWarnings: [
       {
-        path: ['attribution_scopes'],
+        path: ['x'],
         msg: 'unknown field',
       },
     ],
@@ -1463,7 +1458,6 @@ const testCases: TestCase[] = [
       maxSettableEventLevelEpsilon: 14,
       maxTriggerStateCardinality: 2,
     },
-    parseScopes: true,
     expectedErrors: [
       {
         path: [],
@@ -1490,7 +1484,6 @@ const testCases: TestCase[] = [
       maxSettableEventLevelEpsilon: 14,
       maxTriggerStateCardinality: 3,
     },
-    parseScopes: true,
     expectedErrors: [
       {
         path: [],
@@ -1513,7 +1506,6 @@ const testCases: TestCase[] = [
       maxSettableEventLevelEpsilon: 14,
       maxTriggerStateCardinality: 3,
     },
-    parseScopes: false,
     expectedErrors: [
       {
         path: [],
@@ -2689,7 +2681,6 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "attribution_scopes": ["1"]
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes'],
@@ -2706,7 +2697,6 @@ const testCases: TestCase[] = [
         "values": ["1"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2727,7 +2717,6 @@ const testCases: TestCase[] = [
         "values": ["1"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2748,7 +2737,6 @@ const testCases: TestCase[] = [
         "values": ["1"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2769,7 +2757,6 @@ const testCases: TestCase[] = [
         "values": ["1"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2790,7 +2777,6 @@ const testCases: TestCase[] = [
         "values": []
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'values'],
@@ -2806,7 +2792,6 @@ const testCases: TestCase[] = [
         "values": ["1", "2"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2826,7 +2811,6 @@ const testCases: TestCase[] = [
         "limit": 3
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'values'],
@@ -2843,7 +2827,6 @@ const testCases: TestCase[] = [
         "limit": true
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'limit'],
@@ -2865,7 +2848,6 @@ const testCases: TestCase[] = [
         "max_event_states": -1
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'max_event_states'],
@@ -2883,7 +2865,6 @@ const testCases: TestCase[] = [
         "max_event_states": 0
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'max_event_states'],
@@ -2901,7 +2882,6 @@ const testCases: TestCase[] = [
         "max_event_states": 1.5
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'max_event_states'],
@@ -2918,7 +2898,6 @@ const testCases: TestCase[] = [
         "values": ["1", "2"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'values'],
@@ -2935,7 +2914,6 @@ const testCases: TestCase[] = [
         "values": [1]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be a string',
@@ -2952,7 +2930,6 @@ const testCases: TestCase[] = [
         "values": []
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be non-empty if limit is set',
@@ -2969,7 +2946,6 @@ const testCases: TestCase[] = [
         "values": 1
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         msg: 'must be a list',
@@ -2986,7 +2962,6 @@ const testCases: TestCase[] = [
         "values": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'values'],
@@ -3003,7 +2978,6 @@ const testCases: TestCase[] = [
         "values": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
       }
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 'values', 0],
@@ -3030,7 +3004,6 @@ const testCases: TestCase[] = [
       },
       maxSettableEventLevelEpsilon: 14,
     },
-    parseScopes: true,
     expectedErrors: [
       {
         path: [],
@@ -3071,7 +3044,6 @@ const testCases: TestCase[] = [
       },
       maxSettableEventLevelEpsilon: 14,
     },
-    parseScopes: true,
     expectedErrors: [
       {
         path: [],
@@ -3103,7 +3075,6 @@ testCases.forEach((tc) =>
       sourceType: tc.sourceType ?? SourceType.navigation,
       fullFlex: tc.parseFullFlex,
       noteInfoGain: tc.noteInfoGain,
-      scopes: tc.parseScopes,
     })
   )
 )

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -205,18 +205,12 @@ type Source = CommonDebug &
 
 export interface Options {
   fullFlex?: boolean | undefined
-  scopes?: boolean | undefined
 }
 
 export function serializeSource(
   s: source.Source,
   opts: Readonly<Options>
 ): string {
-  const scopeFields = opts.scopes
-    ? ifNotNull('attribution_scopes', s.attributionScopes, (v) =>
-        serializeAttributionScopes(v)
-      )
-    : {}
   const source: Source = {
     ...serializeCommonDebug(s),
     ...serializePriority(s),
@@ -249,7 +243,11 @@ export function serializeSource(
       s.aggregatableDebugReporting,
       (v) => serializeSourceAggregatableDebugReportingConfig(v)
     ),
-    ...scopeFields,
+    ...ifNotNull(
+      'attribution_scopes',
+      s.attributionScopes,
+      (v) => serializeAttributionScopes(v)
+    ),
   }
 
   return stringify(source)
@@ -389,12 +387,6 @@ export function serializeTrigger(
   t: trigger.Trigger,
   opts: Readonly<Options>
 ): string {
-  const scopeFields = opts.scopes
-    ? {
-        attribution_scopes: Array.from(t.attributionScopes),
-      }
-    : {}
-
   const trigger: Trigger = {
     ...serializeCommonDebug(t),
     ...serializeFilterPair(t),
@@ -432,7 +424,7 @@ export function serializeTrigger(
       (v) => serializeAggregatableDebugReportingConfig(v)
     ),
 
-    ...scopeFields,
+    attribution_scopes: Array.from(t.attributionScopes),
   }
 
   return stringify(trigger)

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -243,10 +243,8 @@ export function serializeSource(
       s.aggregatableDebugReporting,
       (v) => serializeSourceAggregatableDebugReportingConfig(v)
     ),
-    ...ifNotNull(
-      'attribution_scopes',
-      s.attributionScopes,
-      (v) => serializeAttributionScopes(v)
+    ...ifNotNull('attribution_scopes', s.attributionScopes, (v) =>
+      serializeAttributionScopes(v)
     ),
   }
 

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -49,7 +49,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       },
       "attribution_scopes": ["1"]
     }`,
-    parseScopes: true,
     expected: Maybe.some({
       aggregatableDedupKeys: [
         {
@@ -1629,7 +1628,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   {
     name: 'attribution-scope-not-string',
     input: `{"attribution_scopes": [1]}`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes', 0],
@@ -1639,7 +1637,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   },
   {
     name: 'attribution-scopes-empty-list',
-    parseScopes: true,
     input: `{
       "attribution_scopes": []
     }`,
@@ -1649,7 +1646,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     input: `{
       "attribution_scopes": 1
     }`,
-    parseScopes: true,
     expectedErrors: [
       {
         path: ['attribution_scopes'],
@@ -1728,7 +1724,6 @@ testCases.forEach((tc) =>
     trigger.validator({
       vsv: { ...vsv.Chromium, ...tc.vsv },
       fullFlex: tc.parseFullFlex,
-      scopes: tc.parseScopes,
     })
   )
 )

--- a/ts/src/header-validator/validate-json.test.ts
+++ b/ts/src/header-validator/validate-json.test.ts
@@ -4,5 +4,4 @@ import * as vsv from '../vendor-specific-values'
 export type TestCase<T> = testutil.TestCase<T> & {
   vsv?: Readonly<Partial<vsv.VendorSpecificValues>>
   parseFullFlex?: boolean
-  parseScopes?: boolean
 }

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -38,7 +38,6 @@ export const UINT32_MAX: number = 2 ** 32 - 1
 export interface RegistrationOptions {
   vsv: VendorSpecificValues
   fullFlex?: boolean | undefined
-  scopes?: boolean | undefined
 }
 
 export class RegistrationContext<

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -726,7 +726,8 @@ function source(j: Json, ctx: Context): Maybe<Source> {
         ),
         attributionScopes: field(
           'attribution_scopes',
-          withDefault(attributionScopes, null)),
+          withDefault(attributionScopes, null)
+        ),
 
         ...commonDebugFields,
         ...priorityField,

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -724,9 +724,9 @@ function source(j: Json, ctx: Context): Maybe<Source> {
           'destination_limit_priority',
           withDefault(int64, 0n)
         ),
-        attributionScopes: ctx.opts.scopes
-          ? field('attribution_scopes', withDefault(attributionScopes, null))
-          : () => Maybe.some(null),
+        attributionScopes: field(
+          'attribution_scopes',
+          withDefault(attributionScopes, null)),
 
         ...commonDebugFields,
         ...priorityField,

--- a/ts/src/header-validator/validate-trigger.ts
+++ b/ts/src/header-validator/validate-trigger.ts
@@ -399,13 +399,11 @@ function trigger(j: Json, ctx: Context): Maybe<Trigger> {
           withDefault(struct, null),
           aggregatableDebugReportingConfig
         ),
-        attributionScopes: ctx.opts.scopes
-          ? field(
-              'attribution_scopes',
-              withDefault(set, new Set<string>()),
-              string
-            )
-          : () => Maybe.some(new Set<string>()),
+        attributionScopes: field(
+          'attribution_scopes',
+          withDefault(set, new Set<string>()),
+          string
+        ),
         ...aggregationCoordinatorOriginField,
         ...commonDebugFields,
         ...filterFields,


### PR DESCRIPTION
With scopes now finalized, we can safely enable its behavior by default.