### PR TITLE
Replace erroneous string sorting with numeric sorting

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2639,9 +2639,16 @@ const testCases: TestCase[] = [
       "trigger_specs": [
         {"trigger_data": [1, 0]},
         {"trigger_data": [3]},
-        {"trigger_data": [2]}
+        {"trigger_data": [2]},
+        {"trigger_data": [4, 5, 6, 7, 8, 9, 10]}
       ]
     }`,
+    vsv: {
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: Infinity,
+        [SourceType.navigation]: Infinity,
+      },
+    },
     parseFullFlex: true,
   },
   {
@@ -2649,8 +2656,14 @@ const testCases: TestCase[] = [
     input: `{
       "destination": "https://a.test",
       "trigger_data_matching": "modulus",
-      "trigger_data": [1, 0, 2, 3]
+      "trigger_data": [1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     }`,
+    vsv: {
+      maxEventLevelChannelCapacityPerSource: {
+        [SourceType.event]: Infinity,
+        [SourceType.navigation]: Infinity,
+      },
+    },
   },
 
   {

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -625,6 +625,10 @@ function defaultTriggerSpecs(
   )
 }
 
+function compareNumbers(a: number, b: number): number {
+  return a - b
+}
+
 function isTriggerDataMatchingValidForSpecs(s: Source, ctx: Context): boolean {
   return ctx.scope('trigger_data_matching', () => {
     if (s.triggerDataMatching !== TriggerDataMatching.modulus) {
@@ -633,7 +637,7 @@ function isTriggerDataMatchingValidForSpecs(s: Source, ctx: Context): boolean {
 
     const triggerData: number[] = s.triggerSpecs
       .flatMap((spec) => Array.from(spec.triggerData))
-      .sort()
+      .sort(compareNumbers)
 
     if (triggerData.some((triggerDatum, i) => triggerDatum !== i)) {
       ctx.error(


### PR DESCRIPTION
Without this, the check for trigger_data_matching with modulus erroneously fails when a multi-digit number is used as trigger data.