### PR TITLE
Introduce Report Data Lifetime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4663,9 +4663,13 @@ Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/
 The user agent must periodically run [=queue reports for delivery=] on the
 [=event-level report cache=] and [=aggregatable attribution report cache=].
 
-Note: The user agent may choose to define certain criteria to ignore
-sending a certain report, for example if the report's time of
-existence exceeds a user agent defined length.
+The user agent may delete reports without sending them according
+to [=implementation-defined=] criteria.
+
+<p class=note>
+For example, this can be used to limit the maximum age of
+any report that is sent.
+</p>
 
 To <dfn>queue reports for delivery</dfn> given a [=set=] of
 [=attribution reports=] |cache|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -4663,9 +4663,9 @@ Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/
 The user agent must periodically run [=queue reports for delivery=] on the
 [=event-level report cache=] and [=aggregatable attribution report cache=].
 
-Note: The user agent may choose to define certain criteria for this process to ignore
-sending otherwise viable reports, such as the report's length of existence
-exceeding a chosen amount of time.
+Note: The user agent may choose to define certain criteria to ignore
+sending a certain report, for example if the report's time of
+existence exceeds a user agent defined length.
 
 To <dfn>queue reports for delivery</dfn> given a [=set=] of
 [=attribution reports=] |cache|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -4663,6 +4663,10 @@ Issue: Specify this in terms of <a href="https://html.spec.whatwg.org/multipage/
 The user agent must periodically run [=queue reports for delivery=] on the
 [=event-level report cache=] and [=aggregatable attribution report cache=].
 
+Note: The user agent may choose to define certain criteria for this process to ignore
+sending otherwise viable reports, such as the report's length of existence
+exceeding a chosen amount of time.
+
 To <dfn>queue reports for delivery</dfn> given a [=set=] of
 [=attribution reports=] |cache|, run the following steps:
 


### PR DESCRIPTION
Adds language to allow user-agents to delete reports before delivery based on implementation-defined criteria.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/pull/1505.html" title="Last updated on Apr 1, 2025, 6:50 PM UTC (7841584)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1505/3e8b1b9...7841584.html" title="Last updated on Apr 1, 2025, 6:50 PM UTC (7841584)">Diff</a>