### PR TITLE
Fix erroneous end tags in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -243,7 +243,7 @@ Add "and [=navigate/navigationSourceEligible=] set to
 
 > [=Navigate=] <var ignore=''>targetNavigable</var>...
 
-<h3 id="monkeypatch-window-open">Window open steps</h4>
+<h3 id="monkeypatch-window-open">Window open steps</h3>
 
 Modify the [=tokenize the features argument=] as follows:
 
@@ -484,7 +484,7 @@ To <dfn>set Attribution Reporting headers</dfn> given a [=request=] |request|:
 1. [=header list/Set a structured field value=] given
     ("<code>[=Attribution-Reporting-Support=]</code>", |supportDict|) in |headers|.
 
-<h3 id="monkeypatch-fetch">Fetch monkeypatches</h4>
+<h3 id="monkeypatch-fetch">Fetch monkeypatches</h3>
 
 Modify [=fetch=] as follows:
 
@@ -517,7 +517,7 @@ add the step
     |request|'s [=request/Attribution Reporting eligibility=] to the result of
     [=get an eligibility from AttributionReportingRequestOptions=] with it.
 
-<h3 id="monkeypatch-xmlhttprequest">XMLHttpRequest monkeypatches</h4>
+<h3 id="monkeypatch-xmlhttprequest">XMLHttpRequest monkeypatches</h3>
 
 An {{XMLHttpRequest}} object has an associated
 <dfn id="xmlhttprequest-eligibility">Attribution Reporting eligibility</dfn> (an


### PR DESCRIPTION
This was preventing the spec from being built.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/attribution-reporting-api/pull/1497.html" title="Last updated on Jan 21, 2025, 7:51 PM UTC (bab8120)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1497/fdb330f...apasel422:bab8120.html" title="Last updated on Jan 21, 2025, 7:51 PM UTC (bab8120)">Diff</a>