### PR TITLE
Removing johnidel from editors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,6 @@ Editor: Andrew Paseltiner, Google LLC. https://google.com, apaseltiner@chromium.
 Editor: Arpana Hosabettu, Google LLC. https://google.com, arpanah@chromium.org
 Editor: Charlie Harrison, Google LLC. https://google.com, csharrison@chromium.org
 Editor: Gilad Barkan, Google LLC. https://google.com, giladbarkan@google.com
-Editor: John Delaney, Google LLC. https://google.com, johnidel@chromium.org
 Editor: Nan Lin, Google LLC. https://google.com, linnan@chromium.org
 Editor: Vikas Sahu, Google LLC. https://google.com, vikassahu@google.com
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johnivdel/conversion-measurement-api/pull/1496.html" title="Last updated on Jan 21, 2025, 7:15 PM UTC (ede061a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1496/fdb330f...johnivdel:ede061a.html" title="Last updated on Jan 21, 2025, 7:15 PM UTC (ede061a)">Diff</a>