### PR TITLE
Lowercase RFC 2119 keywords

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -426,7 +426,7 @@ a [=set=] of [=strings=] |allowedKeys|:
         value |value|, and the parameters |params| to |entries|.
 1. Return a [=structured header/dictionary=] containing |entries|.
 
-Note: The user agent MAY "[=structured header/define new structured fields|grease=]" the
+Note: The user agent may "[=structured header/define new structured fields|grease=]" the
 dictionary structured headers according to the preceding algorithm to help ensure that recipients
 use a proper structured header parser, rather than naive string equality or
 `contains` operations, which makes it easier to introduce backwards-compatible
@@ -1339,7 +1339,7 @@ However attribution data is inherently cross-site, and operations on storage wou
 An <dfn>internal ID</dfn> is an integer.
 
 To <dfn>get the next internal ID</dfn>, return an [=internal ID=] strictly
-greater than any previously returned by this algorithm. The user agent MAY reset
+greater than any previously returned by this algorithm. The user agent may reset
 this sequence when no [=attribution cache=] entry contains an [=internal ID=].
 
 # Constants # {#constants}
@@ -2156,7 +2156,7 @@ To <dfn export>process an attribution eligible response</dfn> given a [=suitable
 |contextOrigin|, an [=eligibility=] |eligibility|, a [=boolean=] |fenced|,
 and a [=response=] |response|:
 
-1. The user-agent MAY ignore the response; if so, return.
+1. The user-agent may ignore the response; if so, return.
 
     Note: The user-agent may prevent attribution for a number of reasons, such as user opt-out. In these
     cases, it is preferred to abort the API flow at response time rather than at request time so this
@@ -4658,7 +4658,7 @@ Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/
 
 # Report delivery # {#report-delivery}
 
-The user agent MUST periodically run [=queue reports for delivery=] on the
+The user agent must periodically run [=queue reports for delivery=] on the
 [=event-level report cache=] and [=aggregatable attribution report cache=].
 
 To <dfn>queue reports for delivery</dfn> given a [=set=] of
@@ -5040,7 +5040,7 @@ To <dfn>attempt to deliver a report</dfn> given an [=attribution report=] |repor
 
 1. [=Assert=]: Neither the [=event-level report cache=] nor the
     [=aggregatable attribution report cache=] [=set/contains=] |report|.
-1. The user-agent MAY ignore the report; if so, return.
+1. The user-agent may ignore the report; if so, return.
 1. Let |url| be the result of executing [=generate an attribution report URL=] on |report|.
 1. Let |data| be the result of executing [=serialize an attribution report=] on |report|.
 1. If |data| is an error, return.
@@ -5049,7 +5049,7 @@ To <dfn>attempt to deliver a report</dfn> given an [=attribution report=] |repor
 
 Issue(220): This fetch should use a network partition key for an opaque origin.
 
-A user agent MAY retry this algorithm in the event that there was an error.
+A user agent may retry this algorithm in the event that there was an error.
 To prevent the report recipient from learning additional information about
 whether a user is online, retries might be limited in number and subject to random delays.
 
@@ -5057,7 +5057,7 @@ whether a user is online, retries might be limited in number and subject to rand
 
 To <dfn>attempt to deliver a debug report</dfn> given an [=attribution report=] |report|:
 
-1. The user-agent MAY ignore the report; if so, return.
+1. The user-agent may ignore the report; if so, return.
 1. Let |url| be the result of executing [=generate an attribution report URL=] on |report| with
     [=generate an attribution report URL/isDebugReport=] set to true.
 1. Let |data| be the result of executing [=serialize an attribution report=] on |report|.
@@ -5069,7 +5069,7 @@ To <dfn>attempt to deliver a debug report</dfn> given an [=attribution report=] 
 
 To <dfn>attempt to deliver a verbose debug report</dfn> given a [=verbose debug report=] |report|:
 
-1. The user-agent MAY ignore the report; if so, return.
+1. The user-agent may ignore the report; if so, return.
 1. Let |url| be the result of executing [=generate a verbose debug report URL=] on |report|.
 1. Let |data| be the result of executing [=serialize a verbose debug report=] on |report|.
 1. Let |request| be the result of executing [=create a report request=] on |url| and |data|.
@@ -5079,7 +5079,7 @@ To <dfn>attempt to deliver a verbose debug report</dfn> given a [=verbose debug 
 
 To <dfn>attempt to deliver an aggregatable debug report</dfn> given an [=aggregatable debug report=] |report|:
 
-1. The user-agent MAY ignore the report; if so, return.
+1. The user-agent may ignore the report; if so, return.
 1. Let |url| be the result of executing [=generate an aggregatable debug report URL=] on |report|.
 1. Let |data| be the result of executing [=serialize an aggregatable debug report=] on |report|.
 1. Let |request| be the result of executing [=create a report request=] on |url| and |data|.
@@ -5087,7 +5087,7 @@ To <dfn>attempt to deliver an aggregatable debug report</dfn> given an [=aggrega
 
 Issue(220): This fetch should use a network partition key for an opaque origin.
 
-A user agent MAY retry this algorithm in the event that there was an error.
+A user agent may retry this algorithm in the event that there was an error.
 
 # Cross App and Web Algorithms # {#cross-app-and-web}
 
@@ -5310,7 +5310,7 @@ context.
 ## Clearing site data ## {#clearing-site-data}
 
 The [=attribution caches=] contain data about a user's web activity. As such,
-the user agent MAY expose controls that allow the user to delete data from them.
+the user agent may expose controls that allow the user to delete data from them.
 
 ## Cross-site information disclosure ## {#cross-site-information-disclosure}
 


### PR DESCRIPTION
Per https://wicg.github.io/attribution-reporting-api/#w3c-conventions "these words do not appear in all uppercase letters in this specification."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1490.html" title="Last updated on Dec 18, 2024, 4:15 PM UTC (48ea07d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1490/51b136f...apasel422:48ea07d.html" title="Last updated on Dec 18, 2024, 4:15 PM UTC (48ea07d)">Diff</a>