### PR TITLE
Use bit search for max epsilon

### DIFF
--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -119,7 +119,7 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
           numStates,
           infoGainUpper,
           epsilonUpper,
-          0.00000000000001
+          1e-14
         )
 
         const epsilonByBitSearch = epsilonToBoundInfoGainAndDp(
@@ -129,12 +129,66 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
         )
 
         assert(epsilonByBitSearch >= epsilonByBinarySearch)
-
-        if (epsilonByBitSearch > epsilonByBinarySearch) {
-          assert(
-            maxInformationGain(numStates, epsilonByBitSearch) <= infoGainUpper
-          )
+        assert(
+          maxInformationGain(numStates, epsilonByBitSearch) <= infoGainUpper
+        )
+        if (epsilonByBitSearch < epsilonUpper) {
+          assert(maxInformationGain(numStates, epsilonByBitSearch + 1e-15)
+                 > infoGainUpper)
         }
+      })
+    )
+  )
+})
+
+const epsilonSearchTests = [
+  {
+    numStates: 5545,
+    infoGainUpper: 6.5,
+    epsilonUpper: 14,
+    expected: 9.028709123768687,
+  },
+  {
+    numStates: 2106,
+    infoGainUpper: 6.5,
+    epsilonUpper: 14,
+    expected: 8.366900276574821,
+  },
+  {
+    numStates: 16036,
+    infoGainUpper: 6.5,
+    epsilonUpper: 14,
+    expected: 9.829279343808693,
+  },
+  {
+    numStates: 84121,
+    infoGainUpper: 11.5,
+    epsilonUpper: 14,
+    expected: 12.45087042924698,
+  },
+  {
+    numStates: 24895,
+    infoGainUpper: 11.5,
+    epsilonUpper: 14,
+    expected: 11.723490703852157,
+  },
+  {
+    numStates: 3648,
+    infoGainUpper: 11.5,
+    epsilonUpper: 14,
+    expected: 12.233993328032184,
+  },
+]
+
+void test('epsilonSearch', async (t) => {
+  await Promise.all(
+    epsilonSearchTests.map((tc) =>
+      t.test(`${tc.numStates}, ${tc.infoGainUpper}, ${tc.epsilonUpper}`, () => {
+        assert.deepStrictEqual(tc.expected, epsilonToBoundInfoGainAndDp(
+          tc.numStates,
+          tc.infoGainUpper,
+          tc.epsilonUpper
+        ))
       })
     )
   )

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -10,7 +10,7 @@ import {
   flipProbabilityDp,
   maxInformationGain,
   epsilonToBoundInfoGainAndDp,
-  epsilonToBoundInfoGainAndDpBinarySearch
+  epsilonToBoundInfoGainAndDpBinarySearch,
 } from './privacy'
 
 const flipProbabilityTests = [
@@ -109,26 +109,29 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const numStatesRange = 100000
 
   await Promise.all(
-    [...Array(500).keys()].map(i =>
-      t.test(`${ i }`, () => {
+    [...Array(500).keys()].map((i) =>
+      t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())] || 11.5
 
         const epsilonByBinarySearch = epsilonToBoundInfoGainAndDpBinarySearch(
           numStates,
           infoGainUpper,
-          epsilonUpper)
+          epsilonUpper
+        )
 
         const epsilonByBitSearch = epsilonToBoundInfoGainAndDp(
           numStates,
           infoGainUpper,
-          epsilonUpper)
+          epsilonUpper
+        )
 
         assert(epsilonByBitSearch >= epsilonByBinarySearch)
 
         if (epsilonByBitSearch > epsilonByBinarySearch) {
-            assert(maxInformationGain(numStates, epsilonByBitSearch)
-                   <= infoGainUpper)
+          assert(
+            maxInformationGain(numStates, epsilonByBitSearch) <= infoGainUpper
+          )
         }
       })
     )

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -133,8 +133,10 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
           maxInformationGain(numStates, epsilonByBitSearch) <= infoGainUpper
         )
         if (epsilonByBitSearch < epsilonUpper) {
-          assert(maxInformationGain(numStates, epsilonByBitSearch + 1e-15)
-                 > infoGainUpper)
+          assert(
+            maxInformationGain(numStates, epsilonByBitSearch + 1e-15) >
+              infoGainUpper
+          )
         }
       })
     )
