### PR TITLE
Use local bikeshed instead of API service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-python@v5
     - name: Build
       run: make
     - name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-out
+/out
+/venv

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,20 @@ OUT_DIR ?= out
 
 all: $(OUT_DIR)/index.html validator
 
-$(OUT_DIR)/index.html: index.bs $(OUT_DIR)
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
-                                --output $@ \
-	                       --write-out '%{http_code}' \
-	                       --header 'Accept: text/plain, text/html' \
-	                       -F die-on=warning \
-	                       -F file=@$<) && \
-	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
-		echo ""; cat $@; echo ""; \
-		rm $@; \
-		exit 22 \
-	);
+venv-marker := venv/.make
+bikeshed := venv/bin/bikeshed
+venv: $(venv-marker)
+
+$(venv-marker): Makefile
+	python3 -m venv venv
+	@touch $@
+
+$(bikeshed): $(venv-marker) Makefile
+	venv/bin/pip install $(notdir $@)
+	@touch $@
+
+$(OUT_DIR)/index.html: index.bs $(OUT_DIR) $(bikeshed)
+	$(bikeshed) --die-on=warning spec $< $@
 
 validator: $(OUT_DIR)/validate-headers.html $(OUT_DIR)/validate-headers.js $(OUT_DIR)/filters.html $(OUT_DIR)/filters-main.js
 
@@ -34,7 +36,7 @@ ts/dist/header-validator/index.js ts/dist/header-validator/filters-main.js: ts/p
 	@ npm run pack --prefix ./ts
 
 clean:
-	@ rm -rf $(OUT_DIR)
+	@ rm -rf $(OUT_DIR) venv
 
 $(OUT_DIR)/filters.html: ts/src/header-validator/filters.html $(OUT_DIR)
 	@ cp $< $@


### PR DESCRIPTION
This allows the spec to be built locally even without internet access and provides better log output.

The Makefile setup is derived from [PPA's](https://github.com/w3c/ppa/blob/f23717f290b86eb5390380b2c97ce876b748f2a5/Makefile#L26).