### PR TITLE
Remove aggregatable report limit when trigger context ID is non-null

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -505,6 +505,9 @@ As the trigger context ID in the aggregatable report explicitly reveals the
 association between the report and the trigger, these reports can be sent
 immediately without delay.
 
+When a trigger context ID is provided, the aggregatable report will not count
+towards the limit of aggregatable reports per source, nor be limited by it.
+
 Note: This is an [alternative](https://github.com/WICG/attribution-reporting-api/blob/main/report_verification.md#could-we-just-tag-reports-with-a-trigger_id-instead-of-using-anonymous-tokens)
 considered for [report verification](https://github.com/WICG/attribution-reporting-api/blob/main/report_verification.md),
 and achieves all of the higher priority [security goals](https://github.com/WICG/attribution-reporting-api/blob/main/report_verification.md#security-goals).

--- a/index.bs
+++ b/index.bs
@@ -4294,7 +4294,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     1. Decrement |sourceToAttribute|'s [=attribution source/remaining named budgets=][|matchedBudgetName|] value by
         |report|'s [=aggregatable attribution report/required aggregatable budget=].
 1. If |matchedDedupKey| is not null, [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].
-1. If |trigger|'s [=attribution trigger/trigger context ID=] is null, [=set/append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
+1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Run [=generate null attribution reports=] with |trigger| and |report|.
 1. If the result of [=checking if attribution debugging can be enabled=]
     with |report|'s [=aggregatable attribution report/attribution debug info=] is true,

--- a/index.bs
+++ b/index.bs
@@ -4287,7 +4287,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
         ("<code>[=trigger debug data type/trigger-aggregate-insufficient-named-budget=]</code>", null)).
 1. [=set/Append=] |report| to the [=aggregatable attribution report cache=].
-1. Increment |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value by 1.
+1. If |trigger|'s [=attribution trigger/trigger context ID=] is null, increment |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value by 1.
 1. Decrement |sourceToAttribute|'s [=attribution source/remaining aggregatable attribution budget=] value by
     |report|'s [=aggregatable attribution report/required aggregatable budget=].
 1. If |matchedBudgetName| is not null and |sourceToAttribute|'s [=attribution source/remaining named budgets=][|matchedBudgetName|] [=map/exists=]:

--- a/index.bs
+++ b/index.bs
@@ -4294,7 +4294,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     1. Decrement |sourceToAttribute|'s [=attribution source/remaining named budgets=][|matchedBudgetName|] value by
         |report|'s [=aggregatable attribution report/required aggregatable budget=].
 1. If |matchedDedupKey| is not null, [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
+1. If |trigger|'s [=attribution trigger/trigger context ID=] is null, [=set/append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Run [=generate null attribution reports=] with |trigger| and |report|.
 1. If the result of [=checking if attribution debugging can be enabled=]
     with |report|'s [=aggregatable attribution report/attribution debug info=] is true,

--- a/index.bs
+++ b/index.bs
@@ -4274,7 +4274,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null,
     return it.
-1. If |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value is equal to [=max aggregatable reports per source=][0], then:
+1. If |sourceToAttribute|'s [=attribution source/number of aggregatable attribution reports=] value is equal to [=max aggregatable reports per source=][0] and |trigger|'s [=attribution trigger/trigger context ID=] is null, then:
     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
         ("<code>[=trigger debug data type/trigger-aggregate-excessive-reports=]</code>", null)).
 1. If the result of running [=check if an attribution source can create aggregatable contributions=]
@@ -4294,7 +4294,7 @@ To <dfn>trigger aggregatable attribution</dfn> given an [=attribution trigger=] 
     1. Decrement |sourceToAttribute|'s [=attribution source/remaining named budgets=][|matchedBudgetName|] value by
         |report|'s [=aggregatable attribution report/required aggregatable budget=].
 1. If |matchedDedupKey| is not null, [=list/append=] it to |sourceToAttribute|'s [=attribution source/aggregatable dedup keys=].
-1. [=set/Append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
+1. If |trigger|'s [=attribution trigger/trigger context ID=] is null, [=set/append=] |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Run [=generate null attribution reports=] with |trigger| and |report|.
 1. If the result of [=checking if attribution debugging can be enabled=]
     with |report|'s [=aggregatable attribution report/attribution debug info=] is true,


### PR DESCRIPTION
The current hard limit on aggregatable reports per source might be too small for
some use-cases. Allowing consumers to manage report counts that already have
privacy constraints applied provides more flexibility. In the case of this
change, when a trigger context ID is supplied, null report rate already manages
the necessary privacy constraints in place of a hard limit on aggregatable
report count.

(See also #1183)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giladbarkan-github/attribution-reporting-api/pull/1475.html" title="Last updated on Dec 30, 2024, 7:36 PM UTC (2075829)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1475/5b6be31...giladbarkan-github:2075829.html" title="Last updated on Dec 30, 2024, 7:36 PM UTC (2075829)">Diff</a>