### PR TITLE
Correct typo in `get sources to delete for the unexpired destination limit`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3041,7 +3041,7 @@ To <dfn>get sources to delete for the unexpired destination limit</dfn> given an
         : [=destination limit record/time=]
         :: |source|'s [=attribution source/source time=]
         : [=destination limit record/source ID=]
-        :: |record|'s [=attribution source/internal ID=]
+        :: |source|'s [=attribution source/internal ID=]
 
     1. [=list/Append=] |destinationRecord| to |destinationRecords|.
 1. [=list/sort in descending order|Sort=] |destinationRecords| in descending order, with |a| less than |b| if the following steps return true:


### PR DESCRIPTION
Hello,

I believe there's a typo introduced in commit bf3f812cfe568bf45012d642a719407c7cfd1e74. The use of `record` seems ambiguous in this context, and moreover, no `record` objects appear to have an attribute named `internal ID`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiratara/attribution-reporting-api/pull/1462.html" title="Last updated on Nov 12, 2024, 7:55 AM UTC (00fef52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1462/9f7c822...hiratara:00fef52.html" title="Last updated on Nov 12, 2024, 7:55 AM UTC (00fef52)">Diff</a>