@@ -184,11 +186,14 @@ void test('epsilonSearch', async (t) => {
   await Promise.all(
     epsilonSearchTests.map((tc) =>
       t.test(`${tc.numStates}, ${tc.infoGainUpper}, ${tc.epsilonUpper}`, () => {
-        assert.deepStrictEqual(tc.expected, epsilonToBoundInfoGainAndDp(
-          tc.numStates,
-          tc.infoGainUpper,
-          tc.epsilonUpper
-        ))
+        assert.deepStrictEqual(
+          tc.expected,
+          epsilonToBoundInfoGainAndDp(
+            tc.numStates,
+            tc.infoGainUpper,
+            tc.epsilonUpper
+          )
+        )
       })
     )
   )

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -118,7 +118,8 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
         const epsilonByBinarySearch = epsilonToBoundInfoGainAndDpBinarySearch(
           numStates,
           infoGainUpper,
-          epsilonUpper
+          epsilonUpper,
+          0.00000000000001
         )
 
         const epsilonByBitSearch = epsilonToBoundInfoGainAndDp(

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -9,6 +9,8 @@ import {
   binaryEntropy,
   flipProbabilityDp,
   maxInformationGain,
+  epsilonToBoundInfoGainAndDp,
+  epsilonToBoundInfoGainAndDpBinarySearch
 } from './privacy'
 
 const flipProbabilityTests = [
@@ -96,6 +98,38 @@ void test('maxInformationGain', async (t) => {
       t.test(`${i}`, () => {
         const actual = maxInformationGain(tc.numStates, tc.epsilon)
         assert.deepStrictEqual(actual, tc.expected)
+      })
+    )
+  )
+})
+
+void test('epsilonToBoundInfoGainAndDp', async (t) => {
+  const infoGainUppers = [11.5, 6.5]
+  const epsilonUpper = 14
+  const numStatesRange = 100000
+
+  await Promise.all(
+    [...Array(500).keys()].map(i =>
+      t.test(`${ i }`, () => {
+        const numStates = Math.ceil(Math.random() * numStatesRange)
+        const infoGainUpper = infoGainUppers[Math.round(Math.random())] || 11.5
+
+        const epsilonByBinarySearch = epsilonToBoundInfoGainAndDpBinarySearch(
+          numStates,
+          infoGainUpper,
+          epsilonUpper)
+
+        const epsilonByBitSearch = epsilonToBoundInfoGainAndDp(
+          numStates,
+          infoGainUpper,
+          epsilonUpper)
+
+        assert(epsilonByBitSearch >= epsilonByBinarySearch)
+
+        if (epsilonByBitSearch > epsilonByBinarySearch) {
+            assert(maxInformationGain(numStates, epsilonByBitSearch)
+                   <= infoGainUpper)
+        }
       })
     )
   )

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -107,9 +107,10 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const infoGainUppers = [11.5, 6.5]
   const epsilonUpper = 14
   const numStatesRange = 100000
+  const numTests = 500
 
   await Promise.all(
-    [...Array(500).keys()].map((i) =>
+    [...Array(numTests).keys()].map((i) =>
       t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())] || 11.5

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -113,7 +113,7 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
     [...Array(numTests).keys()].map((i) =>
       t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
-        const infoGainUpper = infoGainUppers[Math.round(Math.random())] || 11.5
+        const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
 
         const epsilonByBinarySearch = epsilonToBoundInfoGainAndDpBinarySearch(
           numStates,

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -109,7 +109,7 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const numTests = 500
 
   await Promise.all(
-    [...Array(numTests).keys()].map((i) =>
+    Array(numTests).map((_, i) =>
       t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())]!

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -109,7 +109,7 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const numTests = 500
 
   await Promise.all(
-    [...Array(numTests).keys()].map((i) =>
+    Array(numTests).fill(0).map((_, i) =>
       t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())]!

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -109,24 +109,28 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const numTests = 500
 
   await Promise.all(
-    Array(numTests).fill(0).map((_, i) =>
-      t.test(`${i}`, () => {
-        const numStates = Math.ceil(Math.random() * numStatesRange)
-        const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
+    Array(numTests)
+      .fill(0)
+      .map((_, i) =>
+        t.test(`${i}`, () => {
+          const numStates = Math.ceil(Math.random() * numStatesRange)
+          const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
 
-        const epsilon = epsilonToBoundInfoGainAndDp(
-          numStates,
-          infoGainUpper,
-          epsilonUpper
-        )
+          const epsilon = epsilonToBoundInfoGainAndDp(
+            numStates,
+            infoGainUpper,
+            epsilonUpper
+          )
 
-        assert(maxInformationGain(numStates, epsilon) <= infoGainUpper)
+          assert(maxInformationGain(numStates, epsilon) <= infoGainUpper)
 
-        if (epsilon < epsilonUpper) {
-          assert(maxInformationGain(numStates, epsilon + 1e-15) > infoGainUpper)
-        }
-      })
-    )
+          if (epsilon < epsilonUpper) {
+            assert(
+              maxInformationGain(numStates, epsilon + 1e-15) > infoGainUpper
+            )
+          }
+        })
+      )
   )
 })
 

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -109,7 +109,7 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const numTests = 500
 
   await Promise.all(
-    Array(numTests).map((_, i) =>
+    [...Array(numTests).keys()].map((i) =>
       t.test(`${i}`, () => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())]!

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -10,7 +10,6 @@ import {
   flipProbabilityDp,
   maxInformationGain,
   epsilonToBoundInfoGainAndDp,
-  epsilonToBoundInfoGainAndDpBinarySearch,
 } from './privacy'
 
 const flipProbabilityTests = [
@@ -115,28 +114,16 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
         const numStates = Math.ceil(Math.random() * numStatesRange)
         const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
 
-        const epsilonByBinarySearch = epsilonToBoundInfoGainAndDpBinarySearch(
-          numStates,
-          infoGainUpper,
-          epsilonUpper,
-          1e-14
-        )
-
-        const epsilonByBitSearch = epsilonToBoundInfoGainAndDp(
+        const epsilon = epsilonToBoundInfoGainAndDp(
           numStates,
           infoGainUpper,
           epsilonUpper
         )
 
-        assert(epsilonByBitSearch >= epsilonByBinarySearch)
-        assert(
-          maxInformationGain(numStates, epsilonByBitSearch) <= infoGainUpper
-        )
-        if (epsilonByBitSearch < epsilonUpper) {
-          assert(
-            maxInformationGain(numStates, epsilonByBitSearch + 1e-15) >
-              infoGainUpper
-          )
+        assert(maxInformationGain(numStates, epsilon) <= infoGainUpper)
+
+        if (epsilon < epsilonUpper) {
+          assert(maxInformationGain(numStates, epsilon + 1e-15) > infoGainUpper)
         }
       })
     )

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -223,7 +223,7 @@ export function epsilonToBoundInfoGainAndDp(
   epsilonUpperBound: number
 ): number {
   // Calculate epsilon to double precision.
-  const candidate: number[] = new Array(64).fill(0)
+  const candidate: number[] = new Array<number>(64).fill(0)
   let epsilon = 0
 
   for (let i = 1; i < 64; i++) {

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -223,7 +223,7 @@ export function epsilonToBoundInfoGainAndDp(
   epsilonUpperBound: number
 ): number {
   // Calculate epsilon to double precision.
-  const candidate = new Array(64).fill(0)
+  const candidate: number[] = new Array(64).fill(0)
   let epsilon = 0
 
   for (let i = 1; i < 64; i++) {

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -184,7 +184,7 @@ export function maxInformationGain(numStates: number, epsilon: number): number {
 
 // Returns the effective epsilon needed to satisfy an information gain bound
 // given a number of output states in the q-ary symmetric channel.
-function epsilonToBoundInfoGainAndDp(
+export function epsilonToBoundInfoGainAndDpBinarySearch(
   numStates: number,
   infoGainUpperBound: number,
   epsilonUpperBound: number,
@@ -213,4 +213,45 @@ function epsilonToBoundInfoGainAndDp(
 
     return epsilon
   }
+}
+
+// Returns the effective epsilon needed to satisfy an information gain bound
+// given a number of output states in the q-ary symmetric channel.
+export function epsilonToBoundInfoGainAndDp(
+  numStates: number,
+  infoGainUpperBound: number,
+  epsilonUpperBound: number
+): number {
+  // Calculate epsilon to double precision.
+  const candidate = new Array(64).fill(0)
+  let epsilon = 0
+
+  for (let i = 1; i < 64; i++) {
+    candidate[i] = 1
+
+    epsilon = binaryToDouble(candidate)
+    if (epsilon > epsilonUpperBound) {
+      candidate[i] = 0
+      continue
+    }
+
+    const infoGain = maxInformationGain(numStates, epsilon)
+
+    if (infoGain > infoGainUpperBound) {
+      candidate[i] = 0
+
+    } else if (epsilon == epsilonUpperBound) {
+      return epsilon
+    }
+  }
+
+  return binaryToDouble(candidate)
+}
+
+function binaryToDouble(binaryArray: number[]): number {
+    const exponentBias = 1023
+    const sign = binaryArray[0] == 1 ? -1 : 1
+    const exponent = parseInt(binaryArray.slice(1, 12).join(''), 2)
+    const fraction = parseInt('1' + binaryArray.slice(12, 64).join(''), 2)
+    return sign * Math.pow(2, exponent - exponentBias - 52) * fraction
 }

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -184,39 +184,24 @@ export function maxInformationGain(numStates: number, epsilon: number): number {
 
 // Returns the effective epsilon needed to satisfy an information gain bound
 // given a number of output states in the q-ary symmetric channel.
-export function epsilonToBoundInfoGainAndDpBinarySearch(
-  numStates: number,
-  infoGainUpperBound: number,
-  epsilonUpperBound: number,
-  tolerance: number = 0.00001
-): number {
-  // Just perform a simple binary search over values of epsilon.
-  let epsLow = 0
-  let epsHigh = epsilonUpperBound
-
-  for (;;) {
-    const epsilon = (epsHigh + epsLow) / 2
-    const infoGain = maxInformationGain(numStates, epsilon)
-
-    if (infoGain > infoGainUpperBound) {
-      epsHigh = epsilon
-      continue
-    }
-
-    // Allow slack by returning something slightly non-optimal (governed by the tolerance)
-    // that still meets the privacy bar. If epsHigh == epsLow we're now governed by the epsilon
-    // bound and can return.
-    if (infoGain < infoGainUpperBound - tolerance && epsHigh !== epsLow) {
-      epsLow = epsilon
-      continue
-    }
-
-    return epsilon
-  }
-}
-
-// Returns the effective epsilon needed to satisfy an information gain bound
-// given a number of output states in the q-ary symmetric channel.
+//
+// The exponent section of the double is used as a power with base 2, which is
+// multiplied by the significand, which is at least 1 and less than 2. In our
+// case, the sign bit remains unset since we use a positive epsilon. The double
+// is 2^exponent * significand. Since the significand is at least 1, changing it
+// can only lower 2^exponent to at least its own value. And since the
+// significand is less than 2, changing it can only raise 2^exponent to a value
+// less than 2^(exponent + 1). We can therefore first find the highest
+// 2^exponent less than or equal to max-settable-event-level-epsilon that
+// produces information gain within limit, and then search for a significand
+// that raises the overall value as much as possible.
+//
+// In an additive binary representation, the value represented by one bit is
+// higher than all the values added by lower bits together. This inequality
+// holds when multiplying by the constant, 2^exponent. This means that if we
+// search the significand from high bits to low, each choice to set a bit either
+// is already too high, or provides the opportunity to get closer to a higher
+// target using some combination of the lower bits.
 export function epsilonToBoundInfoGainAndDp(
   numStates: number,
   infoGainUpperBound: number,

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -239,7 +239,6 @@ export function epsilonToBoundInfoGainAndDp(
 
     if (infoGain > infoGainUpperBound) {
       candidate[i] = 0
-
     } else if (epsilon == epsilonUpperBound) {
       return epsilon
     }
@@ -249,9 +248,9 @@ export function epsilonToBoundInfoGainAndDp(
 }
 
 function binaryToDouble(binaryArray: number[]): number {
-    const exponentBias = 1023
-    const sign = binaryArray[0] == 1 ? -1 : 1
-    const exponent = parseInt(binaryArray.slice(1, 12).join(''), 2)
-    const fraction = parseInt('1' + binaryArray.slice(12, 64).join(''), 2)
-    return sign * Math.pow(2, exponent - exponentBias - 52) * fraction
+  const exponentBias = 1023
+  const sign = binaryArray[0] == 1 ? -1 : 1
+  const exponent = parseInt(binaryArray.slice(1, 12).join(''), 2)
+  const fraction = parseInt('1' + binaryArray.slice(12, 64).join(''), 2)
+  return sign * Math.pow(2, exponent - exponentBias - 52) * fraction
 }


### PR DESCRIPTION
Bit search can yield higher precision than binary search in constant time and
avoid the use of a tolerance.
