### PR TITLE
Clean up epsilonToBoundInfoGainAndDp

### DIFF
--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -106,32 +106,30 @@ void test('epsilonToBoundInfoGainAndDp', async (t) => {
   const infoGainUppers = [11.5, 6.5]
   const epsilonUpper = 14
   const numStatesRange = 100000
-  const numTests = 500
 
-  await Promise.all(
-    Array(numTests)
-      .fill(0)
-      .map((_, i) =>
-        t.test(`${i}`, () => {
-          const numStates = Math.ceil(Math.random() * numStatesRange)
-          const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
+  const subTests = []
+  for (let i = 0; i < 500; ++i) {
+    subTests.push(
+      t.test(`${i}`, () => {
+        const numStates = Math.ceil(Math.random() * numStatesRange)
+        const infoGainUpper = infoGainUppers[Math.round(Math.random())]!
 
-          const epsilon = epsilonToBoundInfoGainAndDp(
-            numStates,
-            infoGainUpper,
-            epsilonUpper
-          )
+        const epsilon = epsilonToBoundInfoGainAndDp(
+          numStates,
+          infoGainUpper,
+          epsilonUpper
+        )
 
-          assert(maxInformationGain(numStates, epsilon) <= infoGainUpper)
+        assert(maxInformationGain(numStates, epsilon) <= infoGainUpper)
 
-          if (epsilon < epsilonUpper) {
-            assert(
-              maxInformationGain(numStates, epsilon + 1e-15) > infoGainUpper
-            )
-          }
-        })
-      )
-  )
+        if (epsilon < epsilonUpper) {
+          assert(maxInformationGain(numStates, epsilon + 1e-15) > infoGainUpper)
+        }
+      })
+    )
+  }
+
+  await Promise.all(subTests)
 })
 
 const epsilonSearchTests = [

--- a/ts/src/flexible-event/privacy.ts
+++ b/ts/src/flexible-event/privacy.ts
@@ -211,18 +211,19 @@ export function epsilonToBoundInfoGainAndDp(
   const dataView = new DataView(buffer)
 
   for (let bit = 1n << 62n; bit > 0n; bit >>= 1n) {
-    dataView.setBigUint64(0, dataView.getBigUint64(0) | bit)
+    const withoutBit = dataView.getBigUint64(0)
+    dataView.setBigUint64(0, withoutBit | bit)
 
     const epsilon = dataView.getFloat64(0)
     if (epsilon > epsilonUpperBound) {
-      dataView.setBigUint64(0, dataView.getBigUint64(0) & ~bit)
+      dataView.setBigUint64(0, withoutBit)
       continue
     }
 
     const infoGain = maxInformationGain(numStates, epsilon)
 
     if (infoGain > infoGainUpperBound) {
-      dataView.setBigUint64(0, dataView.getBigUint64(0) & ~bit)
+      dataView.setBigUint64(0, withoutBit)
     } else if (epsilon === epsilonUpperBound) {
       return epsilon
     }


### PR DESCRIPTION
- Avoid unnecessary bit operations resulting in bigint construction
- Avoid unnecessary array construction in tests