### PR TITLE
Report aggregatable_debug_reporting issues as warnings

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -1575,7 +1575,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "aggregatable_debug_reporting": 1
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting'],
         msg: 'must be an object',
@@ -1588,7 +1588,7 @@ const testCases: TestCase[] = [
       "destination": "https://a.test",
       "aggregatable_debug_reporting": {}
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'budget'],
         msg: 'required',
@@ -1608,7 +1608,7 @@ const testCases: TestCase[] = [
         "key_piece": "0x1"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'budget'],
         msg: 'must be a number',
@@ -1624,7 +1624,7 @@ const testCases: TestCase[] = [
         "key_piece": "0x1"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'budget'],
         msg: 'must be in the range [1, 65536]',
@@ -1640,7 +1640,7 @@ const testCases: TestCase[] = [
         "key_piece": "0x1"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'budget'],
         msg: 'must be in the range [1, 65536]',
@@ -1656,7 +1656,7 @@ const testCases: TestCase[] = [
         "key_piece": 1
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'key_piece'],
         msg: 'must be a string',
@@ -1672,7 +1672,7 @@ const testCases: TestCase[] = [
         "key_piece": "1"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'key_piece'],
         msg: 'must be a hex128 (must match /^0[xX][0-9A-Fa-f]{1,32}$/)',
