### PR TITLE
Do not set request's window

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5025,8 +5025,6 @@ To <dfn>create a report request</dfn> given a [=URL=] |url| and a [=byte sequenc
     ::  `null`
     :   [=request/origin=]
     ::  |url|'s [=url/origin=]
-    :   [=request/window=]
-    ::  "`no-window`"
     :   [=request/service-workers mode=]
     ::  "`none`"
     :   [=request/initiator=]


### PR DESCRIPTION
Per https://github.com/whatwg/fetch/pull/1823, this concept is going away. After that change, null-client scenarios will automatically do the right thing, and create no user prompts, which aligns with this spec's desired outcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/attribution-reporting-api/pull/1519.html" title="Last updated on May 13, 2025, 5:10 AM UTC (80963b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/attribution-reporting-api/1519/dace1e2...domenic:80963b6.html" title="Last updated on May 13, 2025, 5:10 AM UTC (80963b6)">Diff</a>