### PR TITLE
Unlimited aggregatable reports with trigger context ID

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4149,7 +4149,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
     return it.
-1. If |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value is equal to [=max aggregatable reports per source=][0], then:
+1. If |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value is equal to [=max aggregatable reports per source=][0] and |trigger|'s [=attribution trigger/trigger context ID=] is null, then:
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
         ("<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", null)).
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]


### PR DESCRIPTION
The current hard limit on aggregatable reports per source might be too small for
some use-cases. Allowing consumers to configure it allows for more flexibility
in handling the utility implications of higher limits that would also garner
more constraints due to privacy.

(See also #1183)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giladbarkan-github/attribution-reporting-api/pull/1449.html" title="Last updated on Oct 30, 2024, 7:11 PM UTC (3e1743a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1449/b17479d...giladbarkan-github:3e1743a.html" title="Last updated on Oct 30, 2024, 7:11 PM UTC (3e1743a)">Diff</a>