### PR TITLE
Remove ar_debug requirement for cookie-based debug reporting

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -260,7 +260,7 @@ The report will be JSON encoded with the following scheme:
       "payload": "[base64-encoded HPKE encrypted data readable only by the aggregation service]",
       "key_id": "[string identifying public key used to encrypt payload]",
 
-      // Optional debugging information, if the cookie `ar_debug` is present.
+      // Optional debugging information, if cookie-based debugging is allowed.
       "debug_cleartext_payload": "[base64-encoded unencrypted payload]",
     },
   ],
@@ -269,7 +269,7 @@ The report will be JSON encoded with the following scheme:
   "aggregation_coordinator_origin": "https://publickeyservice.msmt.aws.privacysandboxservices.com",
 
   // Optional debugging information (also present in event-level reports),
-  // if the cookie `ar_debug` is present.
+  // if cookie-based debugging is allowed.
   "source_debug_key": "[64 bit unsigned integer]",
   "trigger_debug_key": "[64 bit unsigned integer]",
 

--- a/EVENT.md
+++ b/EVENT.md
@@ -725,27 +725,13 @@ fully understood during roll-out and help flush out any bugs (either in browser
 or caller code), and more easily compare the performance to cookie-based
 alternatives.
 
-To ensure that this data (which could enable cross-site tracking) is only
-available in a transitional phase while third-party cookies are available and
-are already capable of user tracking, the browser will check (at both source
-and trigger registration) for the presence of a special cookie
-set by the reporting origin:
-```http
-Set-Cookie: ar_debug=1; SameSite=None; Secure; HttpOnly
-```
-If a cookie of this form is not present, debugging information will be ignored. Additionally,
-browsers may choose to enable debugging for specific use-cases (for example, reporting origins
+The debugging information will only be available while third-party cookies are
+available and are already capable of user tracking, and will be ignored if
+third-party cookies are disabled/deprecated generally or for a particular site.
+
+Additionally, browsers may choose to enable debugging for specific use-cases (for example, reporting origins
 can enable debugging without the cookie check for
 [Mode B groups during Chrome-facilitated testing](https://developers.google.com/privacy-sandbox/setup/web/chrome-facilitated-testing#mode-b)). 
-
-Note that in the context of proposals such as
-[CHIPS](https://github.com/privacycg/CHIPS), the cookie must be unpartitioned in
-order to allow debug keys to be registered.
-
-Responses that register sources/triggers can also set the `ar_debug` cookie to
-ensure that registration is eligible for debug reports. When using the `fetch`
-APIs to do this, it will require ensuring the request is allowed to include
-[`credentials`](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
 
 #### Attribution-success debugging reports
 
@@ -818,8 +804,9 @@ The debugging reports will be sent to a new endpoint:
 https://<reporting origin>/.well-known/attribution-reporting/debug/verbose
 ```
 
-In order to receive verbose debug reports on trigger registrations, the special
-`ar_debug` cookie needs to be present for both source and trigger registrations.
+In order to receive verbose debug reports on trigger registrations, at both
+source and trigger registration times, the reporting origin needs to be able to
+access third-party cookies on the corresponding context site.
 
 TODO: Consider adding support for the top-level site to opt in to receiving
 debug reports without cross-site leak.

--- a/EVENT.md
+++ b/EVENT.md
@@ -726,7 +726,7 @@ or caller code), and more easily compare the performance to cookie-based
 alternatives.
 
 The debugging information will only be available if third-party cookies are
-available for current site, and will be ignored if
+available for the current site, and will be ignored if
 third-party cookies are disabled generally or for a particular site.
 
 Additionally, browsers may choose to enable debugging for specific use-cases (for example, reporting origins
@@ -807,7 +807,7 @@ https://<reporting origin>/.well-known/attribution-reporting/debug/verbose
 In order to receive verbose debug reports on trigger registrations, the
 reporting origin needs to be able to access third-party cookies on the
 destination site. If the trigger is attributed to a source, the reporting
-origin also needs to be able to access third-party cookies on the source site
+origin also needed to be able to access third-party cookies on the source site
 at the time of source registration.
 
 TODO: Consider adding support for the top-level site to opt in to receiving

--- a/EVENT.md
+++ b/EVENT.md
@@ -725,9 +725,9 @@ fully understood during roll-out and help flush out any bugs (either in browser
 or caller code), and more easily compare the performance to cookie-based
 alternatives.
 
-The debugging information will only be available while third-party cookies are
-available and are already capable of user tracking, and will be ignored if
-third-party cookies are disabled/deprecated generally or for a particular site.
+The debugging information will only be available if third-party cookies are
+available for current site, and will be ignored if
+third-party cookies are disabled generally or for a particular site.
 
 Additionally, browsers may choose to enable debugging for specific use-cases (for example, reporting origins
 can enable debugging without the cookie check for

--- a/EVENT.md
+++ b/EVENT.md
@@ -804,9 +804,11 @@ The debugging reports will be sent to a new endpoint:
 https://<reporting origin>/.well-known/attribution-reporting/debug/verbose
 ```
 
-In order to receive verbose debug reports on trigger registrations, at both
-source and trigger registration times, the reporting origin needs to be able to
-access third-party cookies on the corresponding context site.
+In order to receive verbose debug reports on trigger registrations, the
+reporting origin needs to be able to access third-party cookies on the
+destination site. If the trigger is attributed to a source, the reporting
+origin also needs to be able to access third-party cookies on the source site
+at the time of source registration.
 
 TODO: Consider adding support for the top-level site to opt in to receiving
 debug reports without cross-site leak.

--- a/EVENT.md
+++ b/EVENT.md
@@ -725,8 +725,8 @@ fully understood during roll-out and help flush out any bugs (either in browser
 or caller code), and more easily compare the performance to cookie-based
 alternatives.
 
-The debugging information will only be available if third-party cookies are
-available for the current site, and will be ignored if
+Debugging will only be permitted if third-party cookies are
+available for the current site, and will be prohibited if
 third-party cookies are disabled generally or for a particular site.
 
 Additionally, browsers may choose to enable debugging for specific use-cases (for example, reporting origins

--- a/index.bs
+++ b/index.bs
@@ -842,7 +842,7 @@ An attribution source is a [=struct=] with the following items:
 :: Number of [=aggregatable attribution reports=] created for this [=attribution source=].
 : <dfn>trigger-data matching mode</dfn>
 :: A [=trigger-data matching mode=].
-: <dfn>debug cookie set</dfn> (default false)
+: <dfn>cookie-based debug allowed</dfn> (default false)
 :: A [=boolean=].
 : <dfn>fenced</dfn>
 :: A [=boolean=].
@@ -1819,28 +1819,7 @@ To <dfn>check if cookie-based debugging is allowed</dfn> given a
     or <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-user controls">user controls</a>
     do not allow cookie access for |domain| on |contextDomain| within a <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-third-party-cookies">third-party context</a>,
     return <strong>blocked</strong>.
-1. For each |cookie| of the user agent's <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-storage-model">cookie store</a>:
-    1. If |cookie|'s name is not "`ar_debug`", [=iteration/continue=].
-    1. If |cookie|'s http-only-flag is false, [=iteration/continue=].
-    1. If |cookie|'s secure-flag is false, [=iteration/continue=].
-    1. If |cookie|'s same-site-flag is not "`None`", [=iteration/continue=].
-    1. If |cookie|'s host-only-flag is true and |domain| is not
-        identical to |cookie|'s domain, [=iteration/continue=].
-    1. If |cookie|'s host-only-flag is false and |domain| does not
-        <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-domain-matching">domain-match</a>
-        |cookie|'s domain, [=iteration/continue=].
-    1. If "`/`" does not
-        <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-paths-and-path-match">path-match</a>
-        |cookie|'s path, [=iteration/continue=].
-    1. Return <strong>allowed</strong>.
-1. Return <strong>blocked</strong>.
-
-Issue: Ideally this would use the
-<a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#name-retrieval-algorithm">cookie-retrieval algorithm</a>,
-but it cannot: There is no way to consider *only* cookies whose http-only-flag
-is true and whose same-site-flag is "`None`"; there is no way to prevent the
-last-access-time from being modified; and the return value is a string that
-would have to be further processed to check for the "`ar_debug`" cookie.
+1. Return <strong>allowed</strong>.
 
 <h3 algorithm id="obtaining-context-origin">Obtaining context origin</h3>
 
@@ -2756,11 +2735,11 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     [=parse an optional 64-bit unsigned integer=] with |value|, "<code>[=source-registration JSON key/debug_key=]</code>",
     and null.
 1. If |debugKey| is an error, set |debugKey| to null.
-1. Let |debugCookieSet| be false.
+1. Let |cookieBasedDebugAllowed| be false.
 1. Let |sourceSite| be the result of [=obtaining a site=] from |sourceOrigin|.
 1. If the result of running [=check if cookie-based debugging is allowed=]
-    with |reportingOrigin| and |sourceSite| is <strong>allowed</strong>, set |debugCookieSet| to true.
-1. If |debugCookieSet| is false, set |debugKey| to null.
+    with |reportingOrigin| and |sourceSite| is <strong>allowed</strong>, set |cookieBasedDebugAllowed| to true.
+1. If |cookieBasedDebugAllowed| is false, set |debugKey| to null.
 1. Let |aggregationKeys| be the result of running [=parse aggregation keys=] with |value|.
 1. If |aggregationKeys| is an error, return it.
 1. Let |maxAttributionsPerSource| be [=default event-level attributions per source=][|sourceType|].
@@ -2843,8 +2822,8 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |debugReportingEnabled|
     : [=attribution source/trigger-data matching mode=]
     :: |triggerDataMatchingMode|
-    : [=attribution source/debug cookie set=]
-    :: |debugCookieSet|
+    : [=attribution source/cookie-based debug allowed=]
+    :: |cookieBasedDebugAllowed|
     : [=attribution source/fenced=]
     :: |fenced|
     : [=attribution source/remaining aggregatable debug budget=]
@@ -3051,7 +3030,7 @@ To <dfn>obtain and deliver a verbose debug report on source registration</dfn> g
 a [=boolean=] |isNoised|, and a [=boolean=] |destinationLimitReplaced|:
 
 1. If |source|'s [=attribution source/debug reporting enabled=] is false, return.
-1. If |source|'s [=attribution source/debug cookie set=] is false, return.
+1. If |source|'s [=attribution source/cookie-based debug allowed=] is false, return.
 1. Let |body| be a new [=map=] with the following key/value pairs:
     : "`attribution_destination`"
     :: |source|'s [=attribution source/attribution destinations=], [=serialize attribution destinations|serialized=].
@@ -3930,7 +3909,7 @@ an [=attribution trigger=] |trigger|, a possibly null [=attribution source=]
 1. If |trigger|'s [=attribution trigger/debug reporting enabled=] is false, return null.
 1. If the result of running [=check if cookie-based debugging is allowed=] with |trigger|'s
     [=attribution trigger/reporting origin=] and |trigger|'s [=attribution trigger/attribution destination=] is <strong>blocked</strong>, return null.
-1. If |sourceToAttribute| is not null and |sourceToAttribute|'s [=attribution source/debug cookie set=] is false,
+1. If |sourceToAttribute| is not null and |sourceToAttribute|'s [=attribution source/cookie-based debug allowed=] is false,
      return null.
 1. Let |data| be a new [=verbose debug data=] with the items:
     : [=verbose debug data/data type=]


### PR DESCRIPTION
Fixes #1440


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/conversion-measurement-api/pull/1441.html" title="Last updated on Oct 15, 2024, 12:55 PM UTC (1ec425a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1441/2877fda...linnan-github:1ec425a.html" title="Last updated on Oct 15, 2024, 12:55 PM UTC (1ec425a)">Diff</a>