### PR TITLE
Set trigger-aggregate-insufficient-budget verbose debug report limit to the remaining budget

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3905,7 +3905,7 @@ a possibly null [=attribution source=] |sourceToAttribute|, and a possibly null
     :: [=map/Set=] |body|["`limit`"] to [=max aggregatable attribution reports per attribution destination=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-aggregate-insufficient-budget=]</code>"
-    :: [=map/Set=] |body|["`limit`"] to [=allowed aggregatable budget per source=],
+    :: [=map/Set=] |body|["`limit`"] to |sourceToAttribute|'s [=attribution source/remaining aggregatable attribution budget=],
          [=serialize an integer|serialized=].
     : "<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>"
     :: [=map/Set=] |body|["`limit`"] to [=max aggregatable reports per source=][0],


### PR DESCRIPTION
Fixes #1431


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1432.html" title="Last updated on Sep 16, 2024, 6:15 PM UTC (a8d678a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1432/6b5bd70...linnan-github:a8d678a.html" title="Last updated on Sep 16, 2024, 6:15 PM UTC (a8d678a)">Diff</a>