### PR TITLE
Remove aggregation key identifier size limit for trigger registrations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1356,9 +1356,7 @@ controls the maximum [=map/size=] of an [=attribution source=]'s
 
 <dfn>Max length per aggregation key identifier</dfn> is a positive integer that controls
 the maximum [=string/length=] of an [=attribution source=]'s [=attribution source/aggregation keys=]'s
-[=map/keys=], an [=attribution trigger=]'s [=attribution trigger/aggregatable values configurations=]'s [=list/item=]'s
-[=aggregatable values configuration/values=]'s [=map/keys=], and an [=aggregatable trigger data=]'s
-[=aggregatable trigger data/source keys=]'s [=set/items=]. Its value is 25.
+[=map/keys=]. Its value is 25.
 
 <dfn>Default trigger data cardinality</dfn> is a [=map=] that
 controls the valid range of [=event-level trigger configuration/trigger data=].
@@ -3482,8 +3480,6 @@ To <dfn>parse aggregatable trigger data</dfn> given a [=map=] |map|:
         1. If |value|["<code>[=trigger-registration JSON key/source_keys=]</code>"] is not a [=list=], return an error.
         1. [=list/iterate|For each=] |sourceKey| of |value|["<code>[=trigger-registration JSON key/source_keys=]</code>"]:
             1. If |sourceKey| is not a [=string=], return an error.
-            1. If |sourceKey|'s [=string/length=] is greater than the
-                [=max length per aggregation key identifier=], return an error.
             1. [=set/Append=] |sourceKey| to |sourceKeys|.
     1. Let |filterPair| be the result of running [=parse a filter pair=] with
         |value|.
@@ -3520,8 +3516,6 @@ To <dfn>parse aggregatable key-values</dfn> given a [=map=] |map| and a positive
 
 1. Let |out| be a new [=map=].
 1. [=map/iterate|For each=] |key| → |value| of |map|:
-    1. If |key|'s [=string/length=] is greater than the [=max length per aggregation key identifier=],
-        return an error.
     1. If |value| is not a [=map=] or an integer, return an error.
     1. If |value| is an integer:
         1. If the result of running [=validate aggregatable key-values value=] with |value| is false, return an error.

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -416,16 +416,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     ],
   },
   {
-    name: 'aggregatable-values-key-too-long',
-    input: `{"aggregatable_values": {"aaaaaaaaaaaaaaaaaaaaaaaaaa": 1}}`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_values', 'aaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        msg: 'key exceeds max length per aggregation key identifier (26 > 25)',
-      },
-    ],
-  },
-  {
     name: 'aggregatable-values-list-values-field-missing',
     input: `{
       "aggregatable_values": [
@@ -832,19 +822,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_trigger_data', 0, 'source_keys', 2],
         msg: 'duplicate value a',
-      },
-    ],
-  },
-  {
-    name: 'source-keys-key-too-long',
-    input: `{"aggregatable_trigger_data": [{
-      "key_piece": "0x1",
-      "source_keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaa"]
-    }]}`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_trigger_data', 0, 'source_keys', 0],
-        msg: 'exceeds max length per aggregation key identifier (26 > 25)',
       },
     ],
   },

--- a/ts/src/header-validator/validate-trigger.ts
+++ b/ts/src/header-validator/validate-trigger.ts
@@ -27,7 +27,6 @@ import {
   aggregatableDebugReportingConfig,
   aggregatableKeyValueValue,
   aggregationCoordinatorOriginField,
-  aggregationKeyIdentifierLength,
   array,
   commonDebugFields,
   enumerated,
@@ -108,9 +107,7 @@ const dedupKeyField: StructFields<DedupKey, Context> = {
 }
 
 function sourceKeys(j: Json, ctx: Context): Maybe<Set<string>> {
-  return set(j, ctx, (j) =>
-    string(j, ctx).filter(aggregationKeyIdentifierLength, ctx)
-  )
+  return set(j, ctx, string)
 }
 
 function aggregatableTriggerData(
@@ -151,14 +148,10 @@ function aggregatableKeyValueFilteringId(
 }
 
 function aggregatableKeyValue(
-  [key, j]: [string, Json],
+  [, j]: [string, Json],
   ctx: Context,
   maxBytes: Maybe<number>
 ): Maybe<AggregatableValuesValue> {
-  if (!aggregationKeyIdentifierLength(key, ctx, 'key ')) {
-    return Maybe.None
-  }
-
   return typeSwitch(j, ctx, {
     number: (j) =>
       aggregatableKeyValueValue(j, ctx).map((j) => ({


### PR DESCRIPTION
Fixes #1434


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1435.html" title="Last updated on Sep 17, 2024, 3:50 PM UTC (23665eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1435/6c726d4...linnan-github:23665eb.html" title="Last updated on Sep 17, 2024, 3:50 PM UTC (23665eb)">Diff</a>