### PR TITLE
Report debug_key/debug_reporting issues as warnings

### DIFF
--- a/ts/src/header-validator/context.ts
+++ b/ts/src/header-validator/context.ts
@@ -18,6 +18,7 @@ export class Context {
     warnings: [],
     notes: [],
   }
+  errorAsWarning: boolean = false
 
   scope<T>(c: PathComponent, f: () => T): T {
     this.path.push(c)
@@ -31,7 +32,11 @@ export class Context {
   }
 
   error(msg: string): void {
-    this.result.errors.push(this.issue(msg))
+    if (this.errorAsWarning) {
+      this.warning(msg)
+    } else {
+      this.result.errors.push(this.issue(msg))
+    }
   }
 
   warning(msg: string): void {

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -622,7 +622,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "debug_key": 1
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_key'],
         msg: 'must be a string',
@@ -635,7 +635,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "debug_key": "-1"
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_key'],
         msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',
@@ -1071,7 +1071,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "debug_reporting": "true"
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_reporting'],
         msg: 'must be a boolean',

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -514,7 +514,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   {
     name: 'debug-reporting-wrong-type',
     input: `{"debug_reporting": "true"}`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_reporting'],
         msg: 'must be a boolean',
@@ -525,7 +525,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   {
     name: 'debug-key-wrong-type',
     input: `{"debug_key": 1}`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_key'],
         msg: 'must be a string',
@@ -535,7 +535,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
   {
     name: 'debug-key-wrong-format',
     input: `{"debug_key": "-1"}`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['debug_key'],
         msg: 'string must represent a non-negative integer (must match /^[0-9]+$/)',

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -243,9 +243,24 @@ export function array<T, C extends Context = Context>(
     )
 }
 
+function withErrorAsWarning<C extends Context, I, O>(
+  f: CtxFunc<C, I, O>
+): CtxFunc<C, I, O> {
+  return (i, ctx) => {
+    const prev = ctx.errorAsWarning
+    ctx.errorAsWarning = true
+    const result = f(i, ctx)
+    ctx.errorAsWarning = prev
+    return result
+  }
+}
+
 export const commonDebugFields: StructFields<CommonDebug> = {
-  debugKey: field('debug_key', withDefault(uint64, null)),
-  debugReporting: field('debug_reporting', withDefault(bool, false)),
+  debugKey: field('debug_key', withDefault(withErrorAsWarning(uint64), null)),
+  debugReporting: field(
+    'debug_reporting',
+    withDefault(withErrorAsWarning(bool), false)
+  ),
 }
 
 export const priorityField: StructFields<Priority> = {


### PR DESCRIPTION
To match the specification, where they do not cause the entire registration to be rejected.