@@ -1689,7 +1689,7 @@ const testCases: TestCase[] = [
         "aggregation_coordinator_origin": 1
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1709,7 +1709,7 @@ const testCases: TestCase[] = [
         "aggregation_coordinator_origin": "a.test"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1729,7 +1729,7 @@ const testCases: TestCase[] = [
         "aggregation_coordinator_origin": "http://a.test"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1749,7 +1749,7 @@ const testCases: TestCase[] = [
         "debug_data": {}
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'must be a list',
@@ -1766,7 +1766,7 @@ const testCases: TestCase[] = [
         "debug_data": [1]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0],
         msg: 'must be an object',
@@ -1783,7 +1783,7 @@ const testCases: TestCase[] = [
         "debug_data": [{}]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'required',
@@ -1812,7 +1812,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'key_piece'],
         msg: 'must be a string',
@@ -1833,7 +1833,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'key_piece'],
         msg: 'must be a hex128 (must match /^0[xX][0-9A-Fa-f]{1,32}$/)',
@@ -1854,7 +1854,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be a number',
@@ -1871,11 +1871,11 @@ const testCases: TestCase[] = [
         "debug_data": [{
           "key_piece": "0x1",
           "types": ["source-success"],
-          "value": 0 
+          "value": 0
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be in the range [1, 65536]',
@@ -1892,11 +1892,11 @@ const testCases: TestCase[] = [
         "debug_data": [{
           "key_piece": "0x1",
           "types": ["source-success"],
-          "value": 65537 
+          "value": 65537
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be in the range [1, 65536]',
@@ -1917,7 +1917,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting'],
         msg: 'data contains value greater than budget (789)',
@@ -1938,7 +1938,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'must be a list',
@@ -1959,7 +1959,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'length must be in the range [1, Infinity]',
@@ -1980,7 +1980,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
         msg: 'must be a string',
@@ -2001,12 +2001,6 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
-        msg: 'duplicate value abc',
-      },
-    ],
     expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
@@ -2015,6 +2009,10 @@ const testCases: TestCase[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
         msg: 'unknown type',
+      },
+      {
+        path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
+        msg: 'duplicate value abc',
       },
     ],
   },
@@ -2025,23 +2023,20 @@ const testCases: TestCase[] = [
       "aggregatable_debug_reporting": {
         "budget": 123,
         "key_piece": "0x1",
-        "debug_data": [{
-          "key_piece": "0x2",
-          "types": ["abc"],
-          "value": 123
-        }, {
-          "key_piece": "0x1",
-          "types": ["abc"],
-          "value": 456
-	}]
+        "debug_data": [
+          {
+            "key_piece": "0x2",
+            "types": ["abc"],
+            "value": 123
+          },
+          {
+            "key_piece": "0x1",
+            "types": ["abc"],
+            "value": 456
+          }
+        ]
       }
     }`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_debug_reporting', 'debug_data'],
-        msg: 'duplicate type: abc',
-      },
-    ],
     expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
@@ -2050,6 +2045,10 @@ const testCases: TestCase[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 1, 'types', 0],
         msg: 'unknown type',
+      },
+      {
+        path: ['aggregatable_debug_reporting', 'debug_data'],
+        msg: 'duplicate type: abc',
       },
     ],
   },
@@ -2067,7 +2066,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
         msg: 'duplicate value source-success',
@@ -2092,7 +2091,7 @@ const testCases: TestCase[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'duplicate type: unspecified',

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -1213,7 +1213,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     input: `{
       "aggregatable_debug_reporting": 1
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting'],
         msg: 'must be an object',
@@ -1225,7 +1225,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     input: `{
       "aggregatable_debug_reporting": {}
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'key_piece'],
         msg: 'required',
@@ -1239,7 +1239,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "key_piece": 1
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'key_piece'],
         msg: 'must be a string',
@@ -1253,7 +1253,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "key_piece": "1"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'key_piece'],
         msg: 'must be a hex128 (must match /^0[xX][0-9A-Fa-f]{1,32}$/)',
@@ -1268,7 +1268,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "aggregation_coordinator_origin": 1
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1286,7 +1286,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "aggregation_coordinator_origin": "a.test"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1304,7 +1304,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "aggregation_coordinator_origin": "http://a.test"
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: [
           'aggregatable_debug_reporting',
@@ -1322,7 +1322,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "debug_data": {}
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'must be a list',
@@ -1337,7 +1337,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "debug_data": [1]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0],
         msg: 'must be an object',
@@ -1352,7 +1352,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "debug_data": [{}]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'required',
@@ -1379,7 +1379,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'key_piece'],
         msg: 'must be a string',
@@ -1398,7 +1398,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'key_piece'],
         msg: 'must be a hex128 (must match /^0[xX][0-9A-Fa-f]{1,32}$/)',
@@ -1417,7 +1417,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be a number',
@@ -1432,11 +1432,11 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "debug_data": [{
           "key_piece": "0x1",
           "types": ["trigger-unknown-error"],
-          "value": 0 
+          "value": 0
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be in the range [1, 65536]',
@@ -1451,11 +1451,11 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         "debug_data": [{
           "key_piece": "0x1",
           "types": ["trigger-unknown-error"],
-          "value": 65537 
+          "value": 65537
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'value'],
         msg: 'must be in the range [1, 65536]',
@@ -1474,7 +1474,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'must be a list',
@@ -1493,7 +1493,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types'],
         msg: 'length must be in the range [1, Infinity]',
@@ -1512,7 +1512,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
         msg: 'must be a string',
@@ -1531,12 +1531,6 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
-        msg: 'duplicate value abc',
-      },
-    ],
     expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
@@ -1545,6 +1539,10 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
         msg: 'unknown type',
+      },
+      {
+        path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
+        msg: 'duplicate value abc',
       },
     ],
   },
@@ -1553,23 +1551,20 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     input: `{
       "aggregatable_debug_reporting": {
         "key_piece": "0x1",
-        "debug_data": [{
-          "key_piece": "0x2",
-          "types": ["abc"],
-          "value": 123
-        }, {
-          "key_piece": "0x1",
-          "types": ["abc"],
-          "value": 456
-	}]
+        "debug_data": [
+          {
+            "key_piece": "0x2",
+            "types": ["abc"],
+            "value": 123
+          },
+          {
+            "key_piece": "0x1",
+            "types": ["abc"],
+            "value": 456
+          }
+        ]
       }
     }`,
-    expectedErrors: [
-      {
-        path: ['aggregatable_debug_reporting', 'debug_data'],
-        msg: 'duplicate type: abc',
-      },
-    ],
     expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 0],
@@ -1578,6 +1573,10 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 1, 'types', 0],
         msg: 'unknown type',
+      },
+      {
+        path: ['aggregatable_debug_reporting', 'debug_data'],
+        msg: 'duplicate type: abc',
       },
     ],
   },
@@ -1593,7 +1592,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
         }]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data', 0, 'types', 1],
         msg: 'duplicate value trigger-unknown-error',
@@ -1605,18 +1604,21 @@ const testCases: jsontest.TestCase<Trigger>[] = [
     input: `{
       "aggregatable_debug_reporting": {
         "key_piece": "0x1",
-        "debug_data": [{
-          "key_piece": "0x2",
-          "types": ["unspecified"],
-          "value": 123
-        }, {
-          "key_piece": "0x3",
-          "types": ["unspecified"],
-          "value": 123
-        }]
+        "debug_data": [
+          {
+            "key_piece": "0x2",
+            "types": ["unspecified"],
+            "value": 123
+          },
+          {
+            "key_piece": "0x3",
+            "types": ["unspecified"],
+            "value": 123
+          }
+        ]
       }
     }`,
-    expectedErrors: [
+    expectedWarnings: [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'duplicate type: unspecified',

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -21,6 +21,7 @@ import {
   required,
   suitableOrigin,
   withDefault,
+  withErrorAsWarning,
 } from './validate'
 import * as validate from './validate'
 
@@ -241,19 +242,6 @@ export function array<T, C extends Context = Context>(
     .flatMap((js) =>
       validate.array(js.entries(), ctx, f, opts?.itemErrorAction)
     )
-}
-
-function withErrorAsWarning<C extends Context, I, O>(
-  f: CtxFunc<C, I, Maybe<O>>,
-  valueIfError: O
-): CtxFunc<C, I, Maybe<O>> {
-  return (i, ctx) => {
-    const prev = ctx.errorAsWarning
-    ctx.errorAsWarning = true
-    const result = f(i, ctx)
-    ctx.errorAsWarning = prev
-    return result.value === undefined ? Maybe.some(valueIfError) : result
-  }
 }
 
 export const commonDebugFields: StructFields<CommonDebug> = {

--- a/ts/src/header-validator/validate-source.ts
+++ b/ts/src/header-validator/validate-source.ts
@@ -22,6 +22,7 @@ import {
   required,
   suitableSite,
   withDefault,
+  withErrorAsWarning,
 } from './validate'
 import * as privacy from '../flexible-event/privacy'
 import { serializeSource } from './to-json'
@@ -737,7 +738,10 @@ function source(j: Json, ctx: Context): Maybe<Source> {
         triggerSpecs: () => triggerSpecsVal,
         aggregatableDebugReporting: field(
           'aggregatable_debug_reporting',
-          withDefault(sourceAggregatableDebugReportingConfig, null)
+          withDefault(
+            withErrorAsWarning(sourceAggregatableDebugReportingConfig, null),
+            null
+          )
         ),
 
         triggerDataMatching: field(

--- a/ts/src/header-validator/validate-trigger.ts
+++ b/ts/src/header-validator/validate-trigger.ts
@@ -18,7 +18,13 @@ import {
   NamedBudget,
   Trigger,
 } from './trigger'
-import { isInteger, isInRange, required, withDefault } from './validate'
+import {
+  isInteger,
+  isInRange,
+  required,
+  withDefault,
+  withErrorAsWarning,
+} from './validate'
 import { Validator } from './validator'
 import {
   Json,
@@ -405,7 +411,7 @@ function trigger(j: Json, ctx: Context): Maybe<Trigger> {
         ),
         aggregatableDebugReporting: field(
           'aggregatable_debug_reporting',
-          withDefault(struct, null),
+          withDefault(withErrorAsWarning(struct, null), null),
           aggregatableDebugReportingConfig
         ),
         attributionScopes: field(

--- a/ts/src/header-validator/validate.ts
+++ b/ts/src/header-validator/validate.ts
@@ -79,6 +79,21 @@ export function withDefault<C extends Context, V, T, Args extends unknown[]>(
   }
 }
 
+export function withErrorAsWarning<
+  C extends Context,
+  V,
+  T,
+  Args extends unknown[],
+>(f: CtxArgFunc<V, C, Args, T>, valueIfError: T): CtxArgFunc<V, C, Args, T> {
+  return (i, ctx, ...args) => {
+    const prev = ctx.errorAsWarning
+    ctx.errorAsWarning = true
+    const result = f(i, ctx, ...args)
+    ctx.errorAsWarning = prev
+    return result.value === undefined ? Maybe.some(valueIfError) : result
+  }
+}
+
 type FieldFunc<D, V> = <T, C extends Context, Args extends unknown[]>(
   name: string,
   f: CtxArgFunc<V | undefined, C, Args, T>,


### PR DESCRIPTION
To match the specification, where they do not cause the entire registration to be rejected.