### PR TITLE
Use more precise warning when public suffix is used as a destination

### DIFF
--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -283,6 +283,16 @@ const testCases: TestCase[] = [
       },
     ],
   },
+  {
+    name: 'destination-uses-public-suffix',
+    input: `{"destination": "https://com"}`,
+    expectedWarnings: [
+      {
+        msg: 'com is a public suffix: only triggers from https://com itself will match, not e.g. https://example.com',
+        path: ['destination'],
+      },
+    ],
+  },
 
   {
     name: 'filter-data-wrong-type',

--- a/ts/src/header-validator/validate.ts
+++ b/ts/src/header-validator/validate.ts
@@ -375,10 +375,14 @@ export function suitableOrigin(s: string, ctx: Context): Maybe<string> {
 }
 
 export function suitableSite(s: string, ctx: Context): Maybe<string> {
-  return suitableScope(
-    s,
-    ctx,
-    'site',
-    (u) => `${u.protocol}//${psl.get(u.hostname)}`
-  )
+  return suitableScope(s, ctx, 'site', (u) => {
+    let site = psl.get(u.hostname)
+    if (site === null) {
+      ctx.warning(
+        `${u.hostname} is a public suffix: only triggers from ${u.protocol}//${u.hostname} itself will match, not e.g. ${u.protocol}//example.${u.hostname}`
+      )
+      site = u.hostname
+    }
+    return `${u.protocol}//${site}`
+  })
 }


### PR DESCRIPTION
For example, previously https://com would be reported as the warning "URL components other than site (https://null) will be ignored".